### PR TITLE
Enabled Travis and updated README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,13 @@ before_script:
 
 script:
   - mkdir build && cd build && cmake .. && make
-  - make test
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
+          export LD_LIBRARY_PATH=${PWD}/schemes/check/src/check-build
+      elif [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
+          export DYLD_LIBRARY_PATH=${PWD}/schemes/check/src/check-build
+      fi
+      make test
 #  - |
 #      if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
 #          make clean

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ provided once examples of fully functioning schemes are part of the CCPP.
      The PGI compilers attach the Fortran module name as a prefix to the Fortran
      symbol. This breaks the method that the CCPP uses to identify which schemes
      to call.
-
 2. [Cmake](https://cmake.org)
 
 ## Building


### PR DESCRIPTION
@davegill @grantfirl,

In rendering the [documentation](http://www.dtcenter.org/GMTB/ccpp_doc/), there are extra quotes, coming from the **pre** tags. I've tried cleaning this up and removed a reference to the IPD.

Also enabled Travis builds and set the {DY}LD_LIBRARY_PATH for the tests.