### PR TITLE
CCPP run _init and _final for schemes

### DIFF
--- a/examples/suite_FV3_test.xml
+++ b/examples/suite_FV3_test.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <suite name="FV3_test" lib="ccppphys" ver="1">
-  <init>FV3_test_init</init>
+  <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">
-      <scheme>FV3_test_run</scheme>
+      <scheme>FV3_test</scheme>
     </subcycle>
   </group>
-  <finalize>FV3_test_finalize</finalize>
+  <!-- <finalize></finalize> -->
 </suite>

--- a/examples/suite_GFS_operational_2017.xml
+++ b/examples/suite_GFS_operational_2017.xml
@@ -9,97 +9,97 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset_run</scheme>
-      <scheme>GFS_rrtmg_pre_run</scheme>
-      <scheme>rrtmg_sw_pre_run</scheme>
-      <scheme>rrtmg_sw_run</scheme>
-      <scheme>rrtmg_sw_post_run</scheme>
-      <scheme>rrtmg_lw_pre_run</scheme>
-      <scheme>rrtmg_lw_run</scheme>
-      <scheme>rrtmg_lw_post_run</scheme>
-      <scheme>GFS_rrtmg_post_run</scheme>
-      <!-- <scheme>memcheck_run</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen_run</scheme> -->
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>rrtmg_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+      <!-- <scheme>memcheck</scheme> -->
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
+      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset_run</scheme>
-      <scheme>get_prs_fv3_run</scheme>
-      <scheme>GFS_suite_interstitial_1_run</scheme>
-      <scheme>sfc_sice_pre_run</scheme>
-      <scheme>dcyc2t3_run</scheme>
-      <scheme>GFS_suite_interstitial_2_run</scheme>
-      <scheme>GFS_surface_generic_pre_run</scheme>
-      <scheme>GFS_PBL_generic_pre_run</scheme>
-      <scheme>lsm_noah_pre_run</scheme>
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>sfc_sice_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>lsm_noah_pre</scheme>
       <!-- DH* TODO - turn into a subsycle loop="2" construct? -->
       <!-- Surface iteration loop 1 -->
-      <scheme>GFS_surface_loop_control_part0_run</scheme>
-      <scheme>sfc_ex_coef_run</scheme>
-      <scheme>GFS_surface_loop_control_part1_run</scheme>
-      <scheme>sfc_nst_pre_run</scheme>
-      <scheme>sfc_nst_run</scheme>
-      <scheme>sfc_nst_post_run</scheme>
-      <scheme>lsm_noah_run</scheme>
-      <scheme>sfc_sice_run</scheme>
-      <scheme>GFS_surface_loop_control_part2_run</scheme>
+      <scheme>GFS_surface_loop_control_part0</scheme>
+      <scheme>sfc_ex_coef</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
       <!-- Surface iteration loop 2 -->
-      <scheme>GFS_surface_loop_control_part0_run</scheme>
-      <scheme>sfc_ex_coef_run</scheme>
-      <scheme>GFS_surface_loop_control_part1_run</scheme>
-      <scheme>sfc_nst_pre_run</scheme>
-      <scheme>sfc_nst_run</scheme>
-      <scheme>sfc_nst_post_run</scheme>
-      <scheme>lsm_noah_run</scheme>
-      <scheme>sfc_sice_run</scheme>
-      <scheme>GFS_surface_loop_control_part2_run</scheme>
+      <scheme>GFS_surface_loop_control_part0</scheme>
+      <scheme>sfc_ex_coef</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
       <!-- End of surface iteration loop -->
