### PR TITLE
Mods to README.md for v0.1.0 release - CCPP only

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ parameterization schemes within the model.
 For the initial release, this XML file has not yet been designed.
 
 
-Within the `src/tests` directoty there is `test_init_fini.f90` which
+Within the `src/tests` directory there is `test_init_fini.f90` which
 will get built when the CCPP library is built. This program only calls
   * `ccpp_init()`
   * `ccpp_fini()`


### PR DESCRIPTION
For v0.1.0, this is a set of mods to the README.md file. I am not able to get the file to "look" nice in HTM without the cheating uses of the 
```
<pre>
blah, blah, blah
</pre>
```
html tags.