### PR TITLE
Simplify GFDL MP fast physics

### DIFF
--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -115,7 +115,7 @@ SCHEME_FILES = {
     'ccpp/physics/physics/get_prs_fv3.F90'                   : [ 'slow_physics' ],
     'ccpp/physics/physics/gfdl_cloud_microphys.F90'          : [ 'slow_physics' ],
     'ccpp/physics/physics/gfdl_fv_sat_adj.F90'               : [ 'fast_physics' ],
-    'ccpp/physics/physics/gfdl_fv_sat_adj_pre.F90'           : [ 'fast_physics' ],
+    #'ccpp/physics/physics/gfdl_fv_sat_adj_pre.F90'           : [ 'fast_physics' ],
     'ccpp/physics/physics/gscond.f'                          : [ 'slow_physics' ],
     'ccpp/physics/physics/gwdc.f'                            : [ 'slow_physics' ],
     'ccpp/physics/physics/gwdps.f'                           : [ 'slow_physics' ],

--- a/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
+++ b/suites/suite_FV3_GFS_2017_updated_gfdlmp.xml
@@ -4,7 +4,6 @@
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">
-      <scheme>fv_sat_adj_pre</scheme>
       <scheme>fv_sat_adj</scheme>
     </subcycle>
   </group>


### PR DESCRIPTION
This PR and https://github.com/NCAR/FV3/pull/79 simplify the CCPP implementation of the fast physics processes in FV3. Essentially, the need to call fv_sat_adj_pre is removed, which leaves fv_sat_adj as the only scheme to run in group fast_physics. The changes to FV3 (https://github.com/NCAR/FV3/pull/79) move the resetting of the arrays from fv_sat_adj_pre back to dynamics (where they also happen for the non-CCPP build). I decided to not remove the file fv_sat_adj_pre.F90 from ccpp-physics yet and just comment out the line in ccpp_prebuild_config_FV3.py for the time being to remind us that this is needed in case it is not done elsewhere.

Results are bit for bit identical on MacOSX+GNU, the usual Theia/Intel tests are running. Regression test logs will be added once they finished. Feel free to review and approve pending bit-for-bit identical results.