### PR TITLE
NEMSfv3gfs standalone CCPP runs

### DIFF
--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -134,6 +134,7 @@ SCHEME_FILES = {
     'ccpp/physics/physics/rrtmg_sw_post.F90'                 : [ 'slow_physics' ],
     'ccpp/physics/physics/rrtmg_sw_pre.F90'                  : [ 'slow_physics' ],
     'ccpp/physics/physics/sfc_diag.f'                        : [ 'slow_physics' ],
+    'ccpp/physics/physics/sfc_diag_post.F90'                 : [ 'slow_physics' ],
     'ccpp/physics/physics/sfc_diff.f'                        : [ 'slow_physics' ],
     'ccpp/physics/physics/sfc_drv.f'                         : [ 'slow_physics' ],
     'ccpp/physics/physics/sfc_nst.f'                         : [ 'slow_physics' ],

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -96,6 +96,7 @@ SCHEME_FILES = {
     'ccpp-physics/physics/rrtmg_sw_post.F90'            : ['physics'],
     'ccpp-physics/physics/rrtmg_sw_pre.F90'             : ['physics'],
     'ccpp-physics/physics/sfc_diag.f'                   : ['physics'],
+    'ccpp/physics/physics/sfc_diag_post.F90'            : ['physics'],
     'ccpp-physics/physics/sfc_diff.f'                   : ['physics'],
     'ccpp-physics/physics/sfc_drv.f'                    : ['physics'],
     'ccpp-physics/physics/sfc_nst.f'                    : ['physics'],

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -97,7 +97,7 @@ SCHEME_FILES = {
     'ccpp-physics/physics/rrtmg_sw_post.F90'            : ['physics'],
     'ccpp-physics/physics/rrtmg_sw_pre.F90'             : ['physics'],
     'ccpp-physics/physics/sfc_diag.f'                   : ['physics'],
-    'ccpp/physics/physics/sfc_diag_post.F90'            : ['physics'],
+    'ccpp-physics/physics/sfc_diag_post.F90'            : ['physics'],
     'ccpp-physics/physics/sfc_diff.f'                   : ['physics'],
     'ccpp-physics/physics/sfc_drv.f'                    : ['physics'],
     'ccpp-physics/physics/sfc_nst.f'                    : ['physics'],

--- a/src/ccpp_fcall.F90
+++ b/src/ccpp_fcall.F90
@@ -367,7 +367,12 @@ module ccpp_fcall
     !! @param[   out] ierr    Integer error flag
     !
     subroutine ccpp_run_scheme(scheme, cdata, stage, ierr)
-
+! DH* temporary, to be removed as soon as possible
+#ifdef TEMPLOG
+        use mpi
+        use omp_lib
+#endif
+! *DH
         type(ccpp_scheme_t),  intent(inout)          :: scheme
         type(ccpp_t), target, intent(inout)          :: cdata
         character(len=*),     intent(in),   optional :: stage
@@ -376,6 +381,11 @@ module ccpp_fcall
         character(:), allocatable      :: stage_local
         character(:), allocatable      :: function_name
         integer :: l
+! DH*
+#ifdef TEMPLOG
+        integer :: mpirank, ompthread, mierr
+#endif
+! *DH
 
         ierr = 0
 
@@ -385,6 +395,14 @@ module ccpp_fcall
             stage_local = trim(CCPP_DEFAULT_STAGE)
         end if
 
+! DH*
+#ifdef TEMPLOG
+        call MPI_COMM_RANK(MPI_COMM_WORLD, mpirank, mierr)
+        ompthread = OMP_GET_THREAD_NUM()
+        if (mpirank==0 .and. ompthread==0 .and. trim(stage_local) == trim(CCPP_DEFAULT_STAGE)) &
+                   write(0,*) 'CCPP DEBUG: calling ' // trim(scheme%name) // ' through option B'
+#endif
+! *DH
         call ccpp_debug('Called ccpp_run_scheme for ' // trim(scheme%name) &
                         //' in stage ' // trim(stage_local))
 

--- a/suites/suite_FV3_GFS_2017_updated.xml
+++ b/suites/suite_FV3_GFS_2017_updated.xml
@@ -33,6 +33,7 @@
       <scheme>GFS_suite_interstitial_1</scheme>
       <scheme>dcyc2t3</scheme>
       <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
@@ -49,6 +50,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
+++ b/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
@@ -39,6 +39,7 @@
       <scheme>GFS_suite_interstitial_1</scheme>
       <scheme>dcyc2t3</scheme>
       <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
@@ -55,6 +56,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_h2ophys.xml
+++ b/suites/suite_FV3_GFS_2017_updated_h2ophys.xml
@@ -33,6 +33,7 @@
       <scheme>GFS_suite_interstitial_1</scheme>
       <scheme>dcyc2t3</scheme>
       <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
@@ -49,6 +50,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_memcheck.xml
+++ b/suites/suite_FV3_GFS_2017_updated_memcheck.xml
@@ -33,6 +33,7 @@
       <scheme>GFS_suite_interstitial_1</scheme>
       <scheme>dcyc2t3</scheme>
       <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
@@ -49,6 +50,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>

--- a/suites/suite_FV3_GFS_2017_updated_wsm6.xml
+++ b/suites/suite_FV3_GFS_2017_updated_wsm6.xml
@@ -33,6 +33,7 @@
       <scheme>GFS_suite_interstitial_1</scheme>
       <scheme>dcyc2t3</scheme>
       <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
@@ -49,6 +50,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>

--- a/suites/suite_SCM_GFS_2017_updated.xml
+++ b/suites/suite_SCM_GFS_2017_updated.xml
@@ -49,6 +49,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>
@@ -77,7 +78,6 @@
       <scheme>zhaocarr_gscond</scheme>
       <scheme>zhaocarr_precpd</scheme>
       <scheme>GFS_MP_generic_post</scheme>
-      <!-- <scheme>sfc_diag</scheme> -->
       <scheme>lsm_noah_post</scheme>
       <scheme>sfc_sice_post</scheme>
     </subcycle>

--- a/suites/suite_SCM_GFS_2017_updated_prescribed_surface.xml
+++ b/suites/suite_SCM_GFS_2017_updated_prescribed_surface.xml
@@ -62,7 +62,6 @@
       <scheme>zhaocarr_gscond</scheme>
       <scheme>zhaocarr_precpd</scheme>
       <scheme>GFS_MP_generic_post</scheme>
-      <!-- <scheme>sfc_diag</scheme> -->
       <scheme>lsm_noah_post</scheme>
       <scheme>sfc_sice_post</scheme>
     </subcycle>

--- a/suites/suite_SCM_GFS_2018_updated.xml
+++ b/suites/suite_SCM_GFS_2018_updated.xml
@@ -49,6 +49,7 @@
     <subcycle loop="1">
       <scheme>dcyc2t3_post</scheme>
       <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
       <scheme>GFS_surface_generic_post</scheme>
       <scheme>GFS_PBL_generic_pre</scheme>
       <scheme>hedmf</scheme>
@@ -76,7 +77,6 @@
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>gfdl_cloud_microphys</scheme>
       <scheme>GFS_MP_generic_post</scheme>
-      <!-- <scheme>sfc_diag</scheme> -->
       <scheme>lsm_noah_post</scheme>
       <scheme>sfc_sice_post</scheme>
     </subcycle>

--- a/suites/suite_SCM_GFS_2018_updated_prescribed_surface.xml
+++ b/suites/suite_SCM_GFS_2018_updated_prescribed_surface.xml
@@ -61,7 +61,6 @@
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>gfdl_cloud_microphys</scheme>
       <scheme>GFS_MP_generic_post</scheme>
-      <!-- <scheme>sfc_diag</scheme> -->
       <scheme>lsm_noah_post</scheme>
       <scheme>sfc_sice_post</scheme>
     </subcycle>


### PR DESCRIPTION
This PR and others listed below enable the "standalone" version of NEMSfv3gfs-CCPP, that is bypassing the remaining GFS physics driver and using the suite definition file only. Results are bit for bit identical between CCPP reference (Theia/Intel 18 without CCPP), CCPP hybrid and CCPP standalone for the tests covered. Tests are also bit for bit identical for NEMSfv3gfs on MacOSX/GNU and for gmtb-scm on MacOSX/GNU.

Changes to ccpp-framework:

- add temporary logging capability to produce similar debugging output as for the CCPP hybrid code  (in GFS_physics_driver.F90) - only used if CCPP flag TEMPLOG is set
- add new scheme / source file sfc_diag_post.F90, clean up suite definition files