### PR TITLE
Change run directory for ccpp_prebuild.py for SCM

### DIFF
--- a/doc/UsersGuide/SCM/chap_install.tex
+++ b/doc/UsersGuide/SCM/chap_install.tex
@@ -107,19 +107,18 @@ The first step in compiling the CCPP and SCM is to match the physics variables, 
 
 \begin{enumerate}
 	\item Run the CCPP prebuild script to match required physics variables with those available from the dycore (SCM) and to generate physics caps and makefile segments.\\
-  \exec{cd ccpp-framework/scripts} \\
-  \exec{./ccpp\_prebuild.py}\\
+  \exec{./ccpp-framework/scripts/ccpp\_prebuild.py}\\
 
 	\item Change directory to the top-level SCM directory.\\
-  \exec{cd ../../gmtb-scm} \\
-	\item Run the machine setup script if necessary. This script loads compiler modules (Fortran 2003-compliant Intel), netCDF module, etc. and sets compiler environment variables.  \\
+  \exec{cd scm} \\
+	\item Run the machine setup script if necessary. This script loads compiler modules (Fortran 2003-compliant Intel), netCDF module, etc. and sets compiler environment variables.\marginpar{MACOSX?}  \\
 For t/csh shell, \\
-  \exec{source Theia\_setup.csh} or\\
-  \exec{source Cheyenne\_setup.csh}\\
+  \exec{source etc/Theia\_setup.csh} or\\
+  \exec{source etc/Cheyenne\_setup.csh}\\
 
 For bourne/bash shells,\\
-  \exec{source Theia\_setup.sh} or\\
-  \exec{source Cheyenne\_setup.sh}\\
+  \exec{. etc/Theia\_setup.sh} or\\
+  \exec{. etc/Cheyenne\_setup.sh}\\
 
 	\item Make a build directory and change into it.  \\
   \exec{mkdir bin \&\& cd bin}\\

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -9,63 +9,63 @@
 
 # Relative to basedir defined in ccpp_prebuild.py
 VARIABLE_DEFINITION_FILES = [
-    '../../scm/src/gmtb_scm_type_defs.f90',
-    '../../scm/src/gmtb_scm_physical_constants.f90'
+    'scm/src/gmtb_scm_type_defs.f90',
+    'scm/src/gmtb_scm_physical_constants.f90'
     ]
 
 # Location of scheme_files relative to basedir defined in ccpp_prebuild.py
 SCHEME_FILES = [
-    '../../ccpp-physics/GFS_layer/GFS_initialize_scm.F90',
-    '../../ccpp-physics/physics/GFS_DCNV_generic.f90',
-    '../../ccpp-physics/physics/GFS_MP_generic_post.f90',
-    '../../ccpp-physics/physics/GFS_MP_generic_pre.f90',
-    '../../ccpp-physics/physics/GFS_PBL_generic.f90',
-    '../../ccpp-physics/physics/GFS_SCNV_generic.f90',
-    '../../ccpp-physics/physics/GFS_calpreciptype.f90',
-    '../../ccpp-physics/physics/GFS_phys_time_vary.f90',
-    '../../ccpp-physics/physics/GFS_rad_time_vary.f90',
-    '../../ccpp-physics/physics/GFS_rrtmg_post.F90',
-    '../../ccpp-physics/physics/GFS_rrtmg_pre.F90',
-    '../../ccpp-physics/physics/GFS_suite_interstitial.ccpp.f90',
-    '../../ccpp-physics/physics/GFS_surface_generic.f90',
-    '../../ccpp-physics/physics/GFS_surface_loop_control.f',
-    '../../ccpp-physics/physics/GFS_zhao_carr_pre.f90',
-    '../../ccpp-physics/physics/cnvc90.f',
-    '../../ccpp-physics/physics/dcyc2.f',
-    '../../ccpp-physics/physics/get_prs_fv3.f90',
-    '../../ccpp-physics/physics/gscond.f',
-    '../../ccpp-physics/physics/gwdc.f',
-    '../../ccpp-physics/physics/gwdps.f',
-    '../../ccpp-physics/physics/mfdeepcnv.f',
-    '../../ccpp-physics/physics/mfshalcnv.f',
-    '../../ccpp-physics/physics/moninedmf.f',
-    '../../ccpp-physics/physics/ozphys.f',
-    '../../ccpp-physics/physics/precpd.f',
-    '../../ccpp-physics/physics/radlw_main.f',
-    '../../ccpp-physics/physics/radsw_main.f',
-    '../../ccpp-physics/physics/rayleigh_damp.f',
-    '../../ccpp-physics/physics/rrtmg_lw_post.F90',
-    '../../ccpp-physics/physics/rrtmg_lw_pre.F90',
-    '../../ccpp-physics/physics/rrtmg_sw_post.F90',
-    '../../ccpp-physics/physics/rrtmg_sw_pre.F90',
-    '../../ccpp-physics/physics/sfc_diag.f',
-    '../../ccpp-physics/physics/sfc_diff.f',
-    '../../ccpp-physics/physics/sfc_drv.f',
-    '../../ccpp-physics/physics/sfc_nst.f',
-    '../../ccpp-physics/physics/sfc_sice.f',
+    'ccpp-physics/GFS_layer/GFS_initialize_scm.F90',
+    'ccpp-physics/physics/GFS_DCNV_generic.f90',
+    'ccpp-physics/physics/GFS_MP_generic_post.f90',
+    'ccpp-physics/physics/GFS_MP_generic_pre.f90',
+    'ccpp-physics/physics/GFS_PBL_generic.f90',
+    'ccpp-physics/physics/GFS_SCNV_generic.f90',
+    'ccpp-physics/physics/GFS_calpreciptype.f90',
+    'ccpp-physics/physics/GFS_phys_time_vary.f90',
+    'ccpp-physics/physics/GFS_rad_time_vary.f90',
+    'ccpp-physics/physics/GFS_rrtmg_post.F90',
+    'ccpp-physics/physics/GFS_rrtmg_pre.F90',
+    'ccpp-physics/physics/GFS_suite_interstitial.ccpp.f90',
+    'ccpp-physics/physics/GFS_surface_generic.f90',
+    'ccpp-physics/physics/GFS_surface_loop_control.f',
+    'ccpp-physics/physics/GFS_zhao_carr_pre.f90',
+    'ccpp-physics/physics/cnvc90.f',
+    'ccpp-physics/physics/dcyc2.f',
+    'ccpp-physics/physics/get_prs_fv3.f90',
+    'ccpp-physics/physics/gscond.f',
+    'ccpp-physics/physics/gwdc.f',
+    'ccpp-physics/physics/gwdps.f',
+    'ccpp-physics/physics/mfdeepcnv.f',
+    'ccpp-physics/physics/mfshalcnv.f',
+    'ccpp-physics/physics/moninedmf.f',
+    'ccpp-physics/physics/ozphys.f',
+    'ccpp-physics/physics/precpd.f',
+    'ccpp-physics/physics/radlw_main.f',
+    'ccpp-physics/physics/radsw_main.f',
+    'ccpp-physics/physics/rayleigh_damp.f',
+    'ccpp-physics/physics/rrtmg_lw_post.F90',
+    'ccpp-physics/physics/rrtmg_lw_pre.F90',
+    'ccpp-physics/physics/rrtmg_sw_post.F90',
+    'ccpp-physics/physics/rrtmg_sw_pre.F90',
+    'ccpp-physics/physics/sfc_diag.f',
+    'ccpp-physics/physics/sfc_diff.f',
+    'ccpp-physics/physics/sfc_drv.f',
+    'ccpp-physics/physics/sfc_nst.f',
+    'ccpp-physics/physics/sfc_sice.f',
     ]
 
 # Relative to basedir defined in ccpp_prebuild.py
