### PR TITLE
Code owner review code protection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+#*       @defunkt
+*       @climbfuji @llpcarson @grantfirl
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+#*.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+#docs/*  docs@example.com


### PR DESCRIPTION
This PR adds a CODEOWNERS file for code owner review code protection. Currently only the GMTB folks, as soon as we have the official approval to work jointly on this with MMM and GCD, they will be added.