-      <scheme>dcyc2t3_post_run</scheme>
-      <scheme>sfc_diag_run</scheme>
-      <scheme>GFS_surface_generic_post_run</scheme>
-      <scheme>edmf_run</scheme>
-      <scheme>GFS_PBL_generic_post_run</scheme>
-      <scheme>gwdps_pre_run</scheme>
-      <scheme>gwdps_run</scheme>
-      <scheme>gwdps_post_run</scheme>
-      <scheme>rayleigh_damp_run</scheme>
-      <scheme>GFS_suite_update_stateout_run</scheme>
-      <scheme>ozphys_run</scheme>
-      <scheme>ozphys_post_run</scheme>
-      <scheme>GFS_DCNV_generic_pre_run</scheme>
-      <scheme>get_phi_fv3_run</scheme>
-      <scheme>GFS_suite_interstitial_3_run</scheme>
-      <scheme>GFS_zhao_carr_pre_run</scheme>
-      <scheme>sasas_deep_run</scheme>
-      <scheme>GFS_DCNV_generic_post_run</scheme>
-      <scheme>gwdc_pre_run</scheme>
-      <scheme>gwdc_run</scheme>
-      <scheme>gwdc_post_run</scheme>
-      <scheme>GFS_SCNV_generic_pre_run</scheme>
-      <scheme>sasas_shal_run</scheme>
-      <scheme>sasas_shal_post_run</scheme>
-      <scheme>GFS_SCNV_generic_post_run</scheme>
-      <scheme>cnvc90_run</scheme>
-      <scheme>GFS_MP_generic_pre_run</scheme>
-      <scheme>zhaocarr_gscond_run</scheme>
-      <scheme>zhaocarr_precpd_run</scheme>
-      <scheme>GFS_calpreciptype_run</scheme>
-      <scheme>GFS_MP_generic_post_run</scheme>
-      <scheme>sfc_diag_run</scheme>
-      <scheme>lsm_noah_post_run</scheme>
-      <scheme>sfc_sice_post_run</scheme>
-      <!-- <scheme>memcheck_run</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen_run</scheme> -->
+      <scheme>dcyc2t3_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>edmf</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>gwdps_pre</scheme>
+      <scheme>gwdps</scheme>
+      <scheme>gwdps_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_update_stateout</scheme>
+      <scheme>ozphys</scheme>
+      <scheme>ozphys_post</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_zhao_carr_pre</scheme>
+      <scheme>sasas_deep</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>gwdc_pre</scheme>
+      <scheme>gwdc</scheme>
+      <scheme>gwdc_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>sasas_shal</scheme>
+      <scheme>sasas_shal_post</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>zhaocarr_gscond</scheme>
+      <scheme>zhaocarr_precpd</scheme>
+      <scheme>GFS_calpreciptype</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>lsm_noah_post</scheme>
+      <scheme>sfc_sice_post</scheme>
+      <!-- <scheme>memcheck</scheme> -->
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
+      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="stochastics">
     <subcycle loop="1">
-      <scheme>GFS_stochastics_run</scheme>
-      <!-- <scheme>memcheck_run</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
+      <scheme>GFS_stochastics</scheme>
+      <!-- <scheme>memcheck</scheme> -->
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
     </subcycle>
   </group>
   <finalize>IPD_finalize</finalize>

--- a/examples/suite_scm_GFS_test.xml
+++ b/examples/suite_scm_GFS_test.xml
@@ -1,100 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <suite name="GFS_operational_2017" lib="ccppphys" ver="1.0.0">
-  <init>GFS_initialize_scm_run</init>
+  <init>GFS_initialize_scm</init>
   <group name="time_vary">
     <subcycle loop="1">
-      <scheme>GFS_phys_time_vary_1_run</scheme>
-      <scheme>GFS_rad_time_vary_run</scheme>
-      <scheme>GFS_phys_time_vary_2_run</scheme>
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
+      <scheme>GFS_phys_time_vary_1</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary_2</scheme>
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset_run</scheme>
-      <scheme>GFS_rrtmg_pre_run</scheme>
-      <scheme>rrtmg_sw_pre_run</scheme>
-      <scheme>rrtmg_sw_run</scheme>
-      <scheme>rrtmg_sw_post_run</scheme>
-      <scheme>rrtmg_lw_pre_run</scheme>
-      <scheme>rrtmg_lw_run</scheme>
-      <scheme>rrtmg_lw_post_run</scheme>
-      <scheme>GFS_rrtmg_post_run</scheme>
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen_run</scheme> -->
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>rrtmg_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
+      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset_run</scheme>
-      <scheme>get_prs_fv3_run</scheme>
-      <scheme>GFS_suite_interstitial_1_run</scheme>
-      <scheme>sfc_sice_pre_run</scheme>
-      <scheme>dcyc2t3_run</scheme>
-      <scheme>GFS_suite_interstitial_2_run</scheme>
-      <scheme>GFS_surface_generic_pre_run</scheme>
-      <scheme>GFS_PBL_generic_pre_run</scheme>
-      <scheme>lsm_noah_pre_run</scheme>
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>sfc_sice_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>lsm_noah_pre</scheme>
       <!-- DH* TODO - turn into a subsycle loop="2" construct? -->
       <!-- Surface iteration loop 1 -->
