### PR TITLE
MP interstitial cleanup 3

### DIFF
--- a/examples/suite_FV3_test.xml
+++ b/examples/suite_FV3_test.xml
@@ -63,7 +63,7 @@
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>
-      <scheme>GFS_zhao_carr_pre</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>

--- a/examples/suite_FV3_test.xml
+++ b/examples/suite_FV3_test.xml
@@ -73,6 +73,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>zhaocarr_gscond</scheme>
       <scheme>zhaocarr_precpd</scheme>

--- a/examples/suite_FV3_test_gfdlmp.xml
+++ b/examples/suite_FV3_test_gfdlmp.xml
@@ -79,6 +79,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>gfdl_cloud_microphys_pre</scheme>
       <scheme>gfdl_cloud_microphys</scheme>

--- a/examples/suite_FV3_test_gfdlmp.xml
+++ b/examples/suite_FV3_test_gfdlmp.xml
@@ -69,7 +69,7 @@
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>
-      <scheme>GFS_gfdlmp_pre</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>

--- a/examples/suite_FV3_test_h2ophys.xml
+++ b/examples/suite_FV3_test_h2ophys.xml
@@ -74,6 +74,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>zhaocarr_gscond</scheme>
       <scheme>zhaocarr_precpd</scheme>

--- a/examples/suite_FV3_test_h2ophys.xml
+++ b/examples/suite_FV3_test_h2ophys.xml
@@ -64,7 +64,7 @@
       <scheme>h2ophys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>
-      <scheme>GFS_zhao_carr_pre</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>

--- a/examples/suite_FV3_test_wsm6.xml
+++ b/examples/suite_FV3_test_wsm6.xml
@@ -72,6 +72,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>GFS_calpreciptype</scheme>
       <scheme>sfc_sice_post</scheme>

--- a/examples/suite_FV3_test_wsm6.xml
+++ b/examples/suite_FV3_test_wsm6.xml
@@ -63,6 +63,7 @@
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>samfdeepcnv</scheme>
       <scheme>GFS_DCNV_generic_post</scheme>
       <scheme>gwdc_pre</scheme>

--- a/examples/suite_GFS_operational_2017_scm.xml
+++ b/examples/suite_GFS_operational_2017_scm.xml
@@ -72,6 +72,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>zhaocarr_gscond</scheme>

--- a/examples/suite_GFS_operational_2017_scm_prescribed_surface.xml
+++ b/examples/suite_GFS_operational_2017_scm_prescribed_surface.xml
@@ -57,6 +57,7 @@
       <scheme>samfshalcnv</scheme>
       <scheme>samfshalcnv_post</scheme>
       <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>zhaocarr_gscond</scheme>

--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -111,8 +111,6 @@ SCHEME_FILES = {
     'ccpp/physics/physics/GFS_surface_generic.f90'           : [ 'slow_physics' ],
     'ccpp/physics/physics/GFS_surface_loop_control.F90'      : [ 'slow_physics' ],
     'ccpp/physics/physics/GFS_time_vary_pre.fv3.f90'         : [ 'slow_physics' ],
-    'ccpp/physics/physics/GFS_zhao_carr_pre.f90'             : [ 'slow_physics' ],
-    'ccpp/physics/physics/GFS_gfdlmp_pre.f90'                : [ 'slow_physics' ],
     'ccpp/physics/physics/cnvc90.f'                          : [ 'slow_physics' ],
     'ccpp/physics/physics/dcyc2.f'                           : [ 'slow_physics' ],
     'ccpp/physics/physics/get_prs_fv3.f90'                   : [ 'slow_physics' ],

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -78,7 +78,6 @@ SCHEME_FILES = {
     'ccpp-physics/physics/GFS_surface_generic.f90'      : ['physics'],
     'ccpp-physics/physics/GFS_surface_loop_control.F90' : ['physics'],
     'ccpp-physics/physics/GFS_time_vary_pre.scm.f90'    : ['physics'],
-    'ccpp-physics/physics/GFS_zhao_carr_pre.f90'        : ['physics'],
     'ccpp-physics/physics/cnvc90.f'                     : ['physics'],
     'ccpp-physics/physics/dcyc2.f'                      : ['physics'],
     'ccpp-physics/physics/get_prs_fv3.f90'              : ['physics'],


### PR DESCRIPTION
Add GFS_suite_interstitial_3 and 4 to SDFs; remove GFS_zhao_carr_pre and GFS_gfdlmp_pre (code is now in GFS_suite_interstitial_3); remove unnecessary interstitial schemes from ccpp_prebuild scripts