### PR TITLE
Memory checking utility for CCPP builds (of NEMSfv3gfs)

### DIFF
--- a/examples/suite_FV3_test_memcheck.xml
+++ b/examples/suite_FV3_test_memcheck.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_test" lib="ccppphys" ver="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+      <scheme>stochastic_physics</scheme>
+      <scheme>stochastic_physics_sfc</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>rrtmg_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+      <!-- <scheme>memcheck</scheme> -->
+      <!-- <scheme>GFS_diagtoscreen</scheme> -->
+      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_ex_coef</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>dcyc2t3_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>hedmf</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>gwdps_pre</scheme>
+      <scheme>gwdps</scheme>
+      <scheme>gwdps_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>ozphys</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_zhao_carr_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>memcheck</scheme>
+      <scheme>gwdc_pre</scheme>
+      <scheme>gwdc</scheme>
+      <scheme>gwdc_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>samfshalcnv_post</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>zhaocarr_gscond</scheme>
+      <scheme>zhaocarr_precpd</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>sfc_sice_post</scheme>
+    </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -144,6 +144,8 @@ SCHEME_FILES = {
     'ccpp/physics/physics/sfc_sice.f'                        : [ 'slow_physics' ],
     # stochastic physics
     'ccpp/physics/stochastic_physics/stochastic_physics.F90' : [ 'slow_physics' ],
+    # memcheck utility
+    'ccpp/physics/physics/memcheck.F90'                      : [ 'slow_physics' ],
     }
 
 # Auto-generated makefile/cmakefile snippets that contain all schemes
@@ -216,6 +218,9 @@ OPTIONAL_ARGUMENTS = {
             'mean_effective_radius_for_ice_cloud',
             'mean_effective_radius_for_snow_flake',
             ],
+        },
+    'memcheck' : {
+        'memcheck_run' : [ 'mpi_root' ],
         },
     #'subroutine_name_1' : 'all',
     #'subroutine_name_2' : 'none',

--- a/src/ccpp_memory.c
+++ b/src/ccpp_memory.c
@@ -35,6 +35,9 @@
 #ifdef MPI
 #include <mpi.h>
 #endif
+#ifdef OPENMP
+#include <omp.h>
+#endif
 
 #include "ccpp_memory.h"
 
@@ -153,6 +156,17 @@ int ccpp_memory_usage_c(const int mpicomm, char* str, int lstr){
 	mpisize = 1;
 #endif
 
+	// Get OpenMP thread number and total number of threads
+	int ompthread;
+	int ompthreads;
+#ifdef OPENMP
+	ompthread = omp_get_thread_num();
+	ompthreads = omp_get_num_threads();
+#else
+	ompthread = 0;
+	ompthreads = 1;
+#endif
+
 	// Retrieve hostname
 	char hostname[128];
 	gethostname(hostname, sizeof(hostname));
@@ -211,7 +225,7 @@ int ccpp_memory_usage_c(const int mpicomm, char* str, int lstr){
 #ifndef MPI
 	snprintf(strtmp, sizeof(strtmp), 
 "--------------------------------------------------------------------------------\n\
-Memory usage - MPI rank %d/%d\n\
+Memory usage - MPI rank %d/%d - OMP thread %d/%d\n\
 \n\
 Statistics for node %s:\n\
 Total virtual  memory:      %lld MB\n\
@@ -224,12 +238,13 @@ Virtual    memory this process: %d MB\n\
 Physical   memory this process: %d MB\n\
 Max. phys. memory this process: %d MB\n\
 --------------------------------------------------------------------------------\n\
-", mpirank, mpisize, hostname, totalVirtMem, virtMemUsed, totalPhysMem, physMemUsed,
+", mpirank, mpisize, ompthread, ompthreads,
+hostname, totalVirtMem, virtMemUsed, totalPhysMem, physMemUsed,
 pid, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax);
 #else
 	snprintf(strtmp, sizeof(strtmp), 
 "--------------------------------------------------------------------------------\n\
-Memory usage - MPI rank %d/%d\n\
+Memory usage - MPI rank %d/%d - OMP thread %d/%d\n\
 \n\
 Statistics for node %s:\n\
 Total virtual  memory:      %lld MB\n\
@@ -247,7 +262,8 @@ Virtual    memory average: %d MB\n\
 Physical   memory average: %d MB\n\
 Max. phys. memory average: %d MB\n\
 --------------------------------------------------------------------------------\n\
-", mpirank, mpisize, hostname, totalVirtMem, virtMemUsed, totalPhysMem, physMemUsed,
+", mpirank, mpisize, ompthread, ompthreads,
+hostname, totalVirtMem, virtMemUsed, totalPhysMem, physMemUsed,
 pid, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax, virtMemPerProcessAvg,
 physMemPerProcessAvg, physMemPerProcessMaxAvg);
 #endif
@@ -294,7 +310,16 @@ int ccpp_memory_usage_c(const int mpicomm, char* str, int lstr){
 	mpisize = 1;
 #endif
 
-	// Retrieve memory statistics
+	// Get OpenMP thread number and total number of threads
+	int ompthread;
+	int ompthreads;
+#ifdef OPENMP
+	ompthread = omp_get_thread_num();
+	ompthreads = omp_get_num_threads();
+#else
+	ompthread = 0;
+	ompthreads = 1;
+#endif
 
 	// Available physical memory - in Byte
 	unsigned long long totalPhysMem;
@@ -338,7 +363,7 @@ int ccpp_memory_usage_c(const int mpicomm, char* str, int lstr){
 #ifndef MPI
 	snprintf(strtmp, sizeof(strtmp), 
 "--------------------------------------------------------------------------------\n\
-Memory usage - MPI rank %d/%d\n\
+Memory usage - MPI rank %d/%d - OMP thread %d/%d\n\
 \n\
 Size of physical memory: %llu MB\n\
 \n\
@@ -346,11 +371,12 @@ Virtual    memory this process: %d MB\n\
 Physical   memory this process: %d MB\n\
 Max. phys. memory this process: %d MB\n\
 --------------------------------------------------------------------------------\n\
-", mpirank, mpisize, totalPhysMem, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax);
+", mpirank, mpisize, ompthread, ompthreads, 
+totalPhysMem, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax);
 #else
 	snprintf(strtmp, sizeof(strtmp), 
 "--------------------------------------------------------------------------------\n\
-Memory usage - MPI rank %d/%d\n\
+Memory usage - MPI rank %d/%d - OMP thread %d/%d\n\
 \n\
 Size of physical memory: %llu MB\n\
 \n\
@@ -363,7 +389,8 @@ Virtual    memory average: %d MB\n\
 Physical   memory average: %d MB\n\
 Max. phys. memory average: %d MB\n\
 --------------------------------------------------------------------------------\n\
-", mpirank, mpisize, totalPhysMem, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax,
+", mpirank, mpisize, ompthread, ompthreads, 
+totalPhysMem, virtMemPerProcess, physMemPerProcess, physMemPerProcessMax,
 virtMemPerProcessAvg, physMemPerProcessAvg, physMemPerProcessMaxAvg);
 #endif
 


### PR DESCRIPTION
This PR enables the memory checking utility for the CCPP build of NEMSfv3gfs. A new SDF is introduced based on the standard SDF (for the fv3_ccpp_control test etc). This SDF can also be used in the future to conduct SDF-only (i.e. pure CCPP) runs with memory testing.

This PR is related to other PRs listed below. For information about regression testing and merging, see https://github.com/NCAR/NEMSfv3gfs/pull/35.