### PR TITLE
Revert "update for deep convection generic interstitials"

### DIFF
--- a/examples/suite_FV3_test.xml
+++ b/examples/suite_FV3_test.xml
@@ -41,9 +41,7 @@
       <scheme>gwdps_pre</scheme>
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
-      <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>samfdeepcnv</scheme>
-      <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>
       <scheme>gwdc</scheme>
       <scheme>gwdc_post</scheme>

--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -60,8 +60,8 @@ SCHEME_FILES_DEPENDENCIES = [
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = {
-    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of categories in which scheme may be called ]
-    'ccpp/physics/physics/GFS_DCNV_generic.f90'           : [ 'slow_physics' ],
+    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of categories in which scheme may be called ] 
+#    'ccpp/physics/physics/GFS_DCNV_generic.f90'           : [ 'slow_physics' ],
 #    'ccpp/physics/physics/GFS_MP_generic_post.f90'        : [ 'slow_physics' ],
 #    'ccpp/physics/physics/GFS_MP_generic_pre.f90'         : [ 'slow_physics' ],
 #    'ccpp/physics/physics/GFS_PBL_generic.f90'            : [ 'slow_physics' ],


### PR DESCRIPTION
Reverts NCAR/ccpp-framework#99 - current trunk is broken, results are no longer bit for bit identical on MacOSX+GNU and code hangs or crashed on Theia+Intel. Removing this PR and the associated PRs for FV3 and ccpp-physics fixes the issue.