### PR TITLE
VLAB master merge follow-up for SCM 08/15/2018

### DIFF
--- a/examples/suite_FV3_test_gfdlmp.xml
+++ b/examples/suite_FV3_test_gfdlmp.xml
@@ -64,7 +64,7 @@
       <scheme>ozphys</scheme>
       <scheme>ozphys_post</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
-      <scheme>GFS_zhao_carr_pre</scheme>
+      <!-- <scheme>GFS_zhao_carr_pre</scheme> -->
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>

--- a/examples/suite_FV3_test_wsm6.xml
+++ b/examples/suite_FV3_test_wsm6.xml
@@ -55,6 +55,8 @@
       <scheme>gwdps_pre</scheme>
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
+      <scheme>ozphys</scheme>
+      <scheme>ozphys_post</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -85,6 +85,7 @@ SCHEME_FILES = {
     'ccpp-physics/physics/gscond.f'                     : ['physics'],
     'ccpp-physics/physics/gwdc.f'                       : ['physics'],
     'ccpp-physics/physics/gwdps.f'                      : ['physics'],
+    'ccpp-physics/physics/h2ophys.f'                    : ['physics'],
     'ccpp-physics/physics/samfdeepcnv.f'                : ['physics'],
     'ccpp-physics/physics/samfshalcnv.f'                : ['physics'],
     'ccpp-physics/physics/moninedmf.f'                  : ['physics'],


### PR DESCRIPTION
This PR makes some follow-up adjustments for SCM after the VLAB master merge for NEMSfv3gfs went in.

For ccpp-framework: add h2ophys to CCPP prebuild config (even though not yet executed, but to make sure all the required variables and their metadata are available).