### PR TITLE
Static build: no cdata to store and retrieve variables

### DIFF
--- a/schemes/check/ccpp_prebuild_config.py
+++ b/schemes/check/ccpp_prebuild_config.py
@@ -43,7 +43,7 @@ CAPS_MAKEFILE = '/dev/null'
 CAPS_CMAKEFILE = '/dev/null'
 
 # Directory where to put all auto-generated physics caps
-CAPS_DIR = '.' # DH*
+CAPS_DIR = '.'
 
 # Optional arguments - only required for schemes that use
 # optional arguments. ccpp_prebuild.py will throw an exception
@@ -64,6 +64,9 @@ OPTIONAL_ARGUMENTS = {
 MODULE_INCLUDE_FILE = 'ccpp_modules_{set}.inc'
 FIELDS_INCLUDE_FILE = 'ccpp_fields_{set}.inc'
 
+# Directory where to write static API to
+STATIC_API_DIR = '.'
+
 # HTML document containing the model-defined CCPP variables
 HTML_VARTABLE_FILE = 'CCPP_VARIABLES_FV3.html'
 
@@ -81,16 +84,3 @@ LATEX_VARTABLE_FILE = 'CCPP_VARIABLES_FV3.tex'
 # OpenMP threads as the second dimension; nb is the loop
 # index for the current block, nt for the current thread
 CCPP_DATA_STRUCTURE = 'cdata'
-
-# Modules to load for auto-generated ccpp_field_add code
-# in the host model cap (e.g. error handling)
-MODULE_USE_TEMPLATE_HOST_CAP = \
-'''
-use ccpp_api, only: ccpp_error
-'''
-
-# Modules to load for auto-generated ccpp_field_get code
-# in the physics scheme cap (e.g. derived data types)
-MODULE_USE_TEMPLATE_SCHEME_CAP = \
-'''
-'''

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -7,11 +7,16 @@ CCPP_ERROR_FLAG_VARIABLE = 'ccpp_error_flag'
 CCPP_ERROR_MSG_VARIABLE  = 'ccpp_error_message'
 CCPP_LOOP_COUNTER        = 'ccpp_loop_counter'
 
+CCPP_TYPE = 'ccpp_t'
+
 CCPP_INTERNAL_VARIABLES = {
     CCPP_ERROR_FLAG_VARIABLE : 'cdata%errflg',
     CCPP_ERROR_MSG_VARIABLE  : 'cdata%errmsg',
     CCPP_LOOP_COUNTER        : 'cdata%loop_cnt',
     }
+
+STANDARD_VARIABLE_TYPES = [ 'character', 'integer', 'logical', 'real' ]
+STANDARD_CHARACTER_TYPE = 'character'
 
 def execute(cmd, abort = True):
     """Runs a local command in a shell. Waits for completion and

--- a/src/ccpp_types.F90
+++ b/src/ccpp_types.F90
@@ -19,15 +19,11 @@
 !
 module ccpp_types
 
-#if 0
 !! \section arg_table_ccpp_types
 !! | local_name                        | standard_name             | long_name                                             | units   | rank | type      |   kind   | intent | optional |
 !! |-----------------------------------|-------------------------- |-------------------------------------------------------|---------|------|-----------|----------|--------|----------|
-!! | cdata%errflg                      | ccpp_error_flag           | error flag for error handling in CCPP                 | flag    |    0 | integer   |          | none   | F        |
-!! | cdata%errmsg                      | ccpp_error_message        | error message for error handling in CCPP              | none    |    0 | character | len=512  | none   | F        |
-!! | cdata%loop_cnt                    | ccpp_loop_counter         | loop counter for subcycling loops in CCPP             | index   |    0 | integer   |          | none   | F        |
+!! | ccpp_t                            | ccpp_t                    | definition of type ccpp_t                             | DDT     |    0 | ccpp_t    |          | none   | F        |
 !!
-#endif
 
     use, intrinsic :: iso_c_binding,                                   &
                       only: c_ptr, c_funptr
@@ -64,6 +60,9 @@ module ccpp_types
 
     !> @var The default loop counter indicating outside of a subcycle loop
     integer, parameter :: CCPP_DEFAULT_LOOP_CNT = -999
+
+    !> @var The default values for block and thread numbers indicating invalid data
+    integer, parameter :: CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER = -999
 
     !>
     !! @brief CCPP field type
@@ -150,6 +149,17 @@ module ccpp_types
             type(ccpp_group_t), allocatable, dimension(:)       :: groups
     end type ccpp_suite_t
 
+#if 0
+!! \section arg_table_ccpp_t
+!! | local_name                        | standard_name             | long_name                                             | units   | rank | type      |   kind   | intent | optional |
+!! |-----------------------------------|-------------------------- |-------------------------------------------------------|---------|------|-----------|----------|--------|----------|
+!! | cdata%errflg                      | ccpp_error_flag           | error flag for error handling in CCPP                 | flag    |    0 | integer   |          | none   | F        |
+!! | cdata%errmsg                      | ccpp_error_message        | error message for error handling in CCPP              | none    |    0 | character | len=512  | none   | F        |
+!! | cdata%loop_cnt                    | ccpp_loop_counter         | loop counter for subcycling loops in CCPP             | index   |    0 | integer   |          | none   | F        |
+!! | cdata%blk_no                      | ccpp_block_number         | number of block for explicit data blocking in CCPP    | index   |    0 | integer   |          | none   | F        |
+!! | cdata%thrd_no                     | ccpp_thread_number        | number of thread for threading in CCPP                | index   |    0 | integer   |          | none   | F        |
+!!
+#endif
     !>
     !! @brief CCPP physics type.
     !!
@@ -170,6 +180,8 @@ module ccpp_types
             integer                                             :: errflg = 0
             character(len=512)                                  :: errmsg = ''
             integer                                             :: loop_cnt = CCPP_DEFAULT_LOOP_CNT
+            integer                                             :: blk_no = CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER
+            integer                                             :: thrd_no = CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER
     end type ccpp_t
 
 contains


### PR DESCRIPTION
This PR and associated PRs remove the need to store host model variables in the cdata structure and retrieve them in the physics for the static build only.

For this to work, and in the absence of a central host model registry in FV3, the following major changes are required:

- the auto-generated ccpp_static_api.F90 is no longer written to ccpp/physics/physics and compiled into the static CCPP physics library, but instead to FV3/gfsphysics/CCPP_layer and compiled with the host model
- the host model variables are imported in the ccpp_static_api module instead of being passed in via the argument list - this allows to maintain the same API for the static and dynamic builds
- in order to retrieve the correct block and thread number inside physics, these are now attributes of cdata (of type ccpp_t), similar to the loop counter, error message and error flag
- by passing the correct cdata (either a scalar or a single member of an array) to the CCPP API (static or dynamic), the system has all required information for all build types
- store the GFS data types required in FV3/gfsphysics/CCPP_data.F90, import them as IPD data types in atmos_model.F90
- do not use variable Atm (of fv_atmos_type) directly for the CCPP fast physics, but instead add the required variables to CCPP_interstitial (in dynamics) - for the sake of performance and memory footprint, use pointers from CCPP_interstitial to Atm; using fv_atmos_type in CCPP seems to be the reason for the GNU compiler crashes in the current gmtb/develop version

Further, these PRs remove several of the hard-coded module use statements, previously defined in ccpp_prebuild_config.py, which required
- defining how kind types and derived data types are declared in the metadata: kind definitions require local_name, standard_name and kind attributes to match; similarly, type definitions require local_name, standard_name and type attributes to match
- cleaning up the inconsistent definition of the FV3 GFS DDTs in the metadata tables so that type definitions and definitions of instances of a DDT are kept separate

These PRs are also one step towards removing the IPD legacy. Once the hybrid build is removed, the remaining call to IPD_initialize can be substituted by a direct call of GFS_initialize (or some other method, to be discussed) and IPD_Control etc can be renamed into GFS_Control etc.
