### PR TITLE
ccpp-framework cleanup 20180402

### DIFF
--- a/schemes/check/CMakeLists.txt
+++ b/schemes/check/CMakeLists.txt
@@ -61,6 +61,19 @@ add_custom_command(
 )
 list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/check_test_cap.f90)
 
+#------------------------------------------------------------------------------
+# The Fortran compiler/linker flag inserted by cmake to create shared libraries
+# with the Intel compiler is deprecated (-i_dynamic), correct here.
+# CMAKE_Fortran_COMPILER_ID = {"Intel", "PGI", "GNU", "Clang", "MSVC", ...}
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+    string(REPLACE "-i_dynamic" "-shared-intel"
+           CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS
+           "${CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS}")
+    string(REPLACE "-i_dynamic" "-shared-intel"
+           CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS
+           "${CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS}")
+endif()
+
 # Guard for undefined/empty CMAKE_Fortran_FLAGS
 set(CMAKE_Fortran_FLAGS " ${CMAKE_Fortran_FLAGS}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,8 +49,6 @@ endif()
 #------------------------------------------------------------------------------
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    #message(STATUS "Setting build type to 'Debug' as none was specified.")
-    #set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
     message(STATUS "Setting build type to 'Release' as none was specified.")
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 


### PR DESCRIPTION
This PR performs cleanup tasks: replace deprecated compiler flag -i_dynamic for Intel with -shared-intel.