-SCHEMES_MAKEFILE = '../../ccpp-physics/CCPP_SCHEMES.mk'
+SCHEMES_MAKEFILE = 'ccpp-physics/CCPP_SCHEMES.mk'
 
 # Relative to basedir defined in ccpp_prebuild.py
 TARGET_FILES = [
-    '../../scm/src/gmtb_scm.f90',
+    'scm/src/gmtb_scm.f90',
     ]
 
 # Relative to basedir defined in ccpp_prebuild.py
-CAPS_MAKEFILE = '../../ccpp-physics/CCPP_CAPS.mk'
-CAPS_DIR = '../../ccpp-physics/physics'
+CAPS_MAKEFILE = 'ccpp-physics/CCPP_CAPS.mk'
+CAPS_DIR = 'ccpp-physics/physics'
 
 # Optional arguments - only required for schemes that use optional arguments. This script will throw
 # an exception if it encounters a scheme subroutine with optional arguments if no entry is made in
@@ -108,7 +108,7 @@ MODULE_INCLUDE_FILE = 'ccpp_modules.inc'
 FIELDS_INCLUDE_FILE = 'ccpp_fields.inc'
 
 # HTML document containing the model-defined CCPP variables, relateive to basedir
-HTML_VARTABLE_FILE = '../../ccpp-physics/CCPP_VARIABLES.html'
+HTML_VARTABLE_FILE = 'ccpp-physics/CCPP_VARIABLES.html'
 
 
 ###############################################################################


### PR DESCRIPTION
This PR updates the Python configuration file and documentation for how to run ccpp_prebuild.py for SCM (from TOP_DIR instead of from TOP_DIR/ccpp-framework/scripts).