### PR TITLE
DevelopersGuide bugfix

### DIFF
--- a/doc/DevelopersGuide/chap_hostmodel.tex
+++ b/doc/DevelopersGuide/chap_hostmodel.tex
@@ -128,7 +128,7 @@ In order to connect CCPP with a host model \execsub{XYZ}, a Python-based configu
 \begin{lstlisting}[language=bash]
 cp ccpp_prebuild_config_FV3.py ccpp_prebuild_config_XYZ.py
 \end{lstlisting}
-and adding \execout{XYZ} to the \execout{HOST_MODELS} list in the section \execout{User definitions} in \execout{ccpp\_prebuild.py}.
+and adding \execout{XYZ} to the \execout{HOST\_MODELS} list in the section \execout{User definitions} in \execout{ccpp\_prebuild.py}.
 
 The configuration in \execout{ccpp\_prebuild\_config\_XYZ.py} depends largely on (a) the directory structure of the host model itself, (b) where the \execout{ccpp-framework} and the \execout{ccpp-physics} directories are located relative to the directory structure of the host model, and (c) from which directory the \execout{ccpp\_prebuild.py} script is executed before/during the build process (this is referred to as \execout{basedir} in \execout{ccpp\_prebuild\_config\_XYZ.py}).
 


### PR DESCRIPTION
Added a missing backslash whose absence caused an error condition during make.
Tested by running make in doc/DevelopersGuide directory.