### PR TITLE
ccpp-framework repo name changes for fv3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ matrix:
        compiler: gcc
        sudo: false
        dist: trusty
-     - os: osx
-       compiler: gcc
+# DH commented out 03/27/2018 because travis has problems with brew
+# todo: fix (maybe below brew install gcc@6?)
+#     - os: osx
+#       compiler: gcc
 
 #======================================================================
 # Building
@@ -86,6 +88,6 @@ after_success:
 #======================================================================
 notifications:
   email:
-    recipients: Timothy.P.Brown@noaa.gov
+    recipients: dom.heinzeller@noaa.gov
     on_success: change
     on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GMTB CCPP
+
 [GMTB](http://www.dtcenter.org/GMTB/html/) Common Community Physics Package
 (CCPP), including the Interoperable Physics Driver (IPD).
 
@@ -62,7 +63,7 @@ libraries, executables) exist.
 
 1. Clone the repository.
 ```
-git clone https://github.com/NCAR/gmtb-ccpp ccpp
+git clone https://github.com/NCAR/ccpp-framework ccpp
 ```
 2. Change into the repository clone
 ```
@@ -126,7 +127,7 @@ All tests should pass, if not, please open an issue. The output should be
 similar to:
 ~~~~{.sh}
 Running tests...
-Test project /home/tbrown/Sources/gmtb-ccpp/build
+Test project /home/tbrown/Sources/ccpp-framework/build
     Start 1: XML_1
 1/8 Test #1: XML_1 ............................   Passed    0.02 sec
     Start 2: XML_2

--- a/doc/UsersGuide/SCM/chap_run.tex
+++ b/doc/UsersGuide/SCM/chap_run.tex
@@ -6,7 +6,7 @@
 \section{A sample test case}
 
 The CCPP uses a run-time, dynamically loaded physics library to select physics suites at runtime.  To utilize a given library (of CCPP-complient!) physics parameterizations, first append the path to the physics suite libraries that you need
-within the CCPP. For example, for the gmtb-gfsphysics suite, use:
+within the CCPP. For example, for the GMTB GFS physics suite, use:
 \begin{itemize}
 	\item for sh, bash
 
@@ -26,7 +26,7 @@ within the CCPP. For example, for the gmtb-gfsphysics suite, use:
 The test case provided with the SCM is TWP-ICE, the Tropical Warm Pool-International Cloud Experiment. The SCM will go through the time steps, applying forcing and calling the physics defined in the suite definition file.
 There is a single command line argument required, which is the name of the case configuration file.  For the provided case, that name is \exec{twpice}.
 
-  \exec{./gmtb\_scm twpice}
+\exec{./gmtb\_scm twpice}
 
 A netcdf output file is generated in the location specified in the case
 configuration file. Any standard NetCDF file viewing or analysis tools may be used to 

--- a/schemes/longnames_autocheck.py
+++ b/schemes/longnames_autocheck.py
@@ -79,7 +79,7 @@ def main():
         os.chdir(basedir)
         user = separator['user']
         branch = separator['branch']
-        clonedir = '{0}_{1}_gmtb-gfsphysics'.format(user, branch)
+        clonedir = '{0}_{1}_ccpp-physics'.format(user, branch)
         use_existing = separator['use_existing']
         if use_existing and not os.path.isdir(clonedir):
             raise Exception('I was asked to use existing clone directory {0}, but it does not exist.'.format(clonedir))
@@ -90,7 +90,7 @@ def main():
 
         if not use_existing:
             # Clone repository
-            cmd = 'git clone https://github.com/{0}/gmtb-gfsphysics.git {1}'.format(user, clonedir)
+            cmd = 'git clone https://github.com/{0}/ccpp-physics.git {1}'.format(user, clonedir)
             execute(cmd)
             # Checkout branch
             os.chdir(clonedir)


### PR DESCRIPTION
This PR updates Python scripts and documentation to reflect repository name changes. Also included is to temporarily deactivate the travis continuous integration for MACOSX (broken since a while due to changes in brew/homebrew), but keeps the Linux config.