-      <scheme>GFS_surface_loop_control_part0_run</scheme>
-      <scheme>sfc_ex_coef_run</scheme>
-      <scheme>GFS_surface_loop_control_part1_run</scheme>
-      <scheme>sfc_nst_pre_run</scheme>
-      <scheme>sfc_nst_run</scheme>
-      <scheme>sfc_nst_post_run</scheme>
-      <scheme>lsm_noah_run</scheme>
-      <scheme>sfc_sice_run</scheme>
-      <scheme>GFS_surface_loop_control_part2_run</scheme>
+      <scheme>GFS_surface_loop_control_part0</scheme>
+      <scheme>sfc_ex_coef</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
       <!-- Surface iteration loop 2 -->
-      <scheme>GFS_surface_loop_control_part0_run</scheme>
-      <scheme>sfc_ex_coef_run</scheme>
-      <scheme>GFS_surface_loop_control_part1_run</scheme>
-      <scheme>sfc_nst_pre_run</scheme>
-      <scheme>sfc_nst_run</scheme>
-      <scheme>sfc_nst_post_run</scheme>
-      <scheme>lsm_noah_run</scheme>
-      <scheme>sfc_sice_run</scheme>
-      <scheme>GFS_surface_loop_control_part2_run</scheme>
+      <scheme>GFS_surface_loop_control_part0</scheme>
+      <scheme>sfc_ex_coef</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
       <!-- End of surface iteration loop -->
-      <scheme>dcyc2t3_post_run</scheme>
-      <scheme>sfc_diag_run</scheme>
-      <scheme>GFS_surface_generic_post_run</scheme>
-      <scheme>edmf_run</scheme>
-      <scheme>GFS_PBL_generic_post_run</scheme>
-      <scheme>gwdps_pre_run</scheme>
-      <scheme>gwdps_run</scheme>
-      <scheme>gwdps_post_run</scheme>
-      <scheme>rayleigh_damp_run</scheme>
-      <scheme>GFS_suite_update_stateout_run</scheme>
-      <scheme>ozphys_run</scheme>
-      <scheme>ozphys_post_run</scheme>
-      <scheme>GFS_DCNV_generic_pre_run</scheme>
-      <scheme>get_phi_fv3_run</scheme>
-      <scheme>GFS_suite_interstitial_3_run</scheme>
-      <scheme>GFS_zhao_carr_pre_run</scheme>
-      <scheme>sasas_deep_run</scheme>
-      <scheme>GFS_DCNV_generic_post_run</scheme>
-      <scheme>gwdc_pre_run</scheme>
-      <scheme>gwdc_run</scheme>
-      <scheme>gwdc_post_run</scheme>
-      <scheme>GFS_SCNV_generic_pre_run</scheme>
-      <scheme>sasas_shal_run</scheme>
-      <scheme>sasas_shal_post_run</scheme>
-      <scheme>GFS_SCNV_generic_post_run</scheme>
-      <scheme>cnvc90_run</scheme>
-      <scheme>GFS_MP_generic_pre_run</scheme>
-      <scheme>zhaocarr_gscond_run</scheme>
-      <scheme>zhaocarr_precpd_run</scheme>
-      <scheme>GFS_calpreciptype_run</scheme>
-      <scheme>GFS_MP_generic_post_run</scheme>
-      <scheme>sfc_diag_run</scheme>
-      <scheme>lsm_noah_post_run</scheme>
-      <scheme>sfc_sice_post_run</scheme>
-      <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen_run</scheme> -->
+      <scheme>dcyc2t3_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>edmf</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>gwdps_pre</scheme>
+      <scheme>gwdps</scheme>
+      <scheme>gwdps_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_update_stateout</scheme>
+      <scheme>ozphys</scheme>
+      <scheme>ozphys_post</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_zhao_carr_pre</scheme>
+      <scheme>sasas_deep</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>gwdc_pre</scheme>
+      <scheme>gwdc</scheme>
+      <scheme>gwdc_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>sasas_shal</scheme>
+      <scheme>sasas_shal_post</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>zhaocarr_gscond</scheme>
+      <scheme>zhaocarr_precpd</scheme>
+      <scheme>GFS_calpreciptype</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>lsm_noah_post</scheme>
+      <scheme>sfc_sice_post</scheme>
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
+      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
-  <finalize>GFS_finalize_scm_run</finalize> <!-- need to add this one? -->
+  <finalize>GFS_finalize_scm</finalize>
 </suite>

--- a/schemes/check/check_test.f90
+++ b/schemes/check/check_test.f90
@@ -20,11 +20,11 @@ module check_test
     implicit none
 
     private
-    public :: test
+    public :: test_run
 
     contains
 
-    subroutine test(gravity, u, v, surf_t)
+    subroutine test_run(gravity, u, v, surf_t)
         implicit none
         real, intent(inout) :: gravity
         real, intent(inout) :: surf_t(:)
