### PR TITLE
Update CCPP prebuild scripts and configs (category/categories -> set/sets)

### DIFF
--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -94,7 +94,7 @@ SCHEME_FILES_DEPENDENCIES = [
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = {
-    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of categories in which scheme may be called ]
+    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of physics sets in which scheme may be called ]
     'ccpp/physics/physics/GFS_DCNV_generic.F90'              : [ 'slow_physics' ],
     'ccpp/physics/physics/GFS_MP_generic.F90'                : [ 'slow_physics' ],
     'ccpp/physics/physics/GFS_PBL_generic.F90'               : [ 'slow_physics' ],
@@ -225,8 +225,8 @@ OPTIONAL_ARGUMENTS = {
 
 # Names of Fortran include files in the host model cap (do not change);
 # both files will be written to the directory of each target file
-MODULE_INCLUDE_FILE = 'ccpp_modules_{category}.inc'
-FIELDS_INCLUDE_FILE = 'ccpp_fields_{category}.inc'
+MODULE_INCLUDE_FILE = 'ccpp_modules_{set}.inc'
+FIELDS_INCLUDE_FILE = 'ccpp_fields_{set}.inc'
 
 # HTML document containing the model-defined CCPP variables
 HTML_VARTABLE_FILE = 'ccpp/physics/CCPP_VARIABLES_FV3.html'

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -62,7 +62,7 @@ SCHEME_FILES_DEPENDENCIES = [
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = {
-    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of categories in which scheme may be called ]
+    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of physics sets in which scheme may be called ]
     'ccpp-physics/physics/GFS_DCNV_generic.F90'         : ['physics'],
     'ccpp-physics/physics/GFS_MP_generic.F90'           : ['physics'],
     'ccpp-physics/physics/GFS_PBL_generic.F90'          : ['physics'],
@@ -79,7 +79,6 @@ SCHEME_FILES = {
     'ccpp-physics/physics/cnvc90.f'                     : ['physics'],
     'ccpp-physics/physics/dcyc2.f'                      : ['physics'],
     'ccpp-physics/physics/get_prs_fv3.F90'              : ['physics'],
-    'ccpp-physics/physics/gfdl_cloud_microphys.F90'     : ['physics'],
     'ccpp-physics/physics/gscond.f'                     : ['physics'],
     'ccpp-physics/physics/gwdc.f'                       : ['physics'],
     'ccpp-physics/physics/gwdps.f'                      : ['physics'],

--- a/scripts/ccpp_prebuild_config_TEST.py
+++ b/scripts/ccpp_prebuild_config_TEST.py
@@ -20,7 +20,7 @@ SCHEME_FILES_DEPENDENCIES = [
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = {
-    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of categories in which scheme may be called ]
+    # Relative path to source (from where ccpp_prebuild.py is called) : [ list of physic sets in which scheme may be called ]
     '../../../../../schemes/check/check_test.f90' : [ 'test' ],
     }
 
@@ -57,8 +57,8 @@ OPTIONAL_ARGUMENTS = {
 
 # Names of Fortran include files in the host model cap (do not change);
 # both files will be written to the directory of each target file
-MODULE_INCLUDE_FILE = 'ccpp_modules_{category}.inc'
-FIELDS_INCLUDE_FILE = 'ccpp_fields_{category}.inc'
+MODULE_INCLUDE_FILE = 'ccpp_modules_{set}.inc'
+FIELDS_INCLUDE_FILE = 'ccpp_fields_{set}.inc'
 
 # HTML document containing the model-defined CCPP variables
 HTML_VARTABLE_FILE = 'CCPP_VARIABLES_FV3.html'

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -97,7 +97,7 @@ def merge_dictionaries(x, y):
                                     '    {0}\n'.format(x[key][0].print_debug()) +\
                                     'vs. {0}'.format(y[key][0].print_debug()))
                 z[key] = x[key] + y[key]
-            # Category dictionaries containing lists of categories of type string for each key=standard_name
+            # Physics set dictionaries containing lists of physics sets of type string for each key=standard_name
             elif type(x[key][0]) is str:
                 z[key] = list(set(x[key] + y[key]))
             else:

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -72,7 +72,7 @@ def metadata_to_html(metadata, model, filename):
     return success
 
 
-def metadata_to_latex(metadata_define, metadata_request, category_request, model, filename):
+def metadata_to_latex(metadata_define, metadata_request, pset_request, model, filename):
     """Create a LaTeX document with a table that lists  each variable provided
     and/or requested. Uses the GMTB LaTeX templates and style definitons in gmtb.sty."""
 
@@ -128,11 +128,11 @@ def metadata_to_latex(metadata_define, metadata_request, category_request, model
             requested = '\\newline '.join(sorted(requested_list))
         else:
             requested = 'NOT REQUESTED'
-        if var_name in category_request.keys():
-            category_list = [ escape_tex(c) for c in category_request[var_name] ]
-            category = '\\newline '.join(sorted(category_list))
+        if var_name in pset_request.keys():
+            pset_list = [ escape_tex(c) for c in pset_request[var_name] ]
+            pset = '\\newline '.join(sorted(pset_list))
         else:
-            category = ''
+            pset = ''
 
         # Create output
         text = '''
@@ -147,7 +147,7 @@ def metadata_to_latex(metadata_define, metadata_request, category_request, model
 \\execout{{source     }} & \\execout{{{target}             }} \\\\
 \\execout{{local\_name}} & \\execout{{{local_name}         }} \\\\
 \\execout{{requested  }} & \\execout{{\\vtop{{{requested}}}}} \\\\
-\\execout{{category   }} & \\execout{{\\vtop{{{category} }}}} \\\\
+\\execout{{physics set}} & \\execout{{\\vtop{{{set} }}}}      \\\\
 \\end{{tabular}}
 \\vspace{{4pt}}
 \\end{{samepage}}'''.format(standard_name=escape_tex(var.standard_name), standard_name_ref=var.standard_name,
@@ -159,7 +159,7 @@ def metadata_to_latex(metadata_define, metadata_request, category_request, model
                           target=target,
                           local_name=local_name,
                           requested=requested,
-                          category=category)
+                          set=pset)
         latex += text
     # Footer
     latex += '''


### PR DESCRIPTION
In the CCPP prebuild scripts, the word category was used thus far to allow splitting physics schemes between different parts of the model code (e.g. slow_physics, fast_physics). As @ligiabernardet said, this is confusing, because people think of categories such as "microphysics", "PBL" etc. first.

We agreed to rename category to set (categories to sets); however, set is a reserved word in Python and as such pset (= physics set) is used in the scripts, the "documentation" and log output uses "physics set".

The correct functioning of the prebuild scripts was tested with SCM and FV3. I ran test cases for both to make sure that the output is still bit for bit identical. I also tested that the auto-generated LaTeX and HTML output of variables provided/requested is still correct.

As announced earlier today, I will force merge this in to get our VLAB branch of FV3 out the door tomorrow.