### PR TITLE
Updating Travis URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [GMTB](http://www.dtcenter.org/GMTB/html/) Common Community Physics Package
 (CCPP), including the Interoperable Physics Driver (IPD).
 
-[![Build Status](https://travis-ci.org/NCAR/gmtb-ccpp.svg?branch=master)](https://travis-ci.org/NCAR/gmtb-ccpp)
+[![Build Status](https://travis-ci.com/NCAR/gmtb-ccpp.svg?branch=master)](https://travis-ci.com/NCAR/gmtb-ccpp)
 [![Coverage Status](https://coveralls.io/repos/github/NCAR/gmtb-ccpp/badge.svg?branch=master)](https://coveralls.io/github/NCAR/gmtb-ccpp?branch=master)
 
 ## Notes to Users


### PR DESCRIPTION
Changing the travis.org to travis.com since this is still a
private repository.