@@ -39,6 +39,6 @@ module check_test
         print *, 'updating v to be -10m/s'
         v = -10.0
 
-    end subroutine test
+    end subroutine test_run
 
 end module check_test

--- a/schemes/check/nan.f90
+++ b/schemes/check/nan.f90
@@ -43,11 +43,11 @@ module check_nans
 
         call ccpp_field_get(cdata, 'northward_wind', v, ierr)
 
-        call test_run(gravity, u, v, surf_t)
+        call nans_run(gravity, u, v, surf_t)
 
     end subroutine nans_cap
 
-    subroutine run(gravity, u, v, surf_t)
+    subroutine nans_run(gravity, u, v, surf_t)
         implicit none
         real, pointer, intent(inout) :: gravity
         real, pointer, intent(inout) :: surf_t(:)
@@ -56,6 +56,6 @@ module check_nans
 
         print *, 'In physics check nans run'
 
-    end subroutine test_run
+    end subroutine nans_run
 
 end module check_test

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES_F90
     ccpp_fields.F90
     ccpp_memory.F90
     ccpp_strings.F90
+    ccpp_scheme.F90
     ccpp_suite.F90
     ccpp_types.F90
     ccpp_xml.F90

--- a/src/ccpp_dl.F90
+++ b/src/ccpp_dl.F90
@@ -20,13 +20,13 @@ module ccpp_dl
     interface
         integer(c_int32_t)                                             &
         function ccpp_dl_open                                          &
-                   (name, library, version, shdl, lhdl)                &
+                   (name, library, version, fhdl, lhdl)                &
                    bind(c, name='ccpp_dl_open')
             import :: c_char, c_int32_t, c_ptr
             character(kind=c_char), dimension(*)  :: name
             character(kind=c_char), dimension(*)  :: library
             character(kind=c_char), dimension(*)  :: version
-            type(c_ptr)                           :: shdl
+            type(c_ptr)                           :: fhdl
             type(c_ptr)                           :: lhdl
         end function ccpp_dl_open
 

--- a/src/ccpp_dl.c
+++ b/src/ccpp_dl.c
@@ -51,14 +51,14 @@ static const char suffix[] = ".so";
  * @param[in]  scheme    The scheme name to call.
  * @param[in]  lib       The library continaing the physics scheme.
  * @param[in]  ver       The library version number.
