### PR TITLE
NEMSfv3gfs - final cleanup of interstitial code

### DIFF
--- a/suites/suite_FV3_GFS_2017_updated.xml
+++ b/suites/suite_FV3_GFS_2017_updated.xml
@@ -23,9 +23,6 @@
       <scheme>rrtmg_lw</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
-      <!-- <scheme>memcheck</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
@@ -60,6 +57,7 @@
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
       <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
+++ b/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
@@ -29,9 +29,6 @@
       <scheme>rrtmg_lw</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
-      <!-- <scheme>memcheck</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
@@ -66,6 +63,7 @@
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
       <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_h2ophys.xml
+++ b/suites/suite_FV3_GFS_2017_updated_h2ophys.xml
@@ -23,9 +23,6 @@
       <scheme>rrtmg_lw</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
-      <!-- <scheme>memcheck</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
@@ -60,6 +57,7 @@
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
       <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>h2ophys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_memcheck.xml
+++ b/suites/suite_FV3_GFS_2017_updated_memcheck.xml
@@ -23,9 +23,6 @@
       <scheme>rrtmg_lw</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
-      <!-- <scheme>memcheck</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
@@ -60,6 +57,7 @@
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
       <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>
@@ -76,6 +74,7 @@
       <scheme>GFS_SCNV_generic_post</scheme>
       <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
       <scheme>zhaocarr_gscond</scheme>
       <scheme>zhaocarr_precpd</scheme>
       <scheme>GFS_MP_generic_post</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_wsm6.xml
+++ b/suites/suite_FV3_GFS_2017_updated_wsm6.xml
@@ -23,9 +23,6 @@
       <scheme>rrtmg_lw</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
-      <!-- <scheme>memcheck</scheme> -->
-      <!-- <scheme>GFS_diagtoscreen</scheme> -->
-      <!-- <scheme>GFS_interstitialtoscreen</scheme> -->
     </subcycle>
   </group>
   <group name="physics">
@@ -60,6 +57,7 @@
       <scheme>gwdps</scheme>
       <scheme>gwdps_post</scheme>
       <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>


### PR DESCRIPTION
This PR, together with those listed below, performs some final cleanup of the interstitial code in GFS_physics_driver.

For ccpp-framework: Update SDFs for FV3: add scheme GFS_stateout_update, remove comments; suite memcheck: add missing scheme MP_generic_pre

For details, see https://github.com/NCAR/FV3/pull/67