- * @param[out] shdl      The scheme function pointer handle.
+ * @param[out] fhdl      The scheme function pointer handle.
  * @param[out] lhdl      The library handle.
  * @retval     0         If it was sucessful
  * @retval     1         If there was an error
  **/
 int
 ccpp_dl_open(const char *scheme, const char *lib, const char *ver,
-	     void **shdl, void **lhdl)
+	     void **fhdl, void **lhdl)
 {
 	int i = 0;
 	int n = 0;
@@ -115,7 +115,7 @@ ccpp_dl_open(const char *scheme, const char *lib, const char *ver,
 	}
 
 	dlerror();
-	*(void **)shdl = dlsym(*lhdl, scheme_cap);
+	*(void **)fhdl = dlsym(*lhdl, scheme_cap);
 	if ((error = dlerror()) != NULL)  {
 		warnx("%s", error);
 		return(EXIT_FAILURE);

--- a/src/ccpp_scheme.F90
+++ b/src/ccpp_scheme.F90
@@ -1,0 +1,159 @@
+!
+! This work (Common Community Physics Package), identified by NOAA, NCAR,
+! CU/CIRES, is free of known copyright restrictions and is placed in the
+! public domain.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+! THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+! IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+!
+
+!>
+!! @brief Physics scheme infrastructure module.
+!
+module ccpp_scheme
+
+    use            :: ccpp_types,                                      &
+                      only: ccpp_scheme_t, CCPP_STAGES
+    use            :: ccpp_errors,                                     &
+                      only: ccpp_error, ccpp_debug
+    use            :: ccpp_strings,                                    &
+                      only: ccpp_cstr
+    use            :: ccpp_dl,                                         &
+                      only: ccpp_dl_open, ccpp_dl_close
+
+    implicit none
+
+    private
+    public :: ccpp_scheme_init,                                        &
+              ccpp_scheme_finalize,                                    &
+              ccpp_scheme_load,                                        &
+              ccpp_scheme_unload
+
+    contains
+
+    !>
+    !! Scheme initialization subroutine.
+    !!
+    !! @param[in,out] scheme   The ccpp_scheme_t type to initalize
+    !! @param[  out]  ierr     Integer error flag
+    !
+    subroutine ccpp_scheme_init(scheme, ierr)
+
+        type(ccpp_scheme_t), intent(inout)  :: scheme
+        integer            , intent(  out)  :: ierr
+
+        integer                            :: i
+
+        call ccpp_debug('Called ccpp_scheme_init')
+
+        ierr = 0
+
+        scheme%functions_max = size(CCPP_STAGES)
+
+        allocate(scheme%functions(1:scheme%functions_max))
+        do i=1,scheme%functions_max
+            scheme%functions(i)%name = trim(scheme%get_function_name(trim(CCPP_STAGES(i))))
+        end do
+
+    end subroutine ccpp_scheme_init
+
+    !>
+    !! Scheme finalization subroutine.
+    !!
+    !! @param[in,out] scheme   The ccpp_scheme_t type to finalize
+    !! @param[  out]  ierr     Integer error flag
+    !
+    subroutine ccpp_scheme_finalize(scheme, ierr)
+
+        type(ccpp_scheme_t), intent(inout)  :: scheme
+        integer            , intent(  out)  :: ierr
+
+        integer                            :: i
+
+        call ccpp_debug('Called ccpp_scheme_finalize')
+
+        ierr = 0
+
+        if (.not.(allocated(scheme%functions))) return
+
+        do i=1,scheme%functions_max
+            if (allocated(scheme%functions(i)%name)) &
+                  deallocate(scheme%functions(i)%name)
+        end do
+
+        deallocate(scheme%functions)
+
+    end subroutine ccpp_scheme_finalize
+
+    !>
+    !! Scheme loading subroutine.
+    !!
+    !! @param[in,out] scheme   The ccpp_scheme_t type to load
+    !! @param[  out]  ierr     Integer error flag
+    !
+    subroutine ccpp_scheme_load(scheme, ierr)
+
+        type(ccpp_scheme_t), intent(inout)  :: scheme
+        integer            , intent(  out)  :: ierr
+
+        integer                            :: i
+
+        call ccpp_debug('Called ccpp_scheme_load')
+
+        ierr = 0
+
+        do i=1, scheme%functions_max
+            associate (f => scheme%functions(i))
+                call ccpp_debug('Loading ' // trim(f%name) &
+                                // ' from ' // trim(scheme%library))
+                ierr = ccpp_dl_open(ccpp_cstr(f%name),    &
+                                    ccpp_cstr(scheme%library), &
+                                    ccpp_cstr(scheme%version), &
+                                    f%function_hdl,       &
+                                    f%library_hdl)
+                if (ierr /= 0) then
+                    call ccpp_error('A problem occured loading ' &
+                                    // trim(f%name) // ' from '  &
+                                    // trim(scheme%library))
+                    return
+                end if
+            end associate
+        end do
+
+    end subroutine ccpp_scheme_load
+
+    !>
+    !! Scheme unloading subroutine.
+    !!
+    !! @param[in,out] scheme   The ccpp_scheme_t type to unload
+    !! @param[  out]  ierr     Integer error flag
+    !
+    subroutine ccpp_scheme_unload(scheme, ierr)
+
+        type(ccpp_scheme_t), intent(inout)  :: scheme
+        integer            , intent(  out)  :: ierr
+
+        integer                            :: i
+
+        call ccpp_debug('Called ccpp_scheme_unload')
+
+        ierr = 0
+
+        do i=1, scheme%functions_max
+            associate (f => scheme%functions(i))
+                ierr = ccpp_dl_close(f%library_hdl)
+                if (ierr /= 0) then
+                    call ccpp_error('A problem occured closing ' &
+                                    // trim(scheme%library))
+                    return
+                end if
+            end associate
+        end do
+
+    end subroutine ccpp_scheme_unload
+
+end module ccpp_scheme


### PR DESCRIPTION
This PR separates out the changes to ccpp-framework in PR https://github.com/NCAR/ccpp-framework/pull/69 that enable running the XXX_init and XXX_finalize routines automatically for every scheme listed in the SDF.

In addition, a suite-specific scheme YYY can be used, for which the YYY_init and YYY_finalize routines can be run explicitly before (init) and after (finalize) the scheme init and finalize routines are run:

```
...
<init>YYY</init>
<group ...>
   ...
   <scheme>XXX</scheme>
   ...
</group>
<finalize>YYY</finalize>
...
```

The above snippet will run:

- during init: YYY_init, XXX_init
- during the time integration: XXX_run
- during finalize: XXX_finalize, YYY_finalize

This PR was tested to work and is ready to review and merge.