### PR TITLE
Metadata conversion and parser

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+### Summary of Issue:
+### Expected behavior and actual behavior:
+### Steps to reproduce the problem (should include model description file(s) or link to publi c repository):
+### What is the changeset ID of the code, and the machine you are using:
+### have you modified the code? If so, it must be committed and available for testing:
+### Screen output or log file showing the error message and context:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+[ 50 character, one line summary ]
+
+[ Description of the changes in this commit. It should be enough
+  information for someone not following this development to understand. 
+  Lines should be wrapped at about 72 characters. ]
+
+User interface changes?: [ No/Yes ]
+[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]
+
+Fixes: [Github issue #s] And brief description of each issue.
+
+Testing:
+  test removed:
+  unit tests:
+  system tests:
+  manual testing:
+

--- a/doc/standard_names.xml
+++ b/doc/standard_names.xml
@@ -1,0 +1,271 @@
+<standard_names name="CCPP Standard Name Library" version="1.0">
+  <section name="dimensions"
+           comment="Note that the cap generator can substitute x_begin:x_end for x_extent">
+    <standard_name name="horizontal_dimension"
+                   long_name="Size horizontal dimension">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="horizontal_loop_extent"
+                   long_name="Number of items in horizontal dimension to use">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="horizontal_loop_begin"
+                   long_name="Beginning index of horizontal dimension to use">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="horizontal_loop_end"
+                   long_name="Ending index of horizontal dimension to use">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="thread_block_number"
+                   long_name="Number of current thread block">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="thread_block_begin"
+                   long_name="Beginning index of all thread blocks">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="thread_block_end"
+                   long_name="Ending index of all thread blocks">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="vertical_layer_dimension"
+                   long_name="number of vertical levels">
+      <type units="none">integer</type>
+    </standard_name>
+    <standard_name name="vertical_level_dimension"
+                   long_name="number of vertical interfaces">
+      <type units="none">integer</type>
+    </standard_name>
+  </section>
+  <section name="constants">
+    <standard_name name="gas_constant_dry_air">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
+                   long_name="latent heat of vaporization of water at 0C">
+      <type kind="kind_phys" units="J kg-1">real</type>
+    </standard_name>
+    <standard_name name="density_of_liquid_water_at_0c"
+                   long_name="density of liquid water at 0C">
+      <type kind="kind_phys" units="kg m-3">real</type>
+    </standard_name>
+  </section>
+  <section name="coordinates">
+    <standard_name name="latitude">
+      <type kind="kind_phys" units="radians">real</type>
+    </standard_name>
+    <standard_name name="longitude">
+      <type kind="kind_phys" units="radians">real</type>
+    </standard_name>
+  </section>
+  <section name="state_variables">
+    <standard_name name="surface_air_pressure">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="dry_surface_pressure">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="surface_geopotential">
+      <type kind="kind_phys" units="m2 s-2">real</type>
+    </standard_name>
+    <standard_name name="temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
+    <standard_name name="eastward_wind"
+                   long_name="Zonal wind">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="northward_wind"
+                   long_name="Meridional wind">
+      <type kind="kind_phys" units="m s-1">real</type>
+    </standard_name>
+    <standard_name name="dry_static_energy_content_of_atmosphere_layer"
+                   long_name="Dry static energy">
+      <type kind="kind_phys" units="J m-2">real</type>
+    </standard_name>
+    <standard_name name="lagrangian_tendency_of_air_pressure"
+                   long_name="Vertical pressure velocity">
+      <type kind="kind_phys" units="Pa s-1">real</type>
+    </standard_name>
+    <standard_name name="air_pressure"
+                   long_name="Midpoint air pressure">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="air_pressure_of_dry_air"
+                   long_name="Dry midpoint pressure">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="pressure_thickness">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="pressure_thickness_of_dry_air">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="reciprocal_of_pressure_thickness">
+      <type kind="kind_phys" units="Pa-1">real</type>
+    </standard_name>
+    <standard_name name="reciprocal_of_pressure_thickness_of_dry_air">
+      <type kind="kind_phys" units="Pa-1">real</type>
+    </standard_name>
+    <standard_name name="natural_log_of_air_pressure">
+      <type kind="kind_phys" units="pmid">real</type>
+    </standard_name>
+    <standard_name name="log_of_air_pressure_of_dry_air">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="inverse_exner_function_wrt_surface_pressure"
+                   long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
+    <standard_name name="geopotential_height_above_surface_at_midpoints">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
+    <standard_name name="constituent_mixing_ratio">
+      <type kind="kind_phys" units="kg/kg moist or dry air depending on type">real</type>
+    </standard_name>
+    <standard_name name="air_pressure_at_interface">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="interface_pressure_dry">
+      <type kind="kind_phys" units="Pa">real</type>
+    </standard_name>
+    <standard_name name="ln_air_pressure_at_interface">
+      <type kind="kind_phys" units="ln(Pa)">real</type>
+    </standard_name>
+    <standard_name name="ln_interface_pressure_dry">
+      <type kind="kind_phys" units="ln(Pa)">real</type>
+    </standard_name>
+    <standard_name name="geopotential_height_above_surface_at_interfaces">
+      <type kind="kind_phys" units="m">real</type>
+    </standard_name>
+    <standard_name name="vertically_integrated_total_kinetic_and_static_energy_of_initial_state">
+      <type kind="kind_phys" units="J m-2">real</type>
+    </standard_name>
+    <standard_name name="vertically_integrated_total_kinetic_and_static_energy_of_current_state">
+      <type kind="kind_phys" units="J m-2">real</type>
+    </standard_name>
+    <standard_name name="vertically_integrated_total_water_of_initial_state">
+      <type kind="kind_phys" units="Pa s2 m-1">real</type>
+    </standard_name>
+    <standard_name name="vertically_integrated_total_water_of_new_state">
+      <type kind="kind_phys" units="Pa s2 m-1">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_temperature"
+                   long_name="Change in temperature from a parameterization">
+      <type kind="kind_phys" units="K s-1">real</type>
+    </standard_name>
+    <standard_name name="total_tendency_of_temperature"
+                   long_name="Total change in temperature from a
+                              physics suite">
+      <type kind="kind_phys" units="K s-1">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_potential_temperature"
+                   long_name="Change in potential temperature from a parameterization">
+      <type kind="kind_phys" units="K s-1">real</type>
+    </standard_name>
+    <standard_name name="total_tendency_of_potential_temperature">
+      <type kind="kind_phys" units="K s-1">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_eastward_wind"
+                   long_name="Change in zonal wind from a parameterization">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="total_tendency_of_eastward_wind">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="tendency_of_northward_wind"
+                   long_name="Change in meridional from a parameterization">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="total_tendency_of_northward_wind">
+      <type kind="kind_phys" units="m s-2">real</type>
+    </standard_name>
+    <standard_name name="surface_energy_flux">
+      <type kind="kind_phys" units="W m-2">real</type>
+    </standard_name>
+    <standard_name name="cumulative_boundary_flux_of_total_energy">
+      <type kind="kind_phys" units="W m-2">real</type>
+    </standard_name>
+    <standard_name name="cumulative_boundary_flux_of_total_water">
+      <type kind="kind_phys" units="W m-2">real</type>
+    </standard_name>
+    <standard_name name="reference_pressure_at_sea_level"
+                   long_name="reference pressure at sea level">
+      <type kind="kind_phys" units="mb">real</type>
+    </standard_name>
+    <standard_name name="exner_function"
+                   long_name="exner function">
+      <type kind="kind_phys" units="none">real</type>
+    </standard_name>
+    <standard_name name="potential_temperature"
+                   long_name="potential temperature">
+      <type kind="kind_phys" units="K">real</type>
+    </standard_name>
+  </section>
+  <section name="constituents">
+    <standard_name name="water_vapor_specific_humidity">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="cloud_liquid_water_mixing_ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="rain_water_mixing_ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_ch4"
+                   long_name="CH4 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_co"
+                   long_name="CO volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_co2"
+                   long_name="CO2 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_ccl4"
+                   long_name="CCL4 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_cfc11"
+                   long_name="CFC11 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_cfc12"
+                   long_name="CFC12 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_cfc113"
+                   long_name="CFC113 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_cfc22"
+                   long_name="CFC22 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_o2"
+                   long_name="O2 volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="volume_mixing_ratio_n2o"
+                   long_name="N2O volume mixing ratio">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+  </section>
+  <section name="standard_variables"
+           comment="Standard / required CCPP variables">
+    <standard_name name="ccpp_error_message"
+                   long_name="Error message for error handling in CCPP">
+      <type kind="len=512" units="1">character</type>
+    </standard_name>
+    <standard_name name="ccpp_error_flag"
+                   long_name="Error flag for error handling in CCPP">
+      <type kind="" units="1">integer</type>
+    </standard_name>
+  </section>
+</standard_names>

--- a/doc/write_standard_name_table.py
+++ b/doc/write_standard_name_table.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+"""
+Convert a metadata standard-name XML library file to a documentation format.
+"""
+
+# Python library imports
+import xml.etree.ElementTree as ET
+import os.path
+import argparse
+import sys
+if __name__ == '__main__' and __package__ is None:
+    cpfroot = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(os.path.join(cpfroot, 'scripts'))
+else:
+    cpfroot = None
+# End if
+# CCPP framework imports
+from parse_tools import validate_xml_file, read_xml_file
+try:
+    from metavar import standard_name_to_long_name
+    have_metavar = True
+except Exception as e:
+    have_metavar = False
+# End try
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument("standard_name_file",
+                        metavar='<standard names filename>',
+                        type=str, help="XML file with standard name library")
+    parser.add_argument("--output-filename", metavar='<output filename>',
+                        type=str, default='Metadata-standard-names',
+                        help="Name of output file (without extension)")
+    parser.add_argument("--output-format", metavar='md', type=str, default='md',
+                        help="Format of output file")
+    pargs = parser.parse_args(args)
+    return pargs
+
+###############################################################################
+def convert_xml_to_markdown(root, library_name, snl):
+###############################################################################
+    snl.write('# {}\n'.format(library_name))
+    # Write a table of contents
+    snl.write('#### Table of Contents\n')
+    for section in root:
+        sec_name = section.get('name')
+        snl.write("* [{name}](#{name})\n".format(name=sec_name))
+    # End for
+    snl.write('\n')
+    for section in root:
+        # Step through the sections
+        sec_name = section.get('name')
+        sec_comment = section.get('comment')
+        snl.write('## {}\n'.format(sec_name))
+        if sec_comment is not None:
+            snl.write('{}\n'.format(sec_comment))
+        # End if
+        for std_name in section:
+            stdn_name = std_name.get('name')
+            stdn_longname = std_name.get('long_name')
+            if have_metavar and (stdn_longname is None):
+                stdn_longname = standard_name_to_long_name({'standard_name':stdn_name})
+            # End if
+            snl.write("* `{}`: {}\n".format(stdn_name, stdn_longname))
+            # Should only be a type in the standard_name text
+            for item in std_name:
+                if item.tag == 'type':
+                    t = item.text
+                    kind = item.get('kind')
+                    if kind is None:
+                        kstr = ''
+                    else:
+                        kstr = "(kind={})".format(kind)
+                    # End if
+                    units = item.get('units')
+                    snl.write('    * `{}{}`: units = {}\n'.format(t, kstr, units))
+                else:
+                    raise ValueError("Unknown standard name property, '{}'".format(item.tag))
+                # End if
+            # End for
+        # End for
+    # End for
+
+###############################################################################
+def main_func():
+###############################################################################
+    args = parse_command_line(sys.argv[1:], __doc__)
+    tree, root = read_xml_file(args.standard_name_file)
+    library_name = root.get('name')
+    if args.output_format != 'md':
+        raise ValueError("Unsupported output format, '{}'".format(args.output_format))
+    # End if
+    with open("{}.{}".format(args.output_filename, args.output_format), "w") as snl:
+        convert_xml_to_markdown(root, library_name, snl)
+
+
+###############################################################################
+if __name__ == "__main__":
+    main_func()

--- a/logging/logging.F90
+++ b/logging/logging.F90
@@ -1,0 +1,406 @@
+module marbl_logging
+
+! ============
+! Module Usage
+! ============
+!
+! Assume a variable named StatusLog (as appears in the marbl_interface_class)
+!
+! -----------------------------------------------
+! Use the following routines to write log entries
+! -----------------------------------------------
+!
+! (1) StatusLog%log_noerror -- this stores a log message in StatusLog that does
+!     not contain a fatal error
+! (2) StatusLog%log_header -- this stores a log message in StatusLog that is
+!     meant to be read as a section header; e.g. StatusLog%log_header('HEADER',...)
+!     writes the following (including blank lines)
+!
+!     ------
+!     HEADER
+!     ------
+!
+! (3) StatusLog%log_error -- this stores a log message in StatusLog that DOES
+!     contain a fatal error. It does this by setting StatusLog%labort_marbl =
+!     .true.; when a call from the GCM to MARBL returns, it is important for the
+!     GCM to check the value of StatusLog%labort_marbl and abort the run if an
+!     error has been reported.
+! (4) StatusLog%log_error_trace -- this stores a log message in StatusLog
+!     detailing what subroutine was just called and where it was called from. It
+!     is meant to provide more information when trying to trace the path through
+!     the code that resulted in an error.
+!
+! -----------------------------------------------
+! Pseudo-code for writing StatusLog in the driver
+! -----------------------------------------------
+!
+!  type(marbl_status_log_entry_type), pointer :: LogEntry
+!
+!  ! Set pointer to first entry of the log
+!  LogEntry => StatusLog%FullLog
+!
+!  do while (associated(LogEntry))
+!    ! If running in parallel, you may want to check if you are the master
+!    ! task or if LogEntry%lalltasks = .true.
+!    write(stdout,*) trim(LogEntry%LogMessage)
+!    LogEntry => LogEntry%next
+!  end do
+!
+!  ! Erase contents of log now that they have been written out
+!  call StatusLog%erase()
+!
+!  if (StatusLog%labort_marbl) then
+!    [GCM abort call: "error found in MARBL"]
+!  end if
+!
+
+  use marbl_kinds_mod, only : char_len
+
+  implicit none
+  private
+  save
+
+  integer, parameter, private :: marbl_log_len = 2*char_len
+
+  !****************************************************************************
+
+  type, public :: marbl_status_log_entry_type
+    integer :: ElementInd = -1      ! ElementInd < 0 implies no location data
+    logical :: lonly_master_writes  ! True => message should be written to stdout
+                           !                  master task; False => all tasks
+    character(len=marbl_log_len) :: LogMessage   ! Message text
+    character(len=char_len)      :: CodeLocation ! Information on where log was written
+
+    type(marbl_status_log_entry_type), pointer :: next
+  end type marbl_status_log_entry_type
+
+  !****************************************************************************
+
+  ! Note: this data type is not in use at the moment, but it is included as an
+  !       initial step towards allowing the user some control over what types
+  !       of messages are added to the log. For example, if you do not want
+  !       the contents of namelists written to the log, you would simply set
+  !
+  !       lLogNamelist = .false.
+  !
+  !       In the future we hope to be able to set these options via namelist,
+  !       but for now lLogNamelist, lLogGeneral, lLogWarning, and lLogError are
+  !       all set to .true. and can not be changed without modifying the source
+  !       code in this file.
+  type, private :: marbl_log_output_options_type
+    logical :: labort_on_warning ! True => elevate Warnings to Errors
+    logical :: lLogVerbose       ! Debugging output should be given Verbose label
+    logical :: lLogNamelist      ! Write namelists to log?
+    logical :: lLogGeneral       ! General diagnostic output
+    logical :: lLogWarning       ! Warnings (can be elevated to errors via labort_on_warning)
+    logical :: lLogError         ! Errors (will toggle labort_marbl whether log
+                                 ! is written or not)
+  contains
+    procedure :: construct => marbl_output_options_constructor
+  end type marbl_log_output_options_type
+
+  !****************************************************************************
+
+  type, public :: marbl_log_type
+    logical, private :: lconstructed = .false. ! True => constructor was already called
+    logical, public  :: labort_marbl = .false. ! True => driver should abort GCM
+    logical, public  :: lwarning     = .false. ! True => warnings are present
+    type(marbl_log_output_options_type) :: OutputOptions
+    type(marbl_status_log_entry_type), pointer :: FullLog
+    type(marbl_status_log_entry_type), pointer :: LastEntry
+  contains
+    procedure, public :: construct => marbl_log_constructor
+    procedure, public :: log_header   => marbl_log_header
+    procedure, public :: log_error    => marbl_log_error
+    procedure, public :: log_warning  => marbl_log_warning
+    procedure, public :: log_noerror  => marbl_log_noerror
+    procedure, public :: log_error_trace => marbl_log_error_trace
+    procedure, public :: log_warning_trace => marbl_log_warning_trace
+    procedure, public :: erase => marbl_log_erase
+    procedure, private :: append_to_log
+  end type marbl_log_type
+
+  !****************************************************************************
+
+contains
+
+  !****************************************************************************
+
+  subroutine marbl_output_options_constructor(this, labort_on_warning, LogVerbose, LogNamelist, &
+                                              LogGeneral, LogWarning, LogError)
+
+    class(marbl_log_output_options_type), intent(inout) :: this
+    logical, intent(in), optional :: labort_on_warning, LogVerbose, LogNamelist
+    logical, intent(in), optional :: LogGeneral, LogWarning, LogError
+
+    if (present(labort_on_warning)) then
+      this%labort_on_warning = labort_on_warning
+    else
+      this%labort_on_warning = .false.
+    end if
+
+    if (present(LogVerbose)) then
+      this%lLogVerbose = LogVerbose
+    else
+      this%lLogVerbose = .false.
+    end if
+
+    if (present(LogNamelist)) then
+      this%lLogNamelist = LogNamelist
+    else
+      this%lLogNamelist = .true.
+    end if
+
+    if (present(LogGeneral)) then
+      this%lLogGeneral = LogGeneral
+    else
+      this%lLogGeneral = .true.
+    end if
+
+    if (present(LogWarning)) then
+      this%lLogWarning = LogWarning
+    else
+      this%lLogWarning = .true.
+    end if
+
+    if (present(LogError)) then
+      this%lLogError = LogError
+    else
+      this%lLogError = .true.
+    end if
+
+  end subroutine marbl_output_options_constructor
+
+  !****************************************************************************
+
+  subroutine marbl_log_constructor(this)
+
+    class(marbl_log_type), intent(inout) :: this
+
+    if (this%lconstructed) return
+    this%lconstructed = .true.
+    nullify(this%FullLog)
+    nullify(this%LastEntry)
+    call this%OutputOptions%construct()
+
+  end subroutine marbl_log_constructor
+
+  !****************************************************************************
+
+  subroutine marbl_log_header(this, HeaderMsg, CodeLoc)
+
+    class(marbl_log_type), intent(inout) :: this
+    ! StatusMsg is the message to be printed in the log; it does not need to
+    !    contain the name of the module or subroutine producing the log message
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_noerror
+    character(len=*),      intent(in)    :: HeaderMsg, CodeLoc
+
+    character(len=len_trim(HeaderMsg)) :: dashes
+    integer :: n
+
+    do n=1, len(dashes)
+      dashes(n:n) = '-'
+    end do
+    call this%log_noerror('', CodeLoc)
+    call this%log_noerror(dashes, CodeLoc)
+    call this%log_noerror(HeaderMsg, CodeLoc)
+    call this%log_noerror(dashes, CodeLoc)
+    call this%log_noerror('', CodeLoc)
+
+  end subroutine marbl_log_header
+
+  !****************************************************************************
+
+  subroutine marbl_log_error(this, ErrorMsg, CodeLoc, ElemInd)
+
+    class(marbl_log_type), intent(inout) :: this
+    ! ErrorMsg is the error message to be printed in the log; it does not need
+    !     to contain the name of the module or subroutine triggering the error
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_error
+    character(len=*),      intent(in)    :: ErrorMsg, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+
+    character(len=marbl_log_len) :: ErrorMsg_loc   ! Message text
+
+    this%labort_marbl = .true.
+
+    ! Only allocate memory and add entry if we want to log full namelist!
+    if (.not.this%OutputOptions%lLogError) then
+      return
+    end if
+
+    write(ErrorMsg_loc, "(4A)") "MARBL ERROR (", trim(CodeLoc), "): ", &
+                                        trim(ErrorMsg)
+
+    call this%append_to_log(ErrorMsg_loc, CodeLoc, ElemInd, lonly_master_writes=.false.)
+
+  end subroutine marbl_log_error
+
+  !****************************************************************************
+
+  subroutine marbl_log_warning(this, WarningMsg, CodeLoc, ElemInd)
+
+    class(marbl_log_type), intent(inout) :: this
+    ! WarningMsg is the message to be printed in the log; it does not need to
+    !    contain the name of the module or subroutine producing the log message
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_warning
+    character(len=*),      intent(in)    :: WarningMsg, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+
+    character(len=marbl_log_len) :: WarningMsg_loc   ! Message text
+
+    this%lwarning = .true.
+
+    ! Only allocate memory and add entry if we want to log full namelist!
+    if (.not.this%OutputOptions%lLogWarning) then
+      return
+    end if
+
+    write(WarningMsg_loc, "(4A)") "MARBL WARNING (", trim(CodeLoc), "): ", &
+                                        trim(WarningMsg)
+
+    call this%append_to_log(WarningMsg_loc, CodeLoc, ElemInd, lonly_master_writes=.false.)
+
+  end subroutine marbl_log_warning
+
+  !****************************************************************************
+
+  subroutine marbl_log_noerror(this, StatusMsg, CodeLoc, ElemInd, lonly_master_writes)
+
+    class(marbl_log_type), intent(inout) :: this
+    ! StatusMsg is the message to be printed in the log; it does not need to
+    !    contain the name of the module or subroutine producing the log message
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_noerror
+    character(len=*),      intent(in)    :: StatusMsg, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+    ! If lonly_master_writes is .false., then this is a message that should be
+    ! printed out regardless of which task produced it. By default, MARBL assumes
+    ! that only the master task needs to print a message
+    logical, optional,     intent(in)    :: lonly_master_writes
+
+    ! Only allocate memory and add entry if we want to log full namelist!
+    if (.not.this%OutputOptions%lLogGeneral) then
+      return
+    end if
+
+    call this%append_to_log(StatusMsg, CodeLoc, ElemInd, lonly_master_writes)
+
+  end subroutine marbl_log_noerror
+
+  !****************************************************************************
+
+  subroutine append_to_log(this, StatusMsg, CodeLoc, ElemInd, lonly_master_writes)
+
+    class(marbl_log_type), intent(inout) :: this
+    ! StatusMsg is the message to be printed in the log; it does not need to
+    !    contain the name of the module or subroutine producing the log message
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_noerror
+    character(len=*),      intent(in)    :: StatusMsg, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+    ! If lonly_master_writes is .false., then this is a message that should be
+    ! printed out regardless of which task produced it. By default, MARBL assumes
+    ! that only the master task needs to print a message
+    logical, optional,     intent(in)    :: lonly_master_writes
+    type(marbl_status_log_entry_type), pointer :: new_entry
+
+    allocate(new_entry)
+    nullify(new_entry%next)
+    if (present(ElemInd)) then
+      new_entry%ElementInd = ElemInd
+    else
+      new_entry%ElementInd = -1
+    end if
+    new_entry%LogMessage   = trim(StatusMsg)
+    new_entry%CodeLocation = trim(CodeLoc)
+    if (present(lonly_master_writes)) then
+      new_entry%lonly_master_writes = lonly_master_writes
+    else
+      new_entry%lonly_master_writes = .true.
+    end if
+
+    if (associated(this%FullLog)) then
+      ! Append new entry to last entry in the log
+      this%LastEntry%next => new_entry
+    else
+      this%FullLog => new_entry
+    end if
+    ! Update LastEntry attribute of linked list
+    this%LastEntry => new_entry
+
+  end subroutine append_to_log
+
+  !****************************************************************************
+
+  subroutine marbl_log_error_trace(this, RoutineName, CodeLoc, ElemInd)
+
+  ! This routine should only be called if another subroutine has returned and
+  ! StatusLog%labort_marbl = .true.
+
+    class(marbl_log_type), intent(inout) :: this
+    ! RoutineName is the name of the subroutine that returned with
+    !             labort_marbl = .true.
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_error_trace
+    !
+    ! Log will contain a message along the lines of
+    !
+    ! "(CodeLoc) Error reported from RoutineName"
+    !
+    ! When the log is printed, this will provide a traceback through the sequence
+    ! of calls that led to the original error message.
+    character(len=*),      intent(in)    :: RoutineName, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+    character(len=char_len) :: log_message
+
+    write(log_message, "(2A)") "Error reported from ", trim(RoutineName)
+    call this%log_error(log_message, CodeLoc, ElemInd)
+
+  end subroutine marbl_log_error_trace
+
+  !****************************************************************************
+
+  subroutine marbl_log_warning_trace(this, RoutineName, CodeLoc, ElemInd)
+
+  ! This routine should only be called if another subroutine has returned and
+  ! StatusLog%lwarning = .true.
+
+    class(marbl_log_type), intent(inout) :: this
+    ! RoutineName is the name of the subroutine that returned with
+    !             lwarning = .true.
+    ! CodeLoc is the name of the subroutine that is calling StatusLog%log_warning_trace
+    !
+    ! Log will contain a message along the lines of
+    !
+    ! "(CodeLoc) Warning reported from RoutineName"
+    !
+    ! When the log is printed, this will provide a traceback through the sequence
+    ! of calls that led to the original warning message.
+    character(len=*),      intent(in)    :: RoutineName, CodeLoc
+    integer, optional,     intent(in)    :: ElemInd
+    character(len=char_len) :: log_message
+
+    write(log_message, "(2A)") "Warning reported from ", trim(RoutineName)
+    call this%log_warning(log_message, CodeLoc, ElemInd)
+    this%lwarning = .false.
+
+  end subroutine marbl_log_warning_trace
+
+  !****************************************************************************
+
+  subroutine marbl_log_erase(this)
+
+    class(marbl_log_type), intent(inout) :: this
+    type(marbl_status_log_entry_type), pointer :: tmp
+
+    do while (associated(this%FullLog))
+      tmp => this%FullLog%next
+      deallocate(this%FullLog)
+      this%FullLog => tmp
+    end do
+    nullify(this%FullLog)
+    nullify(this%LastEntry)
+
+    this%lwarning = .false.
+
+  end subroutine marbl_log_erase
+
+end module marbl_logging

--- a/schema/host_registry_v1_0.xsd
+++ b/schema/host_registry_v1_0.xsd
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+
+<xs:schema elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- identifier types -->
+
+  <xs:simpleType name="standard_name_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9_]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="fortran_id_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]{0,63}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="type_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[iI][nN][tT][eE][gG][eE][rR]"/>
+      <xs:pattern value="[rR][eE][aA][lL]"/>
+      <xs:pattern value="[lL][oO][gG][iI][cC][aA][lL]"/>
+      <xs:pattern value="[cC][hH][aA][rR][aA][cC][tT][eE][rR]"/>
+      <xs:pattern value="[dD][oO][uU][bB][lL][eE][ ]*[pP][rR][eE][cC][iI][sS][iI][oO][nN]"/>
+      <xs:pattern value="[cC][oO][mM][pP][lL][eE][xX]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="int_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[iI][nN][tT][eE][gG][eE][rR]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="version_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[1-9][0-9]*[.][0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="dimension_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]{0,63}"/>
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]{0,63}[:][A-Za-z][A-Za-z0-9_]{0,63}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="fortran_func_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(call)?[ ]*[A-Za-z][A-Za-z0-9_]{0,63}[ ]*[(].*[)]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- attributes -->
+
+  <xs:attribute name="long_name"      type="xs:string"/>
+  <xs:attribute name="local_name"     type="fortran_id_type"/>
+  <xs:attribute name="kind"           type="xs:string"/>
+  <xs:attribute name="module"         type="fortran_id_type"/>
+  <xs:attribute name="name"           type="fortran_id_type"/>
+  <xs:attribute name="pointer"        type="xs:boolean" default="false"/>
+  <xs:attribute name="standard_name"  type="standard_name_type"/>
+  <xs:attribute name="state_variable" type="xs:boolean" default="false"/>
+  <xs:attribute name="units"          type="xs:string"/>
+  <xs:attribute name="version"        type="version_type"/>
+
+  <!-- definition of simple types -->
+
+  <xs:simpleType name="dimensions">
+    <xs:list itemType="dimension_type"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="ddt_type">
+    <xs:restriction base="fortran_id_type"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="module">
+    <xs:restriction base="fortran_id_type"/>
+  </xs:simpleType>
+
+  <!-- definition of complex types -->
+
+  <xs:complexType name="md_type">
+    <xs:simpleContent>
+      <xs:extension base="type_type">
+        <xs:attribute ref="kind"  use="required"/>
+        <xs:attribute ref="units" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="func_call_type">
+    <xs:simpleContent>
+      <xs:extension base="fortran_func_type">
+        <xs:attribute ref="module" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="variable_type">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="type"     type="md_type"/>
+        <xs:element name="ddt_type" type="ddt_type"/>
+      </xs:choice>
+      <xs:element name="dimensions" type="dimensions" />
+      <xs:choice minOccurs="0">
+        <xs:element name="module" type="fortran_id_type"/>
+        <xs:element name="access" type="func_call_type"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute ref="local_name"     use="required"/>
+    <xs:attribute ref="standard_name"  use="required"/>
+    <xs:attribute ref="long_name"      use="optional"/>
+    <xs:attribute ref="pointer"        use="optional"/>
+    <xs:attribute ref="state_variable" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="constant_type">
+    <xs:sequence>
+      <xs:element name="type"     type="md_type"/>
+      <xs:element name="dimensions" type="dimensions" />
+      <xs:choice minOccurs="0">
+        <xs:element name="module" type="fortran_id_type"/>
+        <xs:element name="access" type="func_call_type"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute ref="local_name"     use="required"/>
+    <xs:attribute ref="standard_name"  use="required"/>
+    <xs:attribute ref="long_name"      use="optional"/>
+  </xs:complexType>
+
+  <!-- definition of elements -->
+
+  <xs:element name="constant" type="constant_type">
+  </xs:element>
+
+  <xs:element name="variable" type="variable_type">
+  </xs:element>
+
+  <xs:element name="model">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="constant"          minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="variable"          minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name"    type="xs:string"    use="required"/>
+      <xs:attribute name="version" type="version_type" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/schema/standard_names.xsd
+++ b/schema/standard_names.xsd
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+
+<xs:schema elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- identifier types -->
+
+  <xs:simpleType name="standard_name_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9_]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="type_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[iI][nN][tT][eE][gG][eE][rR]"/>
+      <xs:pattern value="[rR][eE][aA][lL]"/>
+      <xs:pattern value="[lL][oO][gG][iI][cC][aA][lL]"/>
+      <xs:pattern value="[cC][hH][aA][rR][aA][cC][tT][eE][rR]"/>
+      <xs:pattern value="[dD][oO][uU][bB][lL][eE][ ]*[pP][rR][eE][cC][iI][sS][iI][oO][nN]"/>
+      <xs:pattern value="[cC][oO][mM][pP][lL][eE][xX]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="version_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[1-9][0-9]*[.][0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- attributes -->
+
+  <xs:attribute name="comment"        type="xs:string"/>
+  <xs:attribute name="long_name"      type="xs:string"/>
+  <xs:attribute name="kind"           type="xs:string"/>
+  <xs:attribute name="name"           type="standard_name_type"/>
+  <xs:attribute name="units"          type="xs:string"/>
+  <xs:attribute name="version"        type="version_type"/>
+
+  <!-- definition of complex types -->
+
+  <xs:complexType name="md_type">
+    <xs:simpleContent>
+      <xs:extension base="type_type">
+        <xs:attribute ref="kind"  use="optional"/>
+        <xs:attribute ref="units" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="stdname_type">
+    <xs:sequence>
+      <xs:element name="type"     type="md_type"/>
+    </xs:sequence>
+    <xs:attribute ref="name"      use="required"/>
+    <xs:attribute ref="long_name" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="section_type">
+    <xs:sequence>
+      <xs:element name="standard_name" type="stdname_type"
+                  minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute ref="name"    use="required"/>
+    <xs:attribute ref="comment" use="optional"/>
+  </xs:complexType>
+
+  <!-- definition of elements -->
+
+  <xs:element name="section" type="section_type">
+  </xs:element>
+
+  <xs:element name="standard_names">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="section" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name"    type="xs:string"    use="required"/>
+      <xs:attribute name="version" type="version_type" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/schema/suite_v1_0.xsd
+++ b/schema/suite_v1_0.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+
+<xs:schema elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- identifier types -->
+
+  <xs:simpleType name="version_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[1-9][0-9]*[.][0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="fortran_id_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]{0,63}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="subcycle_type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9_]*"/>
+      <xs:pattern value="[1-9][0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- attributes -->
+
+  <xs:attribute name="version"        type="version_type"/>
+
+  <!-- definition of complex types -->
+
+  <xs:complexType name="scheme_type">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="lib" type="xs:string" use="optional"/>
+        <xs:attribute name="version" type="xs:string" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- definition of suite elements -->
+
+  <xs:element name="subcycle">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="scheme" type="scheme_type"
+                    minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="loop" type="subcycle_type" use="optional"/>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="subcycle"/>
+        <xs:element name="scheme" type="scheme_type"/>
+      </xs:choice>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="suite">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element name="init"      type="scheme_type"/>
+          <xs:element name="initalize" type="scheme_type"/>
+        </xs:choice>
+        <xs:element ref="group" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:choice  minOccurs="0" maxOccurs="1">
+          <xs:element name="final"    type="scheme_type"/>
+          <xs:element name="finalize" type="scheme_type"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="name"    type="xs:string"    use="required"/>
+      <xs:attribute name="version" type="version_type" use="required"/>
+      <xs:attribute name="lib"     type="xs:string"    use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python
+
+"""
+Create CCPP parameterization caps, host-model interface code, optional
+physics suite runtime code, and documentation.
+"""
+
+# Python library imports
+import argparse
+import sys
+import os
+import os.path
+import logging
+# CCPP framework imports
+from fortran_tools import parse_fortran_file
+from host_model import HostModel
+from host_cap import write_host_cap
+from ccpp_suite import API, Suite
+from parse_tools import initLog, setLogToStdout, setLogLevel
+from parse_tools import CCPPError, ParseInternalError
+
+## Init this now so that all Exceptions can be trapped
+logger = initLog('ccpp_capgen')
+
+###############################################################################
+def is_xml_file(filename):
+###############################################################################
+    parts = os.path.basename(filename).split('.')
+    return (len(parts) > 1) and (parts[-1].lower() == 'xml')
+
+###############################################################################
+def check_for_existing_file(filename, description, readable=True):
+###############################################################################
+    'Check for file existence and access, abort on error'
+    if os.path.exists(filename):
+        if readable:
+            if not os.access(filename, os.R_OK):
+                raise CCPPError("No read access to {}, '{}'".format(description, filename))
+            # End if
+        # End if (no else needed, checks all done
+    else:
+        raise CCPPError("{}, '{}', must exist".format(description, filename))
+    # End if
+
+###############################################################################
+def check_for_writeable_file(filename, description):
+###############################################################################
+    if os.path.exists(filename) and not os.access(filename, os.W_OK):
+        raise CCPPError("Cannot write {}, '{}'".format(description, filename))
+    elif not os.access(os.path.dirname(filename), os.W_OK):
+        raise CCPPError("Cannot write {}, '{}'".format(description, filename))
+    # End if (else just return)
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument("host_pathnames", metavar='<host files filename>',
+                        type=str, help="File with host filenames to process")
+
+    parser.add_argument("scheme_pathnames", metavar='<scheme files filename>',
+                        type=str, help="File with scheme filenames to process")
+
+    parser.add_argument("--sdf-pathlist", metavar='<sdf file(s)>',
+                        type=str, default='',
+                        help="File with names of suite definition fileames to process or name of single XML SDF file")
+
+    parser.add_argument("--preproc-directives",
+                        metavar='VARDEF1[,VARDEF2 ...]', type=str, default=None,
+                        help="Proprocessor directives used to correctly parse source files")
+
+    parser.add_argument("--cap-pathlist", type=str,
+                        metavar='<filename for list of cap filenames>',
+                        default="capfiles.txt",
+                        help="Filename for list of generated cap files")
+
+    parser.add_argument("--output-root", type=str,
+                        metavar='<directory for generated files>',
+                        default=os.getcwd(),
+                        help="directory for generated files")
+
+    parser.add_argument("--generate-host-cap",
+                        action='store_true', default=False,
+                        help="Generate a host cap with correct API calling sequence")
+
+    parser.add_argument("--generate-docfiles",
+                        metavar='HTML | Latex | HTML,Latex', type=str,
+                        help="Generate LaTeX and/or HTML documentation")
+
+    parser.add_argument("--verbose", action='count',
+                        help="Log more activity, repeat for increased output")
+    pargs = parser.parse_args(args)
+    return pargs
+
+###############################################################################
+def read_pathnames_from_file(pathsfile):
+###############################################################################
+    'Read pathnames from <pathsfile> and return them as a list'
+    pathnames = list()
+    with open(pathsfile, 'r') as infile:
+        for line in infile.readlines():
+            path = line.strip()
+            # Skip blank lines and lines which appear to start with a comment.
+            if (len(path) > 0) and (path[0] != '#') and (path[0] != '!'):
+                # Check for an absolute path
+                if not os.path.isabs(path):
+                    # Assume relative pathnames are relative to pathsfile
+                    path = os.path.join(os.path.dirname(pathsfile), path)
+                # End if
+                pdesc = 'pathname in {}'.format(pathsfile)
+                check_for_existing_file(path, pdesc)
+                pathnames.append(path)
+            # End if (else skip blank or comment line)
+        # End for
+    # End with
+    return pathnames
+
+###############################################################################
+def parse_host_model_files(host_pathsfile, preproc_defs, logger):
+###############################################################################
+    """
+    Gather information from host files (e.g., DDTs, registry) and
+    return a host model object with the information.
+    """
+    mheaders = {}
+    xml_files = list()
+    filenames = read_pathnames_from_file(host_pathsfile)
+    for filename in filenames:
+        if is_xml_file(filename):
+            # We have to process XML files after processing Fortran files
+            # since the Fortran files may define DDTs used by registry files.
+            xml_files.append(filename)
+        else:
+            hheaders = parse_fortran_file(filename, preproc_defs==preproc_defs, logger=logger)
+            for header in hheaders:
+                if header.title in mheaders:
+                    raise CCPPError("Duplicate DDT, {}, found in {}".format(header.title, filename))
+                else:
+                    mheaders[header.title] = header
+                # End if
+            # End for
+        # End if
+    # End for
+    host_model = None
+    for file in xml_files:
+        host_model = HostModel.parse_host_registry(file, logger, mheaders,
+                                                   host_model=host_model)
+    # End for
+    return host_model
+
+###############################################################################
+def parse_scheme_files(scheme_pathsfile, preproc_defs, logger):
+###############################################################################
+    """
+    Gather information from scheme files (e.g., init, run, and finalize
+    methods) and return resulting dictionary.
+    """
+    mheaders = list()
+    filenames = read_pathnames_from_file(scheme_pathsfile)
+    for filename in filenames:
+        logger.info('Reading CCPP schemes from {}'.format(filename))
+        sheaders = parse_fortran_file(filename, preproc_defs==preproc_defs)
+        mheaders.append(sheaders)
+    # End for
+    return mheaders
+
+###############################################################################
+def _main_func():
+###############################################################################
+    args = parse_command_line(sys.argv[1:], __doc__)
+    verbosity = args.verbose
+    if verbosity > 1:
+        setLogLevel(logger, logging.DEBUG)
+    elif verbosity > 0:
+        setLogLevel(logger, logging.INFO)
+    # End if
+    host_pathsfile = os.path.abspath(args.host_pathnames)
+    schemes_pathsfile = os.path.abspath(args.scheme_pathnames)
+    if len(args.sdf_pathlist) > 0:
+        sdf_pathsfile = os.path.abspath(args.sdf_pathlist)
+    else:
+        sdf_pathsfile = None
+    # End if
+    output_dir = os.path.abspath(args.output_root)
+    if os.path.abspath(args.cap_pathlist):
+        cap_output_file = args.cap_pathlist
+    else:
+        cap_output_file = os.path.abspath(os.path.join(output_dir, args.cap_pathlist))
+    # End if
+    preproc_defs = args.preproc_directives
+    gen_hostcap = args.generate_host_cap
+    gen_docfiles = args.generate_docfiles
+    ## A few sanity checks
+    # Check required arguments
+    check_for_existing_file(host_pathsfile, 'Host pathnames file')
+    check_for_existing_file(schemes_pathsfile, 'Schemes pathnames file')
+    check_for_existing_file(schemes_pathsfile, 'SDF pathnames or file')
+    ## Make sure output directory is legit
+    if os.path.exists(output_dir):
+        if not os.path.isdir(output_dir):
+            raise CCPPError("output-root, '{}', is not a directory".format(args.output_root))
+        elif not os.access(output_dir, os.W_OK):
+            raise CCPPError("Cannot write files to output-root ({})".format(args.output_root))
+        # End if (output_dir is okay)
+    else:
+        # Try to create output_dir (let it crash if it fails)
+        os.makedirs(output_dir)
+    # End if
+    # Make sure we can create output file lists
+    if not os.path.isabs(cap_output_file):
+        cap_output_file = os.path.join(output_dir, cap_output_file)
+    # End if
+    check_for_writeable_file(cap_output_file, "Cap output file")
+    # Did we get an SDF input?
+    if sdf_pathsfile is not None:
+        sdf_is_xml = is_xml_file(sdf_pathsfile)
+        if sdf_is_xml:
+            check_for_existing_file(sdf_pathsfile, 'SDF file')
+        else:
+            check_for_existing_file(sdf_pathsfile, 'SDF pathnames file')
+        # End if
+    # End if
+    ##XXgoldyXX: Temporary warning
+    if gen_docfiles:
+        raise CCPPError("--gen-docfiles not yet supported")
+    # End if
+    # First up, handle the host files
+    host_model = parse_host_model_files(host_pathsfile, preproc_defs, logger)
+    # Next, parse the scheme files
+    scheme_headers = parse_scheme_files(schemes_pathsfile, preproc_defs, logger)
+    # Last, we need a list of SDF file(s)
+    if sdf_pathsfile is None:
+        sdfs = list()
+    else:
+        if sdf_is_xml:
+            sdfs = [sdf_pathsfile]
+        else:
+            sdfs = sdf_pathsfile
+        # End if
+    # End if
+    logger.debug("headers = {}".format([host_model._ddt_defs[x].title for x in host_model._ddt_defs.keys()]))
+    logger.debug("variables = {}".format([x.get_prop_value('local_name') for x in host_model.variable_list()]))
+    logger.debug("schemes = {}".format([[x._table_title for x in y] for y in scheme_headers]))
+    # Finally, we can get on with writing suites
+    ccpp_api = API(sdfs, host_model, scheme_headers, logger)
+    cap_filenames = ccpp_api.write(output_dir)
+    if gen_hostcap:
+        # Create a cap file
+        hcap_filename = write_host_cap(host_model, ccpp_api, output_dir, logger)
+    else:
+        hcap_filename = None
+    # End if
+    if not os.path.isabs(cap_output_file):
+        cap_output_file = os.path.join(output_dir, cap_output_file)
+    # End if
+    with open(cap_output_file, 'w') as cap_names:
+        for path in cap_filenames:
+            cap_names.write('{}\n'.format(path))
+        # End for
+        if hcap_filename is not None:
+            cap_names.write('{}\n'.format(hcap_filename))
+        # End if
+    # End with
+
+###############################################################################
+
+if __name__ == "__main__":
+    try:
+        _main_func()
+        sys.exit(0)
+    except ParseInternalError as pie:
+        logger.exception(pie)
+        sys.exit(-1)
+    except CCPPError as ca:
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            logger.exception(ca)
+        else:
+            logger.error(ca)
+        # End if
+        sys.exit(-1)
+    # End try

--- a/scripts/ccpp_suite.py
+++ b/scripts/ccpp_suite.py
@@ -1,0 +1,1108 @@
+#!/usr/bin/env python
+#
+
+"""Classes and methods to create a Fortran suite-implementation file
+to implement calls to a set of suites for a given host model."""
+
+# Python library imports
+from __future__ import print_function
+import copy
+import os.path
+import sys
+import re
+import xml.etree.ElementTree as ET
+# CCPP framework imports
+from parse_tools   import ParseContext, ParseSource, context_string
+from parse_tools   import ParseInternalError, ParseSyntaxError, CCPPError
+from parse_tools   import FORTRAN_ID
+from parse_tools   import read_xml_file, validate_xml_file, find_schema_version
+from metavar       import Var, VarDDT, VarDictionary, ddt_modules
+from state_machine import StateMachine
+from fortran_tools import FortranWriter
+
+###############################################################################
+# Module (global) variables
+###############################################################################
+
+__init_st__ = r"(?:(?i)init(?:ial(?:ize)?)?)"
+__final_st__ = r"(?:(?i)final(?:ize)?)"
+__run_st__ = r"(?:(?i)run)"
+__ts_init_st__ = r"(?:(?i)timestep_init(?:ial(?:ize)?)?)"
+__ts_final_st__ = r"(?:(?i)timestep_final(?:ize)?)"
+
+dimension_re = re.compile(FORTRAN_ID+r"_((?i)dimension)$")
+
+array_ref_re = re.compile(r"([^(]*)[(]([^)]*)[)]")
+
+# Allowed CCPP transitions
+CCPP_STATE_MACH = StateMachine((('initialize',       'uninitialized',
+                                 'initialized',       __init_st__),
+                                ('timestep_initial', 'initialized',
+                                 'in_time_step',      __ts_init_st__),
+                                ('run',              'in_time_step',
+                                 'in_time_step',      __run_st__),
+                                ('timestep_final',   'in_time_step',
+                                 'initialized',       __ts_final_st__),
+                                ('finalize',         'initialized',
+                                 'uninitialized',     __final_st__)))
+
+# Required variables for inclusion in auto-generated schemes
+CCPP_REQUIRED_VARS = [Var({'local_name' : 'errflg',
+                           'standard_name' : 'ccpp_error_flag', 'units' : '1',
+                           'dimensions' : '()', 'type' : 'integer'},
+                          ParseSource('ccpp_suite', 'REGISTRY',
+                                      ParseContext())),
+                      Var({'local_name' : 'errmsg',
+                           'standard_name' : 'ccpp_error_message',
+                           'units' : '1', 'dimensions' : '()',
+                           'type' : 'integer'},
+                          ParseSource('ccpp_suite', 'REGISTRY',
+                                      ParseContext()))]
+
+# CCPP copyright statement to be included in all generated Fortran files
+COPYRIGHT = '''!
+! This work (Common Community Physics Package Framework), identified by
+! NOAA, NCAR, CU/CIRES, is free of known copyright restrictions and is
+! placed in the public domain.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+! THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+! IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+###############################################################################
+
+class Scheme(object):
+    "A single scheme in a suite (e.g., init method)"
+
+    def __init__(self, scheme_xml, context):
+        self._name = scheme_xml.text
+        self._context = context
+        self._version = scheme_xml.get('version', None)
+        self._lib = scheme_xml.get('lib', None)
+
+    @property
+    def name(self):
+        '''Return name of scheme'''
+        return self._name
+
+    def ddtspec_to_str(self, ddt_spec, host_model):
+        "Properly convert a DDT field reference to a string"
+        args = list()
+        alen = len(ddt_spec)
+        index = 0
+        for var in ddt_spec:
+            ddt = index < (alen - 1)
+            argstr = self.host_arg_str(var, host_model, ddt)
+            index = index + 1
+            args.append(argstr)
+        # End for
+        return '%'.join(args)
+
+    def find_host_model_var(self, hdim, host_model):
+        "Create the correct array dimension reference for hdim"
+        hsdims = list()
+        for hsdim in hdim.split(':'):
+            hsdim_var = host_model.find_variable(hsdim, loop_subst=True)
+            if hsdim_var is None:
+                raise CCPPError("No matching host variable for {} dimension, {}".format(self._subroutine_name, hsdim))
+            elif isinstance(hsdim_var, tuple):
+                # This is a dimension range (e.g., from a loop_subst)
+                lnames = [x.get_prop_value('local_name') for x in hsdim_var]
+                hsdims.extend(lnames)
+            elif isinstance(hsdim_var, VarDDT):
+                # This is a DDT reference
+                ##XXgoldyXX: HACK! Take this out when DDTS removed from suites
+                hsdims.append(self.ddtspec_to_str(hsdim_var._var_ref_list, host_model))
+            else:
+                hsdims.append(hsdim_var.get_prop_value('local_name'))
+            # End if
+        # End for
+        loop_var = VarDictionary.loop_var_match(hdim)
+        if (dimension_re.match(hdim) is not None) and (len(hsdims) == 1):
+            # We need to specify the whole range
+            hsdims = ['1'] + hsdims
+        elif loop_var and (len(hsdims) == 1):
+            # We may to specify the whole range
+            lv_type = hdim.split('_')[-1]
+            if lv_type == 'extent':
+                hsdims = ['1'] + hsdims # This should print as '1:<name>_extent'
+            elif lv_type == 'beg':
+                hsdims.append('') # This should print as '<name>_beg:'
+            elif lv_type == 'end':
+                hsdims = [''] + hsdims # This should print as ':<name>_end'
+            elif lv_type == 'number':
+                pass # This should be a single value (not an array section)
+            else:
+                raise ParseInternalError("Unknown loop variable type, '{}' in '{}'".format(lv_type, hdim))
+            # End if
+        # End if
+        return ':'.join(hsdims)
+
+    def host_arg_str(self, hvar, host_model, ddt):
+        '''Create the proper statement of a piece of a host-model variable.
+        If ddt is True, we can only have a single element selected
+        '''
+        hstr = hvar.get_prop_value('local_name')
+        hdims = hvar.get_dimensions()
+        dimsep = ''
+        # Does the local name have any extra indices?
+        match = array_ref_re.match(hstr.strip())
+        if match is not None:
+            tokens = [x.strip() for x in match.group(2).strip().split(',')]
+            # There should one ':' token for each entry in hdims
+            if tokens.count(':') != len(hdims):
+                raise CCPPError("Invalid DDT variable spec, {}, should have {} colons".format(hstr, len(hdims)))
+            else:
+                hstr = match.group(1)
+                hdims_temp = hdims
+                hdims = list()
+                hdim_index = 0
+                for token in tokens:
+                    if token == ':':
+                        hdims.append(hdims_temp[hdim_index])
+                        hdim_index = hdim_index + 1
+                    else:
+                        hdims.append(token)
+                    # End if
+                # End for
+            # End if
+        # End if
+        if len(hdims) > 0:
+            dimstr = '('
+        else:
+            dimstr = ''
+        # End if
+        for hdim in hdims:
+            # We can only have a single element of a DDT when selecting
+            # a field. Is this a thread block?
+            if ddt and (hdim == 'thread_block_begin:thread_block_end'):
+                hdim = 'thread_block_number'
+            # End if
+            if ddt and (':' in hdim):
+                raise CCPPError("Invalid DDT dimension spec {}{}".format(hstr, hdimval))
+            else:
+                # Find the host model variable for each dim
+                hsdims = self.find_host_model_var(hdim, host_model)
+                dimstr = dimstr + dimsep + hsdims
+                dimsep = ', '
+            # End if
+        # End for
+        if len(hdims) > 0:
+            dimstr = dimstr + ')'
+        # End if
+        return hstr + dimstr
+
+    def analyze(self, phase, parent, scheme_headers, suite_vars, logger):
+        # Find the host model (do we need to do this?)
+        host_model = parent
+        while host_model.parent is not None:
+            host_model = host_model.parent
+        # End if
+        my_header = None
+        for module in scheme_headers:
+            for header in module:
+                func_id, trans_id, match_trans = CCPP_STATE_MACH.transition_match(header.title, transition=phase)
+                if func_id == self.name:
+                    my_header = header
+                    self._subroutine_name = header.title
+                    break
+                # End if
+            # End for
+            if my_header is not None:
+                break
+            # End if
+        # End for
+        if my_header is None:
+            estr = 'No {} header found for subroutine, {}'
+            raise ParseInternalError(estr.format(phase, self.name),
+                                     context=self._context)
+        # End if
+        if my_header.module is None:
+            estr = 'No module found for subroutine, {}'
+            raise ParseInternalError(estr.format(self._subroutine_name),
+                                     context=self._context)
+        # End if
+        scheme_mods = set()
+        scheme_use = 'use {}, only: {}'.format(my_header.module,
+                                               self._subroutine_name)
+        scheme_mods.add(scheme_use)
+        if my_header is None:
+            raise CCPPError('Could not find subroutine, {}'.format(subroutine_name))
+        else:
+            # We need to find the host model variable for each of our arguments
+            my_args = my_header.variable_list()
+            host_arglist = list()
+            for svar in my_args:
+                stdname = svar.get_prop_value('standard_name')
+                intent = svar.get_prop_value('intent').lower()
+                hvar = parent.find_variable(stdname, loop_subst=True)
+                if (intent == 'in') or (intent == 'inout'):
+                    if hvar is None:
+                        raise CCPPError("No matching host or suite variable for {} input, {}".format(self._subroutine_name, stdname))
+                elif hvar is None:
+                    # Create suite variable for intent(out)
+                    suite_vars.add_variable(svar, exists_ok=False)
+                    hvar = suite_vars.find_variable(stdname)
+                # End if (no else needed)
+                if isinstance(hvar, VarDDT):
+                    ##XXgoldyXX: HACK! Take this out when DDTS removed from suites
+                    host_arglist.append(self.ddtspec_to_str(hvar._var_ref_list, host_model))
+                elif isinstance(hvar, tuple):
+                    loop_subst = VarDictionary.loop_subst_match(stdname)
+                    if (loop_subst is not None) and (len(loop_subst) == 2):
+                        # Special case for loops
+                        lnames = [x.get_prop_value('local_name') for x in hvar]
+                        argstr = "{end} - {beg} + 1".format(beg=lnames[0], end=lnames[1])
+                        host_arglist.append(argstr)
+                    else:
+                        for var in hvar:
+                            argstr = self.host_arg_str(var, host_model, False)
+                            host_arglist.append(argstr)
+                        # End for
+                    # End if
+                else:
+                    argstr = self.host_arg_str(hvar, host_model, False)
+                    host_arglist.append(argstr)
+                # End if
+            # End for
+            self._arglist = host_arglist
+        # End if
+        return scheme_mods, list() # No loop variables for scheme
+
+    def write(self, outfile, indent):
+        my_args = ', '.join(self._arglist)
+        outfile.write('call {}({})'.format(self._subroutine_name, my_args), indent)
+
+    def schemes(self):
+        'Return self as a list for consistency with subcycle'
+        return [self]
+
+###############################################################################
+
+class Subcycle(object):
+    "Class to represent a subcycled group of schemes"
+
+    __def_name_index__ = 0 # To create unique default loop index variables
+
+    def __init__(self, sub_xml, context):
+        self._name = sub_xml.get('name', None)
+        if self._name is None:
+            Subcycle.__def_name_index__ = Subcycle.__def_name_index__ + 1
+            self._name = "subcycle_index{}".format(Subcycle.__def_name_index__)
+        # End if
+        self._loop = sub_xml.get('loop', "1")
+        self._context = context
+        self._schemes = list()
+        for scheme in sub_xml:
+            self._schemes.append(Scheme(scheme, context))
+        # End forn
+
+    def analyze(self, phase, parent, scheme_headers, suite_vars, logger):
+        loopvars = set()
+        loopvars.add('{}integer :: {}'.format(indent(2), self.name))
+        scheme_mods = set()
+        for scheme in self._schemes:
+            smods, lvars = scheme.analyze(phase, parent, scheme_headers, suite_vars, logger)
+            for smod in smods:
+                scheme_mods.add(smod)
+            # End for
+            for lvar in lvars:
+                loopvars.add(lvar)
+            # End for
+        # End for
+        return scheme_mods, loopvars
+
+    def write(self, outfile, indent):
+        outfile.write('do {} = 1, {}'.format(self.name, self.loop), indent)
+        # Note that 'scheme' may be a sybcycle or other construct
+        for scheme in self._schemes:
+            scheme.write(outfile, indent+1)
+        # End for
+        outfile.write('end do', 2)
+
+    @property
+    def name(self):
+        '''name property to be consistent with other classes'''
+        return self._name
+
+    @property
+    def loop(self):
+        '''Get the loop value or variable standard_name'''
+        return self._loop
+
+    @property
+    def schemes(self):
+        '''Get the list of schemes'''
+        return self._schemes
+
+###############################################################################
+
+class Group(VarDictionary):
+    """Class to represent a grouping of schemes in a suite
+    A Group object is implemented as a subroutine callable by the API.
+    The main arguments to a group are the host model variables.
+    Additional output arguments are generated from schemes with intent(out)
+    arguments.
+    Additional input or inout arguments are generated for inputs needed by
+    schemes which are produced (intent(out)) by other groups.
+    """
+
+    __subhead__ = '''
+   subroutine {subname}({args})
+'''
+
+    __subend__ = '''
+   end subroutine {subname}
+'''
+
+    def __init__(self, group_xml, transition, parent, context):
+        self._name = parent.name + '_' + group_xml.get('name')
+        if transition not in CCPP_STATE_MACH.transitions():
+            raise ParseInternalError("Bad transition argument to Group, '{}'".format(transition))
+        # End if
+        self._transition = transition
+        self._parts = list()
+        super(Group, self).__init__(self.name, parent_dict=parent)
+        for item in group_xml:
+            if item.tag == 'subcycle':
+                self.add_item(Subcycle(item, self, context))
+            else:
+                self.add_item(Scheme(item, context))
+            # End if
+        # End for
+        # Grab a frozen copy of the context
+        self._context = ParseContext(context=context)
+        self._loop_var_defs = set()
+        self._local_schemes = set()
+        self._host_vars = None
+        self._host_ddts = None
+
+    def has_item(self, item_name):
+        'Check to see if an item is already in this group'
+        has = False
+        for item in self._parts:
+            if item.name == item_name:
+                has = True
+                break
+            # End if
+        # End for
+        return has
+
+    def add_item(self, item):
+        'Add an item (e.g., Suite, Subcycle) to this group'
+        self._parts.append(item)
+
+    def schemes(self):
+        "Return a flattened list of schemes for this group"
+        schemes = list()
+        for item in self._parts:
+            schemes.extend(item.schemes())
+        # End for
+        return schemes
+
+    @property
+    def phase(self):
+        'Return the CCPP state transition for this group spec'
+        return self._transition
+
+    def phase_match(self, scheme_name):
+        '''If scheme_name matches the group phase, return the group and
+            function ID. Otherwise, return None
+        '''
+        fid, tid, mt = CCPP_STATE_MACH.transition_match(scheme_name,
+                                                        transition=self.phase)
+        if tid is not None:
+            return self, fid
+        else:
+            return None, None
+        # End if
+
+    def analyze(self, phase, suite_vars, scheme_headers, logger):
+        # We need a copy of the API and host model variables for dummy args
+        self._host_vars = suite_vars.parent.variable_list(recursive=True,
+                                                          loop_vars=(phase=='run'))
+        self._phase = phase
+        for item in self._parts:
+            # Items can be schemes, subcycles or other objects
+            # All have the same interface and return a set of module use
+            # statements (lschemes) and a set of loop variables
+            lschemes, lvars = item.analyze(phase, self, scheme_headers, suite_vars, logger)
+            # Keep track of loop variables to define
+            for lvar in lvars:
+                self._loop_var_defs.add(lvar)
+            # End for
+            for lscheme in lschemes:
+                self._local_schemes.add(lscheme)
+            # End for
+        # End for
+        self._phase_check_stmts = Suite.check_suite_state(phase)
+        self._set_state = Suite.set_suite_state(phase)
+        # Find any host DDT variables to create use statements
+        self._host_ddts = ddt_modules(self._host_vars)
+
+    def write(self, outfile, host_arglist, indent,
+              suite_vars=None, allocate=False, deallocate=False):
+        local_subs = ''
+        # group type for (de)allocation
+        if 'timestep' in self._phase:
+            group_type = 'timestep'
+        else:
+            group_type = 'run'
+        # End if
+        # First, write out the subroutine header
+        subname = self.name
+        outfile.write(Group.__subhead__.format(subname=subname, args=host_arglist), indent)
+        # Write out any use statements
+        mlen = max([len(x[0]) for x in self._host_ddts])
+        for ddt in self._host_ddts:
+            mspc = (mlen - len(ddt[0]))*' '
+            outfile.write("use {}, {}only: {}".format(ddt[0], mspc, ddt[1]),
+                          indent+1)
+        # End for
+        # Write out the scheme use statements
+        for scheme in self._local_schemes:
+            outfile.write(scheme, indent+1)
+        # End for
+        outfile.write('', 0)
+        # Write out dummy arguments
+        outfile.write('! Dummy arguments', indent+1)
+        for var in self._host_vars:
+            var.write_def(outfile, indent+1, self)
+        # End for
+        if len(self._loop_var_defs) > 0:
+            outfile.write('\n! Local Variables', indent+1)
+        # Write out local variables
+        for var in self._loop_var_defs:
+            outfile.write(var, indent+1)
+        # End for
+        outfile.write('', 0)
+        # Check state machine
+        verrflg = self.find_variable('ccpp_error_flag', any_scope=True)
+        if verrflg is not None:
+            errflg = verrflg.get_prop_value('local_name')
+        else:
+            raise CCPPError("No ccpp_error_flag variable for group, {}".format(self.name))
+        # End if
+        verrmsg = self.find_variable('ccpp_error_message', any_scope=True)
+        if verrmsg is not None:
+            errmsg = verrmsg.get_prop_value('local_name')
+        else:
+            raise CCPPError("No ccpp_error_message variable for group, {}".format(self.name))
+        # End if
+        for stmt in self._phase_check_stmts:
+            text = stmt[0].format(errflg=errflg , errmsg=errmsg, funcname=self.name)
+            outfile.write(text, indent + stmt[1])
+        # End for
+        # Allocate suite vars
+        if allocate:
+            for svar in suite_vars.variable_list():
+                timestep_var = svar.get_prop_value('persistence')
+                if group_type == timestep_var:
+                    dims = svar.get_dimensions()
+                    rdims = list()
+                    for dim in dims:
+                        dvar = self.find_dimension_subst(dim, context=self._context)
+                        if dvar is None:
+                            dvar = self.find_variable(dim, any_scope=True)
+                        # End if
+                        if dvar is None:
+                            raise CCPPError("Dimension variable, {} not found{}".format(dim, context_string(self._context)))
+                        else:
+                            rdims.append(dvar)
+                        # End if
+                    # End for
+                    alloc_str = ', '.join([x.get_prop_value('local_name') for x in rdims])
+                    lname = svar.get_prop_value('local_name')
+                    outfile.write("allocate({}({}))".format(lname, alloc_str), indent+1)
+                # End if
+            # End for
+        # End if
+        # Write the scheme and subcycle calls
+        for item in self._parts:
+            item.write(outfile, indent+1)
+        # End for
+        # Deallocate suite vars
+        if deallocate:
+            for svar in suite_vars.variable_list():
+                timestep_var = svar.get_prop_value('persistence')
+                if group_type == timestep_var:
+                    lname = svar.get_prop_value('local_name')
+                    outfile.write('deallocate({})'.format(lname), indent+1)
+                # End if
+            # End for
+        # End if
+        outfile.write(self._set_state[0], indent + self._set_state[1])
+        outfile.write(Group.__subend__.format(subname=subname), indent)
+
+    @property
+    def name(self):
+        '''Get the name of the group.'''
+        return self._name
+
+###############################################################################
+
+class Suite(VarDictionary):
+
+    ___state_machine_initial_state__ = 'uninitialized'
+    __state_machine_var_name__     = 'ccpp_suite_state'
+
+    __header__ ='''
+!>
+!! @brief Auto-generated cap module for the CCPP suite
+!!
+!
+module {module}
+'''
+
+    __state_machine_init__ ='''
+character(len=16) :: {css_var_name} = '{state}'
+'''
+
+    __footer__ = '''
+end module {module}
+'''
+
+    # Note that these group names need to match CCPP_STATE_MACH
+    __initial_group__ = '<group name="initialize"></group>'
+
+    __final_group__ = '<group name="finalize"></group>'
+
+    __timestep_initial_group__ = '<group name="timestep_initial"></group>'
+
+    __timestep_final_group__ = '<group name="timestep_final"></group>'
+
+    __scheme_template__ = '<scheme>{}</scheme>'
+
+    def __init__(self, filename, api, logger):
+        self._logger = logger
+        self._name = None
+        self._sdf_name = filename
+        self._groups = list()
+        self._suite_init_group = None
+        self._suite_final_group = None
+        self._timestep_init_group = None
+        self._timestep_final_group = None
+        self._context = None
+        # Full phases/groups are special groups where the entire state is passed
+        self._full_groups = {}
+        self._full_phases = {}
+        super(Suite, self).__init__(self.sdf_name, parent_dict=api, logger=logger)
+        if not os.path.exists(self._sdf_name):
+            raise CCPPError("Suite definition file {0} not found.".format(self._sdf_name))
+        else:
+            self.parse()
+        # End if
+
+    @property
+    def name(self):
+        '''Get the name of the suite.'''
+        return self._name
+
+    @property
+    def sdf_name(self):
+        '''Get the name of the suite definition file.'''
+        return self._sdf_name
+
+    @classmethod
+    def check_suite_state(cls, stage):
+        "Return a list of CCPP state check statements for <stage>"
+        check_stmts = list()
+        if stage in CCPP_STATE_MACH.transitions():
+            # We need to make sure we are an allowed previous state
+            prev_state = CCPP_STATE_MACH.initial_state(stage)
+            css = "trim({})".format(Suite.__state_machine_var_name__)
+            prev_str = "({} /= '{}')".format(css, prev_state)
+            check_stmts.append(("if {} then".format(prev_str), 1))
+            check_stmts.append(("{errflg} = 1", 2))
+            errmsg_str = ("\"Invalid initial CCPP state, '\"//"+ css +
+                          "//\"' in {funcname}\"")
+            check_stmts.append(("{{errmsg}} = {}".format(errmsg_str), 2))
+            check_stmts.append(("return", 2))
+            check_stmts.append(("end if", 1))
+        else:
+            raise ParseInternalError("Unknown stage, '{}'".format(stage))
+        # End if
+        return check_stmts
+
+    @classmethod
+    def set_suite_state(cls, phase):
+        final = CCPP_STATE_MACH.final_state(phase)
+        return ("ccpp_suite_state = '{}'".format(final), 1)
+
+    def new_group(self, group_string, transition):
+        gxml = ET.fromstring(group_string)
+        group = Group(gxml, transition, self, self._context)
+        self._full_groups[group.name] = group
+        self._full_phases[group.phase] = group
+        return group
+
+    def parse(self):
+        '''Parse the suite definition file.'''
+        success = True
+
+        tree, suite_xml = read_xml_file(self._sdf_name, self._logger)
+        # We do not have line number information for the XML file
+        self._context = ParseContext(filename=self._sdf_name)
+        # Validate the XML file
+        version = find_schema_version(suite_xml, self._logger)
+        res = validate_xml_file(self._sdf_name, 'suite', version, self._logger)
+        if not res:
+            raise CCPPError("Invalid suite definition file, '{}'".format(self._sdf_name))
+        # End if
+        self._name = suite_xml.get('name')
+        self._logger.info("Reading suite definition file for '{}'".format(self._name))
+        self._suite_init_group = self.new_group(Suite.__initial_group__,
+                                                "initialize")
+        self._suite_final_group = self.new_group(Suite.__final_group__,
+                                                 "finalize")
+        self._timestep_init_group = self.new_group(Suite.__timestep_initial_group__,
+                                                   "timestep_initial")
+        self._timestep_final_group = self.new_group(Suite.__timestep_final_group__,
+                                                    "timestep_final")
+        # Set up some groupings for later efficiency
+        self._beg_groups = [x.name for x in [self._suite_init_group,
+                                             self._timestep_init_group]]
+        self._end_groups = [x.name for x in [self._suite_final_group,
+                                             self._timestep_final_group]]
+        # Build hierarchical structure as in SDF
+        self._groups.append(self._suite_init_group)
+        self._groups.append(self._timestep_init_group)
+        for suite_item in suite_xml:
+            item_type = suite_item.tag.lower()
+            # Suite item is a group or a suite-wide init or final method
+            if item_type == 'group':
+                # Parse a group
+                self._groups.append(Group(suite_item, 'run', self, self._context))
+            else:
+                match_trans = CCPP_STATE_MACH.group_match(item_type)
+                if match_trans is None:
+                    raise CCPPError("Unknown CCPP suite component tag type, '{}'".format(item_type))
+                elif match_trans in self._full_phases:
+                    # Parse a suite-wide initialization scheme
+                    self._full_phases[match_trans].add_item(Scheme(suite_item, self._context))
+                else:
+                    raise ParseInternalError("Unhandled CCPP suite component tag type, '{}'".format(match_trans))
+                # End if
+        # End for
+        self._groups.append(self._timestep_final_group)
+        self._groups.append(self._suite_final_group)
+        return success
+
+    @property
+    def module(self):
+        '''Get the list of the module generated for this suite.'''
+        return self._module
+
+    @property
+    def groups(self):
+        '''Get the list of groups in this suite.'''
+        return self._groups
+
+    def analyze(self, host_model, scheme_headers, logger):
+        '''Collect all information needed to write a suite file
+        >>> CCPP_STATE_MACH.transition_match('foo_init')
+        ('foo', 'init', 'initialize')
+        >>> CCPP_STATE_MACH.transition_match('foo_init', transition='finalize')
+        (None, None, None)
+        >>> CCPP_STATE_MACH.transition_match('FOO_INIT')
+        ('FOO', 'INIT', 'initialize')
+        >>> CCPP_STATE_MACH.transition_match('foo_initial')
+        ('foo', 'initial', 'initialize')
+        >>> CCPP_STATE_MACH.transition_match('foo_initialize')
+        ('foo', 'initialize', 'initialize')
+        >>> CCPP_STATE_MACH.transition_match('foo_initialize')[1][0:4]
+        'init'
+        >>> CCPP_STATE_MACH.transition_match('foo_initize')
+        (None, None, None)
+        >>> CCPP_STATE_MACH.transition_match('foo_run')
+        ('foo', 'run', 'run')
+        >>> CCPP_STATE_MACH.transition_match('foo_finalize')
+        ('foo', 'finalize', 'finalize')
+        >>> CCPP_STATE_MACH.transition_match('foo_finalize')[1][0:5]
+        'final'
+        >>> CCPP_STATE_MACH.transition_match('foo_final')
+        ('foo', 'final', 'finalize')
+        >>> CCPP_STATE_MACH.transition_match('foo_finalize_bar')
+        (None, None, None)
+        '''
+        # Collect all the available schemes
+        for header_list in scheme_headers:
+            for header in header_list:
+                pgroup = None
+                for gname in self._full_groups.keys():
+                    mgroup = self._full_groups[gname]
+                    pgroup, func_id = mgroup.phase_match(header.title)
+                    if pgroup is not None:
+                        break
+                    # End if
+                # End for
+                if pgroup is not None:
+                    if not pgroup.has_item(header.title):
+                        sstr = Suite.__scheme_template__.format(func_id)
+                        sxml = ET.fromstring(sstr)
+                        scheme = Scheme(sxml, self._context)
+                        pgroup.add_item(scheme)
+                    # End if (no else needed)
+                else:
+                    if header.title.lower()[-4:] != '_run':
+                        raise CCPPError("Unknown CCPP scheme run type, '{}'".format(header.title))
+                    # End if
+                # End if
+            # End for
+        # End for
+        # Grab the host model argument list
+        self._host_arg_list_full = host_model.argument_list()
+        self._host_arg_list_noloop = host_model.argument_list(loop_vars=False)
+        # First pass, create init, run, and finalize sequences
+        for item in self.groups:
+            if item.name in self._full_groups:
+                phase = self._full_groups[item.name].phase
+            else:
+                phase = 'run'
+            # End if
+            logger.debug("Group {}, schemes = {}".format(item.name, [x.name for x in item.schemes()]))
+            # Note that the group analyze can update this suite's vars
+            item.analyze(phase, self, scheme_headers, logger)
+        # End for
+
+    def is_run_group(self, group):
+        """Method to separate out run-loop groups from special initial
+        and final groups
+        """
+        return (group.name not in self._beg_groups) and (group.name not in self._end_groups)
+
+    def max_part_len(self):
+        "What is the longest suite subroutine name?"
+        maxlen = 0
+        for spart in self.groups:
+            if self.is_run_group(spart):
+                maxlen = max(maxlen, len(spart.name))
+            # End if
+        # End for
+        return maxlen
+
+    def part_list(self):
+        "Return list of run phase parts (groups)"
+        parts = list()
+        for spart in self.groups:
+            if self.is_run_group(spart):
+                parts.append(spart.name[len(self.name)+1:])
+            # End if
+        # End for
+        return parts
+
+    def write(self, output_dir):
+        """Create caps for all groups in the suite and for the entire suite
+        (calling the group caps one after another)"""
+        # Set name of module and filename of cap
+        self._module = 'ccpp_{}_cap'.format(self.name)
+        filename = '{module_name}.F90'.format(module_name=self._module)
+        # Init
+        module_use = None
+        output_file_name = os.path.join(output_dir, filename)
+        with FortranWriter(output_file_name, 'w') as outfile:
+            # Write suite header
+            outfile.write(COPYRIGHT, 0)
+            outfile.write(Suite.__header__.format(module=self._module), 0)
+            # Write module 'use' statements here
+            outfile.write('use machine', 1)
+            outfile.write('implicit none\nprivate\n\n! Suite interfaces', 1)
+            outfile.write(Suite.__state_machine_init__.format(css_var_name=Suite.__state_machine_var_name__, state=Suite.___state_machine_initial_state__), 1)
+            for group in self._groups:
+                outfile.write('public :: {}'.format(group.name), 1)
+            # End for
+            outfile.write('\n! Private suite variables', 1)
+            for svar in self.keys():
+                self[svar].write_def(outfile, 1, self, allocatable=True)
+            # End for
+            outfile.write('\ncontains', 0)
+            for group in self._groups:
+                if group.name in self._beg_groups:
+                    group.write(outfile, self._host_arg_list_noloop, 1,
+                                suite_vars=self, allocate=True)
+                elif group.name in self._end_groups:
+                    group.write(outfile, self._host_arg_list_noloop, 1,
+                                suite_vars=self, deallocate=True)
+                else:
+                    group.write(outfile, self._host_arg_list_full, 1)
+                # End if
+            # End for
+            # Finish off the module
+            outfile.write(Suite.__footer__.format(module=self._module), 0)
+            return output_file_name
+
+###############################################################################
+
+class API(VarDictionary):
+
+    __suite_fname__ = 'ccpp_physics_suite_list'
+    __part_fname__  = 'ccpp_physics_suite_part_list'
+
+    __header__ = '''
+!>
+!! @brief Auto-generated API for {host_model} calls to CCPP suites
+!!
+!
+module {module}
+'''
+    __preamble__ = '''
+{module_use}
+
+implicit none
+private
+
+'''
+
+    __sub_name_template__ = 'ccpp_physics'
+
+    __subhead__ = 'subroutine {subname}({host_call_list})'
+
+    __subfoot__ = 'end subroutine {subname}\n'
+
+    __footer__ = '''
+end module {module}
+'''
+
+    __api_source__ = ParseSource("CCPP_API", "MODULE",
+                                 ParseContext(filename="ccpp_suite.F90"))
+
+    # Note, we cannot add these vars to our dictionary as we do not want
+    #    them showing up in group dummy arg lists
+    __suite_name__ = Var({'local_name':'suite_name',
+                          'standard_name':'suite_name',
+                          'intent':'in', 'type':'character',
+                          'kind':'len=*', 'units':'',
+                          'dimensions':'()'}, __api_source__)
+
+    __suite_part__ = Var({'local_name':'suite_part',
+                          'standard_name':'suite_part',
+                          'intent':'in', 'type':'character',
+                          'kind':'len=*', 'units':'',
+                          'dimensions':'()'}, __api_source__)
+
+    def __init__(self, sdfs, host_model, scheme_headers, logger):
+        self._module        = 'ccpp_physics_api'
+        self._host          = host_model
+        self._schemes       = scheme_headers
+        self._suites        = list()
+        super(API, self).__init__(self.module, parent_dict=host_model, logger=logger)
+        self._host_arg_list_full = host_model.argument_list()
+        self._host_arg_list_noloop = host_model.argument_list(loop_vars=False)
+        # Turn the SDF files into Suites
+        for sdf in sdfs:
+            suite = Suite(sdf, self, logger)
+            suite.analyze(host_model, scheme_headers, logger)
+            self._suites.append(suite)
+        # End for
+        # Find DDTs for use statements
+        host_vars = host_model.variable_list()
+        self._host_ddt_list_full = ddt_modules(host_vars)
+        host_vars = host_model.variable_list(loop_vars=False)
+        self._host_ddt_list_noloop = ddt_modules(host_vars)
+        # We will need the correct names for errmsg and errflg
+        self._errmsg_var = host_model.find_variable('ccpp_error_message')
+        if self._errmsg_var is None:
+            raise CCPPError('Required variable, ccpp_error_message, not found')
+        # End if
+        self._errflg_var = host_model.find_variable('ccpp_error_flag')
+        if self._errflg_var is None:
+            raise CCPPError('Required variable, ccpp_error_flag, not found')
+        # End if
+
+    @property
+    def module(self):
+        '''Get the module name of the API.'''
+        return self._module
+
+    @property
+    def suite_name_var(self):
+        return type(self).__suite_name__
+
+    @property
+    def suite_part_var(self):
+        return type(self).__suite_part__
+
+    @classmethod
+    def interface_name(cls, phase):
+        'Return the name of an API interface function'
+        return "{}_{}".format(cls.__sub_name_template__, phase)
+
+    def write(self, output_dir):
+        """Write CCPP API module"""
+        if len(self._suites) == 0:
+            raise CCPPError("No suite specified for generating API")
+        # End if
+        filename = os.path.join(output_dir, self.module + '.F90')
+        api_filenames = list()
+        module_use = 'use machine'
+        # Write out the suite files
+        for suite in self._suites:
+            out_file_name = suite.write(output_dir)
+            api_filenames.append(out_file_name)
+        # End for
+        errmsg_name = self._errmsg_var.get_prop_value('local_name')
+        errflg_name = self._errflg_var.get_prop_value('local_name')
+        # Write out the API module
+        with FortranWriter(filename, 'w') as api:
+            api.write(COPYRIGHT, 0)
+            api.write(API.__header__.format(host_model=self._host.name,
+                                            module=self.module), 0)
+            api.write(API.__preamble__.format(module_use=module_use), 1)
+            for stage in CCPP_STATE_MACH.transitions():
+                api.write("public :: ccpp_physics_{}".format(stage), 1)
+            # End for
+            api.write("public :: {}".format(API.__suite_fname__), 1)
+            api.write("public :: {}".format(API.__part_fname__), 1)
+            api.write("\ncontains\n", 0)
+            # Write the module body
+            max_suite_len = 0
+            for suite in self._suites:
+                max_suite_len = max(max_suite_len, len(suite.module))
+            # End for
+            for stage in CCPP_STATE_MACH.transitions():
+                host_call_list = self.suite_name_var.get_prop_value('local_name')
+                if stage == 'run':
+                    host_call_list = host_call_list + ', ' + self.suite_part_var.get_prop_value('local_name')
+                    hal = self._host_arg_list_full
+                    hddt = self._host_ddt_list_full
+                else:
+                    hal = self._host_arg_list_noloop
+                    hddt = self._host_ddt_list_noloop
+                # End if
+                host_call_list = host_call_list + ", " + hal
+                host_call_list = host_call_list + ', '.join(self.prop_list('local_name'))
+                subname = API.interface_name(stage)
+                api.write(API.__subhead__.format(subname=subname, host_call_list=host_call_list), 1)
+                # Write out any use statements
+                mlen = max([len(x[0]) for x in hddt])
+                mlen = max(mlen, max_suite_len)
+                for suite in self._suites:
+                    mspc = (mlen - len(suite.module))*' '
+                    if stage == 'run':
+                        for spart in suite.groups:
+                            if suite.is_run_group(spart):
+                                api.write("use {}, {}only: {}".format(suite.module, mspc, spart.name), 2)
+                            # End if
+                        # End for
+                    else:
+                        api.write("use {}, {}only: {}_{}".format(suite.module, mspc, suite.name, stage), 2)
+                    # End if
+                # End for
+                for ddt in hddt:
+                    mspc = (mlen - len(ddt[0]))*' '
+                    api.write("use {}, {}only: {}".format(ddt[0], mspc, ddt[1]), 2)
+                # End for
+                # Declare dummy arguments
+                self.suite_name_var.write_def(api, 2, self)
+                if stage == 'run':
+                    self.suite_part_var.write_def(api, 2, self)
+                # End if
+                for var in self._host.variable_list():
+                    stdname = var.get_prop_value('standard_name')
+                    if (stage=='run') or (not VarDictionary.loop_var_match(stdname)):
+                        var.write_def(api, 2, self)
+                    # End if
+                # End for
+                self.declare_variables(api, 2, loop_vars=(stage=='run'))
+                # Now, add in cases for all suite parts
+                else_str = '\n'
+                for suite in self._suites:
+                    api.write("{}if (trim(suite_name) == '{}') then".format(else_str, suite.name), 2)
+                    if stage == 'run':
+                        el2_str = ''
+                        for spart in suite.groups:
+                            if suite.is_run_group(spart):
+                                pname = spart.name[len(suite.name)+1:]
+                                api.write("{}if (trim(suite_part) == '{}') then".format(el2_str, pname), 3)
+                                api.write("call {}({})".format(spart.name, self._host_arg_list_full), 4)
+                                el2_str = 'else '
+                            # End if
+                        # End for
+                        api.write("else", 3)
+                        api.write("{errmsg} = 'No suite part named '//trim(suite_part)".format(errmsg=errmsg_name), 4)
+                        api.write("{errmsg} = trim({errmsg})//' found in suite {sname}'".format(errmsg=errmsg_name, sname=suite.name), 4)
+                        api.write("{errflg} = 1".format(errflg=errflg_name), 4)
+                        api.write("end if", 3)
+                    else:
+                        api.write("call {}_{}({})".format(suite.name, stage, self._host_arg_list_noloop), 3)
+                    # End if
+                    else_str = 'else '
+                # End for
+                api.write("else", 2)
+                api.write("{errmsg} = 'No suite named '//trim(suite_name)//' found'".format(errmsg=errmsg_name), 3)
+                api.write("{errflg} = 1".format(errflg=errflg_name), 3)
+                api.write("end if", 2)
+                api.write(API.__subfoot__.format(subname=subname), 1)
+            # End for
+            # Write the list_suites subroutine
+            api.write("subroutine {}(suites)".format(API.__suite_fname__), 1)
+            nsuites = 0
+            for suite in self._suites:
+                nsuites = nsuites + 1
+            # End for
+            api.write("character(len=*), allocatable, intent(out) :: suites(:)", 2)
+            api.write("\ninteger                                    :: sindex", 2)
+            api.write("\nallocate(suites({}))".format(nsuites), 2)
+            api.write("do sindex = 1, {}".format(nsuites), 2)
+            for suite in self._suites:
+                api.write("suites(sindex) = '{}'".format(suite.name), 3)
+            # End for
+            api.write("end do", 2)
+            api.write("end subroutine {}".format(API.__suite_fname__), 1)
+            # Write out the suite part list subroutine
+            inargs = "suite_name, part_list, {errmsg}, {errflg}".format(errmsg=errmsg_name,
+                                                                        errflg=errflg_name)
+            api.write("\nsubroutine {}({})".format(API.__part_fname__, inargs), 1)
+            api.write("character(len=*),              intent(in)  :: suite_name", 2)
+            api.write("character(len=*), allocatable, intent(out) :: part_list(:)", 2)
+            self._errmsg_var.write_def(api, 2, self)
+            self._errflg_var.write_def(api, 2, self)
+            api.write("\ninteger                                   :: pindex\n", 2)
+            else_str = ''
+            for suite in self._suites:
+                api.write("{}if(trim(suite_name) == '{}') then".format(else_str, suite.name), 2)
+                parts = suite.part_list()
+                nparts = len(parts)
+                api.write("allocate(part_list({}))\n".format(nparts), 3)
+                api.write("do pindex = 1, {}".format(nparts), 3)
+                for part in parts:
+                    api.write("part_list(pindex) = '{}'".format((part)), 4)
+                # End for
+                api.write("end do", 3)
+                else_str = 'else '
+            # End for
+            api.write("else", 2)
+            api.write("{errmsg} = 'No suite named '//trim(suite_name)//' found'".format(errmsg=errmsg_name), 3)
+            api.write("{errflg} = 1".format(errflg=errflg_name), 3)
+            api.write("end if", 2)
+            api.write("end subroutine {}".format(API.__part_fname__), 1)
+            # Finish off the module
+            api.write(API.__footer__.format(module=self.module), 0)
+        # End with
+        api_filenames.append(filename)
+        return api_filenames
+
+###############################################################################
+if __name__ == "__main__":
+    from parse_tools import initLog, setLogToNull
+    logger = initLog('ccpp_suite')
+    setLogToNull(logger)
+    try:
+        # First, run doctest
+        import doctest
+        doctest.testmod()
+        frame_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        cpf = os.path.dirname(frame_root)
+        kessler = os.path.join(cpf, 'cam_driver', 'suites',
+                               'suite_cam_kessler_test_simple1.xml')
+        if os.path.exists(kessler):
+            foo = Suite(kessler, VarDictionary('foo'), logger)
+        else:
+            raise CCPPError("Cannot find test file, '{}'".format(kessler))
+    except CCPPError as sa:
+        print("{}".format(sa))
+# No else

--- a/scripts/convert_metadata.py
+++ b/scripts/convert_metadata.py
@@ -1,0 +1,218 @@
+import sys
+import os.path
+import re
+
+yes_re = re.compile(r"(?i)^\s*yes\s*$")
+required_attrs = ['standard_name', 'units', 'dimensions', 'type']
+warning = True
+
+########################################################################
+
+def next_line(lines, max_line, cindex=-1):
+    nindex = cindex + 1
+    if nindex > max_line:
+        return None, -1
+    else:
+        return lines[nindex].rstrip('\n'), nindex
+
+########################################################################
+
+def subst_missing_dim(var_name, index, subst_dim_name, dim_names):
+    missing_dim_str = "WARNING: Missing variable? Substituting {} for ':' in {}"
+    if dim_names[index] == ':':
+        dim_names[index] = subst_dim_name
+        if warning:
+            print(missing_dim_str.format(subst_dim_name, var_name))
+        # End if
+    # End if
+
+
+def convert_file(filename_in, filename_out):
+    """Convert a file's old metadata to the new format
+    Note that only the bare minimum error checking is done.
+    """
+    # First, suck in the old file
+    do_convert = True
+    if not os.path.exists(filename_in):
+        raise IOError("convert_file: file, '{}', does not exist".format(filename_in))
+    # End if
+    if os.path.exists(filename_out):
+        yes = raw_input("Overwrite '{}' (Yes/No)? ".format(filename_out))
+        if yes_re.match(yes) is None:
+            return
+        # End if
+    # End if
+    # Read all lines of the file at once
+    with open(filename_in, 'r') as file:
+        fin_lines = file.readlines()
+        for index in xrange(len(fin_lines)):
+            fin_lines[index] = fin_lines[index].rstrip('\n')
+        # End for
+    # End with
+    max_line = len(fin_lines) - 1
+    with open(filename_out, 'w') as file:
+        line, lindex = next_line(fin_lines, max_line)
+        while line is not None:
+            # Check for beginning of new table
+            words = line.split()
+            # This is case sensitive
+            if len(words) > 2 and words[0] in ['!!', '!>'] and '\section' in words[1] and 'arg_table_' in words[2]:
+                # We have a new table, parse the header
+                table_name = words[2].replace('arg_table_','')
+                # The header line is not modified
+                file.write(line+"\n")
+                line, lindex = next_line(fin_lines, max_line, cindex=lindex)
+                words = line.split('|')
+                header_locs = {}
+                dim_names = [':']*15
+                # Do not work on a blank table
+                if len(words) > 1:
+                    table_header = [x.strip() for x in words[1:-1]]
+                    for ind in xrange(len(table_header)):
+                        header_locs[table_header[ind]] = ind
+                    # End for
+                    # Find the local_name index (exception if not found)
+                    local_name_ind = header_locs['local_name']
+                    # The table header line is not output
+                    line, lindex = next_line(fin_lines, max_line, cindex=lindex)
+                    # This is the delimiter line, do not output
+                    # Parse the entries
+                    while len(words) > 1:
+                        line, lindex = next_line(fin_lines, max_line, cindex=lindex)
+                        words = line.split('|')
+                        if len(words) <= 1:
+                            # End of table, just write and continue
+                            file.write(line+'\n')
+                            continue
+                        # End if
+                        entries = [x.strip() for x in words[1:-1]]
+                        # Okay, one check
+                        if len(entries) != len(header_locs):
+                            raise ValueError("Malformed table entry")
+                        # End if
+                        # First output the local name
+                        var_name = entries[local_name_ind]
+                        file.write("!! [ {} ]\n".format(var_name))
+                        # Now, output the rest of the entries
+                        for ind in xrange(len(entries)):
+                            attr_name = table_header[ind]
+                            entry = entries[ind]
+                            if attr_name == 'local_name':
+                                # Already handled this
+                                continue
+                            elif attr_name == 'rank':
+                                attr_name = 'dimensions'
+                            elif attr_name == 'standard_name':
+                                # The standard name needs to be lowercase
+                                std_name = entry.lower()
+                                # Standard names cannot have dashes
+                                std_name = std_name.replace('-', '_')
+                                # Standard names cannot have periods
+                                std_name = std_name.replace('.', '_')
+                                entries[ind] = std_name
+                                entry = std_name
+                            elif attr_name == 'intent':
+                                if entry.lower() == 'none':
+                                    raise ValueError("{} has units = none in {}".format(var_name, table_name))
+                                # End if
+                            # No else needed
+                            # End if
+                            # Guess dimension names for arrays
+                            std_name = entries[header_locs['standard_name']]
+                            if std_name == 'vertical_dimension':
+                                dim_names[1] = std_name
+                            elif std_name == 'horizontal_dimension':
+                                dim_names[0] = std_name
+                            elif std_name == 'horizontal_loop_extent':
+                                if dim_names[0] == ':':
+                                    dim_names[0] = std_name
+                                # End if
+                            elif std_name == 'number_of_tracers':
+                                dim_names[2] = std_name
+                            elif std_name[0:18] == 'number_of_tracers_':
+                                if len(dim_names[2]) == 0:
+                                    dim_names[2] = std_name
+                                # End if
+                            # End if
+                            # Fix dimensions entry
+                            if attr_name == 'dimensions':
+                                rank = int(entry)
+                                if rank > 0:
+                                    subst_missing_dim(var_name, 0,
+                                                      'horizontal_dimension',
+                                                      dim_names)
+                                # End if
+                                if rank > 1:
+                                    subst_missing_dim(var_name, 1,
+                                                      'vertical_dimension',
+                                                      dim_names)
+                                # End if
+                                if rank > 2:
+                                    subst_missing_dim(var_name, 2,
+                                                      'number_of_tracers',
+                                                      dim_names)
+                                # End if
+                                entry = "("
+                                for dind in xrange(rank):
+                                    if dind > 0:
+                                        entry = entry + ", "
+                                    # End if
+                                    entry = "{}{}".format(entry, dim_names[dind])
+                                # End for
+                                entry = entry + ")"
+                            # End if
+                            # Output attribute
+                            if (len(entry) > 0) or (attr_name in required_attrs):
+                                file.write("!!    {} = {}\n".format(attr_name, entry))
+                            # End if
+                        # End for (done with entry)
+                    # End while (done with table)
+                else:
+                    # Just write the line (should be a table ending)
+                    if line.strip() != '!!':
+                        raise ValueError("All tables must end with !! line")
+                    # End if
+                    file.write(line+'\n')
+                # End if (blank table)
+            else:
+                # Not a table, just write and continue
+                file.write(line+'\n')
+            # End if
+            # Always load a new line
+            line, lindex = next_line(fin_lines, max_line, cindex=lindex)
+        # End while
+
+########################################################################
+
+def usage(cmd):
+    print("Usage:")
+    print("{} <source_file> <target_file>".format(cmd))
+    print("{} <source_file> [ <source_file> ...] [ <target_directory>".format(cmd))
+    print("")
+    print("Translate the metadata in each <source_file> into a new file")
+
+########################################################################
+
+if __name__ == "__main__":
+    # Process the files passed in
+    num_args = len(sys.argv)
+    if num_args < 3:
+        usage(sys.argv[0])
+    else:
+        if os.path.isdir(sys.argv[-1]):
+            target_dir = os.path.abspath(sys.argv[-1])
+            num_args = num_args - 1
+            for index in xrange(1, num_args):
+                source_file = os.path.abspath(sys.argv[index])
+                filename = os.path.basename(source_file)
+                dest_file = os.path.join(target_dir, filename)
+                convert_file(source_file, dest_file)
+        else:
+            if num_args != 3:
+                usage(sys.argv[0])
+            else:
+                convert_file(sys.argv[1], sys.argv[2])
+            # End if
+        # End if
+    # End if
+# End if

--- a/scripts/fortran_tools/__init__.py
+++ b/scripts/fortran_tools/__init__.py
@@ -1,0 +1,16 @@
+"""Public API for the fortran_parser library
+"""
+
+__all__ = [
+    'parse_fortran_file',
+    'FortranWriter'
+]
+
+import six
+if six.PY3:
+    from fortran_tools.parse_fortran_file import parse_fortran_file
+    from fortran_tools.fortran_write      import FortranWriter
+else:
+    from parse_fortran_file import parse_fortran_file
+    from fortran_write      import FortranWriter
+# End if

--- a/scripts/fortran_tools/fortran_write.py
+++ b/scripts/fortran_tools/fortran_write.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+#
+
+"""Code to write Fortran code
+"""
+
+# Python library imports
+from __future__ import print_function
+# CCPP framework imports
+
+class FortranWriter(object):
+    """Class to turn output into properly continued and indented Fortran code
+    >>> FortranWriter("foo.F90", 'r') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: Read mode not allowed in FortranWriter object
+    >>> FortranWriter("foo.F90", 'wb') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: Binary mode not allowed in FortranWriter object
+    """
+
+    ###########################################################################
+    # Class variables
+    ###########################################################################
+    INDENT          =   3 # Spaces per indent level
+    CONTINUE_INDENT =   5 # Extra spaces on continuation line
+    LINE_FILL       =  78 # Target line length
+    LINE_MAX        = 130 # Max line length
+
+    ###########################################################################
+
+    def indent(self, level=0, continue_line=False):
+        'Return an indent string for any level'
+        indent = self._indent * level
+        if continue_line:
+            indent = indent + self._continue_indent
+        # End if
+        return indent*' '
+
+    ###########################################################################
+
+    def find_best_break(self, choices, last=None):
+        if last is None:
+            last = self._line_fill
+        # End if
+        'Find largest good break'
+        possible = [x for x in choices if x < last]
+        if len(possible) == 0:
+            best = self._line_max + 1
+        else:
+            best = max(possible)
+        # End if
+        if (best > self._line_max) and (last < self._line_max):
+            best = self.find_best_break(choices, last=self._line_max)
+        # End if
+        return best
+
+    ###########################################################################
+
+    def write(self, statement, indent_level, continue_line=False):
+        if '\n' in statement:
+            for stmt in statement.split('\n'):
+                self.write(stmt, indent_level, continue_line)
+            # End for
+        else:
+            istr = self.indent(indent_level, continue_line)
+            outstr = istr + statement.strip()
+            line_len = len(outstr)
+            if line_len > self._line_fill:
+                # Collect pretty break points
+                spaces = list()
+                commas = list()
+                sptr = len(istr)
+                in_single_char = False
+                in_double_char = False
+                while sptr < line_len:
+                    if in_single_char:
+                        if outstr[sptr] == "'":
+                            in_single_char = False
+                        # End if (no else, just copy stuff in string)
+                    elif in_double_char:
+                        if outstr[sptr] == '"':
+                            in_double_char = False
+                        # End if (no else, just copy stuff in string)
+                    elif outstr[sptr] == "'":
+                        in_single_char = True
+                    elif outstr[sptr] == '"':
+                        in_double_char = True
+                    elif outstr[sptr] == '!':
+                        # Commend in non-character context, suck in rest of line
+                        sptr = line_len - 1
+                    elif outstr[sptr] == ' ':
+                        # Non-quote spaces are where we can break
+                        spaces.append(sptr)
+                    elif outstr[sptr] == ',':
+                        # Non-quote commas are where we can break
+                        commas.append(sptr)
+                    # End if (no else, other characters will be ignored)
+                    sptr = sptr + 1
+                # End while
+                best = self.find_best_break(spaces)
+                if best >= self._line_fill:
+                    best = self.find_best_break(commas)
+                # End if
+                if len(outstr) > best:
+                    fill = "{}&".format((self._line_fill-best)*' ')
+                else:
+                    fill = ''
+                # End if
+                self._file.write("{}{}\n".format(outstr[0:best+1], fill))
+                statement = outstr[best+1:]
+                self.write(statement, indent_level, continue_line=True)
+            else:
+                self._file.write("{}\n".format(outstr))
+            # End if
+        # End if
+
+    ###########################################################################
+
+    def __init__(self, filename, mode, indent=None,
+                 continue_indent=None, line_fill=None, line_max=None):
+        # We only handle writing situations (for now) and only text
+        if ('r' in mode):
+            raise ValueError('Read mode not allowed in FortranWriter object')
+        elif ('b' in mode):
+            raise ValueError('Binary mode not allowed in FortranWriter object')
+        else:
+            self._file = open(filename, mode)
+        # End if
+        if indent is None:
+            self._indent=FortranWriter.INDENT
+        else:
+            self._indent = indent
+        # End if
+        if continue_indent is None:
+            self._continue_indent=FortranWriter.CONTINUE_INDENT
+        else:
+            self._continue_indent = continue_indent
+        # End if
+        if line_fill is None:
+            self._line_fill=FortranWriter.LINE_FILL
+        else:
+            self._line_fill = line_fill
+        # End if
+        if line_max is None:
+            self._line_max=FortranWriter.LINE_MAX
+        else:
+            self._line_max = line_max
+        # End if
+
+    ###########################################################################
+
+    def __enter__(self, *args):
+        return self
+
+    ###########################################################################
+
+    def __exit__(self, *args):
+        self._file.close()
+        return False
+
+###############################################################################
+if __name__ == "__main__":
+    # First, run doctest
+    import doctest
+    doctest.testmod()
+    # Make sure we can write a file
+    import sys
+    import os
+    import os.path
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import six
+    name = 'foo'
+    while os.path.exists(name+'.F90'):
+        name = name + 'xo'
+    # End while
+    name = name + '.F90'
+    if os.access(os.getcwd(), os.W_OK):
+        check = ['      subroutine foo(long_argument1, long_argument2, long_argument3,           &',
+                 '           long_argument4)',
+                 '      end subroutine foo']
+        with FortranWriter(name, 'w') as foo:
+            foo.write("subroutine foo(long_argument1, long_argument2, long_argument3, long_argument4)", 2)
+            foo.write("end subroutine foo", 2)
+        # End with
+        # Check file
+        with open(name, 'r') as foo:
+            statements = foo.readlines()
+            if len(statements) != len(check):
+                print("ERROR: File has {} statements, should have {}".format(len(statements), len(check)))
+            else:
+                for line_num in xrange(len(statements)):
+                    if statements[line_num].rstrip() != check[line_num]:
+                        print("ERROR: Line {} does not match".format(line_num+1))
+                    # End if
+                # End for
+        # End with
+        os.remove(name)
+    else:
+        print("WARNING: Unable to write test file, '{}'".format(name))
+    # End if
+# No else

--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python
+
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    import os.path
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import re
+from parse_tools import ParseContext, ParseSyntaxError, ParseInternalError
+from parse_tools import check_fortran_intrinsic, check_fortran_type
+
+# A collection of types and tools for parsing Fortran code to support
+# CCPP metadata parsing. The purpose of this code is limited to type
+# checking of routines with CCPP metadata caps, therefore full routines are
+# not parsed and a full Fortran syntax tree is not warranted.
+
+########################################################################
+
+class Ftype(object):
+    """Ftype is the base class for all Fortran types
+    It is also the final type for intrinsic types except for character
+    >>> Ftype('integer').typestr
+    'integer'
+    >>> Ftype('integer', kind_in='( kind= I8').print_decl() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid kind_selector, '( kind= I8', at <standard input>:1
+    >>> Ftype('integer', kind_in='(kind=I8)').print_decl()
+    'integer(kind=I8)'
+    >>> Ftype('integer', kind_in='(I8)').print_decl()
+    'integer(kind=I8)'
+    >>> Ftype('real', kind_in='(len=*,R8)').print_decl() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid kind_selector, '(len=*,R8)', at <standard input>:1
+    >>> Ftype(typestr_in='real', line_in='real(kind=kind_phys)') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseInternalError: typestr_in and line_in cannot both be used in a single call, at <standard input>:1
+    >>> Ftype(typestr_in='real', line_in='real(kind=kind_phys)', context=ParseContext(linenum=37, filename="foo.F90")) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseInternalError: typestr_in and line_in cannot both be used in a single call, at foo.F90:37
+    >>> Ftype(line_in='real(kind=kind_phys)').print_decl()
+    'real(kind=kind_phys)'
+    >>> Ftype(line_in="integer").print_decl()
+    'integer'
+    >>> Ftype(line_in="INTEGER").print_decl()
+    'INTEGER'
+    """
+
+    # Note that "character" is not in intrinsic_types even though it is a
+    # Fortran intrinsic. This is because character has its own type.
+    intrinsic_types = [ r"integer", r"real", r"logical",
+                        r"double\s*precision", r"complex" ]
+
+    itype_re = re.compile(r"(?i)({})\s*(\([A-Za-z0-9,=_\s]+\))?".format(r"|".join(intrinsic_types)))
+    kind_re = re.compile(r"(?i)kind\s*(\()?\s*([\'\"])?(.+?)([\'\"])?\s*(\))?")
+
+    def __init__(self, typestr_in=None, kind_in=None, line_in=None, context=None):
+        if context is None:
+            self._context = ParseContext()
+        else:
+            self._context = ParseContext(context=context)
+        # We have to distinguish which type of initialization we have
+        if typestr_in is not None:
+            if line_in is not None:
+                raise ParseInternalError("typestr_in and line_in cannot both be used in a single call", self._context)
+            # End if
+            self.typestr = typestr_in
+            self.default_kind = kind_in is None
+            if kind_in is None:
+                self.kind = None
+            elif kind_in[0] == '(':
+                # Parse an explicit kind declaration
+                self.kind = self.parse_kind_selector(kind_in)
+            else:
+                # The kind has already been parsed for us (e.g., by character)
+                self.kind = kind_in
+        elif kind_in is not None:
+            raise ParseInternalError("kind_in cannot be passed without typestr_in", self._context)
+        elif line_in is not None:
+            match = Ftype.itype_re.match(line_in.strip())
+            if match is None:
+                raise ParseSyntaxError("type declaration", token=line_in, context=self._context)
+            elif check_fortran_intrinsic(match.group(1)):
+                self.typestr = match.group(1)
+                if match.group(2) is not None:
+                    # Parse kind section
+                    self.kind = self.parse_kind_selector(match.group(2).strip())
+                else:
+                    self.kind = None
+                # End if
+                self.default_kind = self.kind is None
+            else:
+                raise ParseSyntaxError("type declaration", token=line_in, context=self._context)
+        else:
+            raise ParseInternalError("At least one of typestr_in or line must be passed", self._context)
+
+    def parse_kind_selector(self, kind_selector, context=None):
+        if context is None:
+            if hasattr(self, 'context'):
+                context = self._context
+            else:
+                context = ParseContext()
+            # End if
+        kind = None
+        if (kind_selector[0] == '(') and (kind_selector[-1] == ')'):
+            args = kind_selector[1:-1].split('=')
+        else:
+            args = kind_selector.split('=')
+        # End if
+        if (len(args) > 2) or (len(args) < 1):
+            raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+        elif len(args) == 1:
+            kind = args[0].strip()
+        elif args[0].strip().lower() != 'kind':
+            # We have two args, the first better be kind
+            raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+        else:
+            # We have two args and the second is our kind string
+            kind = args[1].strip()
+        # End if
+        # One last check for missing right paren
+        match = Ftype.kind_re.search(kind)
+        if match is not None:
+            if match.group(2) is not None:
+                if match.group(2) != match.group(4):
+                    raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+                elif (match.group(1) is None) and (match.group(5) is not None):
+                    raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+                elif (match.group(1) is not None) and (match.group(5) is None):
+                    raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+                else:
+                    pass
+            else:
+                pass
+        elif kind[0:4].lower() == "kind":
+            raise ParseSyntaxError("kind_selector", token=kind_selector, context=context)
+        else:
+            pass
+        return kind
+
+    def print_decl(self):
+        """Return a string of the declaration of the type"""
+        if self.default_kind:
+            return self.typestr
+        elif check_fortran_intrinsic(self.typestr):
+            return "{}(kind={})".format(self.typestr, self.kind)
+        else:
+            # Derived type
+            return "{}({})".format(self.typestr, self.kind)
+
+########################################################################
+
+class Ftype_character(Ftype):
+    """Ftype_character is a type that represents character types
+    >>> Ftype_character.type_match('character') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+    >>> Ftype_character.type_match('CHARACTER') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+    >>> Ftype_character.type_match('chaRActer (len=*)') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+    >>> Ftype_character.type_match('integer')
+
+    >>> Ftype_character('character', ParseContext(169, 'foo.F90')).print_decl()
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid character declaration, 'character', at foo.F90:170
+    >>> Ftype_character('character ::', ParseContext(171, 'foo.F90')).print_decl()
+    'character(len=1)'
+    >>> Ftype_character('CHARACTER(len=*)', ParseContext(174, 'foo.F90')).print_decl()
+    'CHARACTER(len=*)'
+    >>> Ftype_character('CHARACTER(len=:)', None).print_decl()
+    'CHARACTER(len=:)'
+    >>> Ftype_character('character(*)', None).print_decl()
+    'character(len=*)'
+    >>> Ftype_character('character*7', None).print_decl() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid character declaration, 'character*7', at <standard input>:1
+    >>> Ftype_character('character*7,', None).print_decl()
+    'character(len=7)'
+    >>> Ftype_character("character (kind=kind('a')", None).print_decl() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid kind_selector, 'kind=kind('a'', at <standard input>:1
+    >>> Ftype_character("character (kind=kind('a'))", None).print_decl()
+    "character(len=1, kind=kind('a'))"
+    >>> Ftype_character("character  (13, kind=kind('a'))", None).print_decl()
+    "character(len=13, kind=kind('a'))"
+    >>> Ftype_character("character  (len=13, kind=kind('a'))", None).print_decl()
+    "character(len=13, kind=kind('a'))"
+    >>> Ftype_character("character  (kind=kind('b'), len=15)", None).print_decl()
+    "character(len=15, kind=kind('b'))"
+    """
+
+    char_re = re.compile(r"(?i)(character)\s*(\([A-Za-z0-9,=*:\s\'\"()]+\))?")
+    chartrail_re = re.compile(r"\s*[,:]|\s+[A-Z]")
+    oldchar_re = re.compile(r"(?i)(character)\s*(\*)\s*([0-9]+\s*)")
+    oldchartrail_re = re.compile(r"\s*[,]|\s+[A-Z]")
+    len_token_re = re.compile(r"(?i)([:]|[*]|[0-9]+|[A-Z][A-Z0-9_]*)$")
+
+    @classmethod
+    def type_match(cls, line):
+        """Return an RE match if <line> represents an Ftype_character declaration"""
+        # Try old style first to eliminate as a possibility
+        match = Ftype_character.oldchar_re.match(line.strip())
+        if match is None:
+            match = Ftype_character.char_re.match(line.strip())
+        # End if
+        return match
+
+    def __init__(self, line, context):
+        """Initialize a character type from a declaration line"""
+
+        clen = None
+        kind = None # This will be interpreted as default kind
+        match = Ftype_character.type_match(line)
+        if match is None:
+            raise ParseSyntaxError("character declaration", token=line, context=context)
+        elif len(match.groups()) == 3:
+            # We have an old style character declaration
+            if match.group(2) != '*':
+                raise ParseSyntaxError("character declaration", token=line, context=context)
+            elif Ftype_character.oldchartrail_re.match(line.strip()[len(match.group(0)):]) is None:
+                raise ParseSyntaxError("character declaration", token=line, context=context)
+            else:
+                clen = match.group(3)
+            # End if
+        elif match.group(2) is not None:
+            # Parse attributes (strip off parentheses
+            attrs = [ x.strip() for x in match.group(2)[1:-1].split(',') ]
+            if len(attrs) == 0:
+                # Empty parentheses is not allowed
+                raise ParseSyntaxError("char_selector", token=match.group(2), context=context)
+            if len(attrs) > 2:
+                # Too many attributes!
+                raise ParseSyntaxError("char_selector", token=match.group(2), context=context)
+            elif attrs[0][0:4].lower() == "kind":
+                # The first arg is kind, try to parse it
+                kind = self.parse_kind_selector(attrs[0], context=context)
+                # If there is a second arg, it must be of form len=<length_selector>
+                if len(attrs) == 2:
+                    clen = self.parse_len_select(attrs[1], context, len_optional=False)
+            elif len(attrs) == 2:
+                # We have both a len and a kind, len first
+                clen = self.parse_len_select(attrs[0], context, len_optional=True)
+                kind = self.parse_kind_selector(attrs[1], context)
+            else:
+                # We just a len argument
+                clen = self.parse_len_select(attrs[0], context, len_optional=True)
+            # End if
+        else:
+            # We had better check the training characters
+            if Ftype_character.chartrail_re.match(line.strip()[len(match.group(0)):]) is None:
+                raise ParseSyntaxError("character declaration", token=line, context=context)
+        # End if
+        if clen is None:
+            clen = 1
+        # End if
+        self.lenstr = "{}".format(clen)
+        super(Ftype_character, self).__init__(typestr_in=match.group(1), kind_in=kind, context=context)
+
+    def parse_len_token(self, token, context):
+        """Check to make sure token is a valid length identifier"""
+        match = Ftype_character.len_token_re.match(token)
+        if match is not None:
+            return match.group(1)
+        else:
+            raise ParseSyntaxError("length type-param-value", token=token, context=context)
+
+    def parse_len_select(self, lenselect, context, len_optional=True):
+        """Parse a character type length_selector"""
+        largs = [ x.strip() for x in lenselect.split('=') ]
+        if len(largs) > 2:
+            raise ParseSyntaxError("length_selector", token=lenselect, context=context)
+        elif (not len_optional) and ((len(largs) != 2) or (largs[0].lower() != 'len')):
+            raise ParseSyntaxError("length_selector when len= is required", token=lenselect, context=context)
+        elif len(largs) == 2:
+            if largs[0].lower() != 'len':
+                raise ParseSyntaxError("length_selector", token=lenselect, context=context)
+            else:
+                return self.parse_len_token(largs[1], context)
+        elif len_optional:
+            return self.parse_len_token(largs[0], context)
+        else:
+            raise ParseSyntaxError("length_selector when len= is required", token=lenselect, context=context)
+
+    def print_decl(self):
+        """Return a string of the declaration of the type
+        For characters, we will always print an explicit len modifier
+        """
+        if self.default_kind:
+            kind_str = ""
+        else:
+            kind_str = ", kind={}".format(self.kind)
+        # End if
+        return "{}(len={}{})".format(self.typestr, self.lenstr, kind_str)
+
+    def to_xml(self, element, include_context=False):
+        """Output a variable's character type information to an XML element"""
+        super(Ftype_character, self).to_xml(element, include_context)
+        sub_element = ET.SubElement(element, 'len')
+        sub_element.text = self.lenstr
+
+########################################################################
+
+class Ftype_type_decl(Ftype):
+    """Ftype_type_decl is a type that represents derived Fortran type
+    declarations.
+    >>> Ftype_type_decl.type_match('character')
+
+    >>> Ftype_type_decl.type_match('type') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+    """
+
+    type_decl_re = re.compile(r"(?i)(type)\s*(\(\s*[A-Z][A-Z0-9_]*\s*\))?")
+
+    @classmethod
+    def type_match(cls, line):
+        """Return an RE match if <line> represents an Ftype_type_decl declaration"""
+        match = Ftype_type_decl.type_decl_re.match(line.strip())
+        # End if
+        return match
+
+    def __init__(self, line, context):
+        """Initialize an extended type from a declaration line"""
+        match = Ftype_type_decl.type_match(line)
+        if match is None:
+            raise ParseSyntaxError("character declaration", token=line, context=context)
+        elif len(match.groups()) == 3:
+            # We have an old style character declaration
+            if match.group(2) != '*':
+                raise ParseSyntaxError("character declaration", token=line, context=context)
+            elif Ftype_character.oldchartrail_re.match(line.strip()[len(match.group(0)):]) is None:
+                raise ParseSyntaxError("character declaration", token=line, context=context)
+            else:
+                clen = match.group(3)
+            # End if
+        elif match.group(2) is not None:
+            # Parse attributes (strip off parentheses
+            attrs = [ x.strip() for x in match.group(2)[1:-1].split(',') ]
+
+    def to_xml(self, element, include_context=False):
+        """Output a variable's extended type information to an XML element"""
+        super(Ftype_type_decl, self).to_xml(element, include_context)
+        sub_element = ET.SubElement(element, 'len')
+        sub_element.text = self.lenstr
+
+########################################################################
+# Future classes
+#class Ftype_type_def(Ftype_type_decl) # Not sure about that super class
+#class Fmodule_spec(object) # vars and types from a module specification part
+# Fmodule_spec will contain a list of documented variables and a list of
+# documented type definitions
+#class Fmodule_subprog(object) # routines from a module subprogram part
+#class Fmodule(object) # Info about and parsing for a Fortran module
+#Fmodule will contain an Fmodule_spec and a Fmodule_subprog
+########################################################################
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/fortran_tools/parse_fortran_file.py
+++ b/scripts/fortran_tools/parse_fortran_file.py
@@ -1,0 +1,572 @@
+#! /usr/bin/env python
+"""
+Tool to parse a Fortran file and return signature information
+from metadata tables.
+At the file level, we allow only PROGRAM blocks and MODULE blocks.
+Subroutines, functions, or data are not supported outside a MODULE.
+"""
+
+import os.path
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import re
+from parse_tools import CCPPError, ParseInternalError, ParseSyntaxError
+from parse_tools import ParseContext, ParseObject
+from parse_tools import FortranMetadataSyntax, FORTRAN_ID
+from metadata_table import MetadataHeader
+
+comment_re = re.compile(r"!.*$")
+fixed_comment_re = re.compile(r"(?i)([C*]|(?:[ ]{0,4}!))")
+program_re = re.compile(r"(?i)\s*program\s+"+FORTRAN_ID)
+endprogram_re = re.compile(r"(?i)\s*end\s*program\s+"+FORTRAN_ID+r"?")
+module_re = re.compile(r"(?i)\s*module\s+"+FORTRAN_ID)
+endmodule_re = re.compile(r"(?i)\s*end\s*module\s+"+FORTRAN_ID+r"?")
+contains_re = re.compile(r"(?i)\s*contains")
+continue_re = re.compile(r"(?i)&\s*(!.*)?$")
+fixed_continue_re = re.compile(r"(?i)     [^0 ]")
+blank_re = re.compile(r"\s+")
+
+########################################################################
+
+def line_statements(line):
+    """Break up line into a list of component Fortran statements
+    Note, because this is a simple script, we can cheat on the
+    interpretation of two consecutive quote marks.
+    >>> line_statements('integer :: i, j')
+    ['integer :: i, j']
+    >>> line_statements('integer :: i; real :: j')
+    ['integer :: i', ' real :: j']
+    >>> line_statements('integer :: i ! Do not break; here')
+    ['integer :: i ! Do not break; here']
+    >>> line_statements("write(6, *) 'This is all one statement; y''all;'")
+    ["write(6, *) 'This is all one statement; y''all;'"]
+    >>> line_statements('write(6, *) "This is all one statement; y""all;"')
+    ['write(6, *) "This is all one statement; y""all;"']
+    >>> line_statements(" ! This is a comment statement; y'all;")
+    [" ! This is a comment statement; y'all;"]
+    >>> line_statements("!! ")
+    ['!! ']
+    """
+    statements = list()
+    ind_start = 0
+    ind_end = 0
+    line_len = len(line)
+    in_single_char = False
+    in_double_char = False
+    while ind_end < line_len:
+        if in_single_char:
+            if line[ind_end] == "'":
+                in_single_char = False
+            # End if (no else, just copy stuff in string)
+        elif in_double_char:
+            if line[ind_end] == '"':
+                in_double_char = False
+            # End if (no else, just copy stuff in string)
+        elif line[ind_end] == "'":
+            in_single_char = True
+        elif line[ind_end] == '"':
+            in_double_char = True
+        elif line[ind_end] == '!':
+            # Commend in non-character context, suck in rest of line
+            ind_end = line_len - 1
+        elif line[ind_end] == ';':
+            # The whole reason for this routine, the statement separator
+            if ind_end > ind_start:
+                statements.append(line[ind_start:ind_end])
+            # End if
+            ind_start = ind_end + 1
+            ind_end = ind_start - 1
+        # End if (no else, other characters will be copied)
+        ind_end = ind_end + 1
+    # End while
+    # Cleanup
+    if ind_end > ind_start:
+        statements.append(line[ind_start:ind_end])
+    # End if
+    return statements
+
+########################################################################
+
+def read_statements(pobj, statements=None):
+    """Retrieve the next line and break it into statements"""
+    while (statements is None) or (sum([len(x) for x in statements]) == 0):
+        nline, nline_num = pobj.next_line()
+        if nline is None:
+            statements = None
+            break
+        else:
+            statements = line_statements(nline)
+        # End if
+    # End while
+    return statements
+
+########################################################################
+def scan_fixed_line(line, in_single_char, in_double_char, context):
+    """Scan a fixed-format FORTRAN line for continue indicators, continued
+    quotes, and comments
+    Return continue_in_col, in_single_char, in_double_char,
+           comment_col
+    >>> scan_fixed_line('     & line continued', False, False, ParseContext())
+    (5, False, False, -1)
+    >>> scan_fixed_line('     & line continued"', False, True, ParseContext())
+    (5, False, False, -1)
+    >>> scan_fixed_line('     * line continued', False, False, ParseContext())
+    (5, False, False, -1)
+    >>> scan_fixed_line('     1 line continued', False, False, ParseContext())
+    (5, False, False, -1)
+    >>> scan_fixed_line('C     comment line', False, False, ParseContext())
+    (-1, False, False, 0)
+    >>> scan_fixed_line('*     comment line', False, False, ParseContext())
+    (-1, False, False, 0)
+    >>> scan_fixed_line('!     comment line', False, False, ParseContext())
+    (-1, False, False, 0)
+    >>> scan_fixed_line(' !    comment line', False, False, ParseContext())
+    (-1, False, False, 1)
+    >>> scan_fixed_line('    ! comment line', False, False, ParseContext())
+    (-1, False, False, 4)
+    >>> scan_fixed_line('     ! not comment line', False, False, ParseContext())
+    (5, False, False, -1)
+    >>> scan_fixed_line('!...................................', False, False, ParseContext())
+    (-1, False, False, 0)
+    >>> scan_fixed_line('123   x = x + 1', False, False, ParseContext())
+    (-1, False, False, -1)
+    """
+
+    # Check if comment or continue statement
+    cmatch = fixed_comment_re.match(line)
+    is_comment =  cmatch is not None
+    is_continue = fixed_continue_re.match(line) is not None
+    # A few sanity checks
+    if (in_single_char or in_double_char) and (not is_continue):
+        raise ParseSyntaxError("Cannot start line in character context if not a continued line", context=context)
+    # Endif
+    if in_single_char and in_double_char:
+        raise ParseSyntaxError("Cannot be both in an apostrophe character context and a quote character context", context=context)
+
+    if is_continue:
+        continue_in_col = 5
+        comment_col = -1
+        index = 6
+    elif is_comment:
+        comment_col = len(cmatch.group(1)) - 1
+        continue_in_col = -1
+        index = len(line.rstrip())
+    else:
+        continue_in_col = -1
+        comment_col = -1
+        index = 0
+    # End if
+
+    last_ind = len(line.rstrip()) - 1
+    # Process the line
+    while index <= last_ind:
+        blank = blank_re.match(line[index:])
+        if blank is not None:
+            index = index + len(blank.group(0)) - 1 # +1 at end of loop
+        elif in_single_char:
+            if line[index:min(index+1,last_ind)] == "''":
+                # Embedded single quote
+                index = index + 1 # +1 and end of loop
+            elif line[index] == "'":
+                in_single_char = False
+                # End if
+            # End if (just ignore any other character)
+        elif in_double_char:
+            if line[index:min(index+1,last_ind)] == '""':
+                # Embedded double quote
+                index = index + 1 # +1 and end of loop
+            elif line[index] == '"':
+                in_double_char = False
+                # End if
+            # End if (just ignore any other character)
+        elif line[index] == "'":
+            # If we got here, we are not in a character context, start single
+            in_single_char = True
+        elif line[index] == '"':
+            # If we got here, we are not in a character context, start double
+            in_double_char = True
+        elif line[index] == '!':
+            # If we got here, we are not in a character context, done with line
+            comment_col = index
+            index = last_ind
+        # End if
+        index = index + 1
+    # End while
+
+    return continue_in_col, in_single_char, in_double_char, comment_col
+
+########################################################################
+
+def scan_free_line(line, in_continue, in_single_char, in_double_char, context):
+    """Scan a Fortran line for continue indicators, continued quotes, and
+    comments
+    Return continue_in_col, continue_out_col, in_single_char, in_double_char,
+           comment_col
+    >>> scan_free_line("! Comment line", False, False, False, ParseContext())
+    (-1, -1, False, False, 0)
+    >>> scan_free_line("!! ", False, False, False, ParseContext())
+    (-1, -1, False, False, 0)
+    >>> scan_free_line("int :: index", False, False, False, ParseContext())
+    (-1, -1, False, False, -1)
+    >>> scan_free_line("int :: inde& ! oops", False, False, False, ParseContext())
+    (-1, 11, False, False, 13)
+    >>> scan_free_line("int :: inde&", False, False, False, ParseContext())
+    (-1, 11, False, False, -1)
+    >>> scan_free_line("character(len=*), parameter :: foo = 'This line & not continued'", False, False, False, ParseContext())
+    (-1, -1, False, False, -1)
+    >>> scan_free_line("character(len=*), parameter :: foo = 'This is continue line& ", False, False, False, ParseContext())
+    (-1, 59, True, False, -1)
+    >>> scan_free_line('character(len=*), parameter :: foo = "This line & not continued"', False, False, False, ParseContext())
+    (-1, -1, False, False, -1)
+    >>> scan_free_line('character(len=*), parameter :: foo = "This is continue line& ', False, False, False, ParseContext())
+    (-1, 59, False, True, -1)
+    >>> scan_free_line('  & line continued"', True, False, True, ParseContext())
+    (2, -1, False, False, -1)
+    >>> scan_free_line('  & line continued"', True, True, False, ParseContext()) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Cannot end non-continued line in a character context, in <standard input>
+    >>> scan_free_line("  & line continued'", True, False, True, ParseContext()) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Cannot end non-continued line in a character context, in <standard input>
+    >>> scan_free_line("int :: inde&", False, True, False, ParseContext())
+    Traceback (most recent call last):
+    ParseSyntaxError: Cannot start line in character context if not a continued line, in <standard input>
+    >>> scan_free_line("int :: inde&", True, True, True, ParseContext())
+    Traceback (most recent call last):
+    ParseSyntaxError: Cannot be both in an apostrophe character context and a quote character context, in <standard input>
+    """
+
+    # A few sanity checks
+    if (in_single_char or in_double_char) and (not in_continue):
+        raise ParseSyntaxError("Cannot start line in character context if not a continued line", context=context)
+    # Endif
+    if in_single_char and in_double_char:
+        raise ParseSyntaxError("Cannot be both in an apostrophe character context and a quote character context", context=context)
+
+    continue_in_col = -1
+    continue_out_col = -1
+    comment_col = -1
+
+    index = 0
+    last_ind = len(line.rstrip()) - 1
+    # Is first non-blank character a continue character?
+    if line.lstrip()[0] == '&':
+        if not in_continue:
+            raise ParseSyntaxError("Cannot begin line with continue character (&), not on continued line", context=context)
+        else:
+            continue_in_col = line.find('&')
+            index = continue_in_col + 1
+        # End if
+    # Process rest of line
+    while index <= last_ind:
+        blank = blank_re.match(line[index:])
+        if blank is not None:
+            index = index + len(blank.group(0)) - 1 # +1 at end of loop
+        elif in_single_char:
+            if line[index:min(index+1,last_ind)] == "''":
+                # Embedded single quote
+                index = index + 1 # +1 and end of loop
+            elif line[index] == "'":
+                in_single_char = False
+            elif (line[index] == '&'):
+                if index == last_ind:
+                    continue_out_col = index
+                # End if
+            # End if (just ignore any other character)
+        elif in_double_char:
+            if line[index:min(index+1,last_ind)] == '""':
+                # Embedded double quote
+                index = index + 1 # +1 and end of loop
+            elif line[index] == '"':
+                in_double_char = False
+            elif line[index] == '&':
+                if index == last_ind:
+                    continue_out_col = index
+                # End if
+            # End if (just ignore any other character)
+        elif line[index] == "'":
+            # If we got here, we are not in a character context, start single
+            in_single_char = True
+        elif line[index] == '"':
+            # If we got here, we are not in a character context, start double
+            in_double_char = True
+        elif line[index] == '!':
+            # If we got here, we are not in a character context, done with line
+            comment_col = index
+            index = last_ind
+        elif line[index] == '&':
+            # If we got here, we are not in a character context, note continue
+            # First make sure this is a valid continue
+            match = continue_re.match(line[index:])
+            if match is not None:
+                continue_out_col = index
+            else:
+                raise ParseSyntaxError("Invalid continue, ampersand not followed by comment character", context=context)
+            # End if
+        # End if
+        index = index + 1
+    # End while
+    # A final check
+    if (in_single_char or in_double_char) and (continue_out_col < 0):
+        raise ParseSyntaxError("Cannot end non-continued line in a character context", context=context)
+
+    return continue_in_col, continue_out_col, in_single_char, in_double_char, comment_col
+
+########################################################################
+
+def read_file(filename, preproc_defs=None):
+    """Read a file into an array of lines.
+    Preprocess lines to consolidate continuation lines.
+    Remove preprocessor directives and code eliminated by #if statements
+    Remvoved code results in blank lines, not removed lines
+    """
+    if not os.path.exists(filename):
+        raise IOError("read_file: file, '{}', does not exist".format(filename))
+    else:
+        # We need special rules for fixed-form source
+        fixed_form = filename[-2:] == '.f'
+        # Read all lines of the file at once
+        with open(filename, 'r') as file:
+            file_lines = file.readlines()
+            for index in xrange(len(file_lines)):
+                file_lines[index] = file_lines[index].rstrip('\n')
+            # End for
+        # End with
+        # create a parse object and context for this file
+        pobj = ParseObject(filename, file_lines, syntax=None)
+        continue_col = -1 # Active continue column
+        in_schar = False # Single quote character context
+        in_dchar = False # Double quote character context
+        prev_line = None
+        prev_line_num = -1
+        curr_line, curr_line_num = pobj.curr_line()
+        while curr_line is not None:
+            # Skip empty lines and comment-only lines
+            if (len(curr_line.strip()) == 0) or (curr_line.lstrip()[0] == '!'):
+                curr_line, curr_line_num = pobj.next_line()
+                continue
+            # End if
+            # scan the line for properties
+            if fixed_form:
+                res = scan_fixed_line(curr_line, in_schar, in_dchar, pobj)
+                cont_in_col, in_schar, in_dchar, comment_col = res
+                continue_col = cont_in_col # No warning in fixed form
+                cont_out_col = -1
+                if (comment_col < 0) and (prev_line is None):
+                    # Real statement, grab the line # in case is is continued
+                    prev_line_num = curr_line_num
+                # End if
+            else:
+                res = scan_free_line(curr_line, (continue_col >= 0),
+                                     in_schar, in_dchar, pobj)
+                cont_in_col, cont_out_col, in_schar, in_dchar, comment_col = res
+            # End if
+            # If in a continuation context, move this line to previous
+            if continue_col >= 0:
+                if fixed_form and (prev_line is None):
+                    prev_line = pobj.peek_line(prev_line_num)
+                # End if
+                if prev_line is None:
+                    raise ParseInternalError("No prev_line to continue", context=pobj)
+                # End if
+                sindex = max(0, cont_in_col)
+                if cont_out_col > 0:
+                    eindex = cont_out_col
+                else:
+                    eindex = len(curr_line)
+                # End if
+                prev_line = prev_line + curr_line[sindex:eindex]
+                # Rewrite the file's lines
+                pobj.write_line(prev_line_num, prev_line)
+                pobj.write_line(curr_line_num, "")
+                if cont_out_col < 0:
+                    # We are done with this line, reset prev_line
+                    prev_line = None
+                    if not fixed_form:
+                        prev_line_num = -1
+                    # End if
+                # End if
+            # End if
+            continue_col = cont_out_col
+            if (continue_col >= 0) and (prev_line is None):
+                # We need to set up prev_line as it is continued
+                prev_line = curr_line[0:continue_col]
+                if not (in_schar or in_dchar):
+                    prev_line = prev_line.rstrip()
+                # End if
+                prev_line_num = curr_line_num
+            # End if
+            curr_line, curr_line_num = pobj.next_line()
+        # End while
+        return pobj
+
+########################################################################
+
+def is_executable_statement(statement, in_module):
+    "Return True iff <statement> is an executable Fortran statement"
+    # Fill this in when we need to parse programs or subroutines
+    if in_module and (contains_re.match(statement) is not None):
+        return True
+    else:
+        return False
+    # End if
+
+########################################################################
+
+def parse_specification(pobj, statements, mod_name=None, prog_name=None, logger=None):
+    "Parse specification part of a module or (sub)program"
+    if (mod_name is not None) and (prog_name is not None):
+        raise ParseInternalError("<mod_name> and <prog_name> cannot both be used")
+    elif mod_name is not None:
+        spec_name = mod_name
+        endmatch = endmodule_re
+        endname = 'MODULE'
+        inmod = True
+    elif prog_name is not None:
+        spec_name = prog_name
+        endmatch = endprogram_re
+        endname = 'PROGRAM'
+        inmod = False
+    else:
+        raise ParseInternalError("One of <mod_name> or <prog_name> must be used")
+    # End if
+    inspec = True
+    mheaders = list()
+    while inspec and (statements is not None):
+        for index in xrange(len(statements)):
+            # End program or module
+            pmatch = endmatch.match(statements[index])
+            if pmatch is not None:
+                # We never found a contains statement
+                inspec = False
+                break
+            elif statements[index].strip().lower() == 'contains':
+                # We are done with the specification
+                inspec = False
+                break
+            elif MetadataHeader.metadata_table_start(statements[index],
+                                                     context=pobj,
+                                                     syntax=FortranMetadataSyntax):
+                mheaders.append(MetadataHeader(pobj, spec_name=spec_name, logger=logger))
+                break
+            elif is_executable_statement(statements[index], inmod):
+                inspec = False
+                break
+            # End if
+        # End for
+        if inspec:
+            statements = read_statements(pobj)
+        # End if
+    # End while
+    return statements, mheaders
+
+########################################################################
+
+def parse_program(pobj, statements, logger=None):
+    # The first statement should be a program statement, grab the name
+    pmatch = program_re.match(statements[0])
+    if pmatch is None:
+        raise ParseSyntaxError('PROGRAM statement', statements[0])
+    # End if
+    prog_name = pmatch.group(1)
+    pobj.enter_region('PROGRAM', region_name=prog_name, nested_ok=False)
+    # After the program name is the specification part
+    statements, mheaders = parse_specification(pobj, statements[1:], prog_name=prog_name, logger=logger)
+    # Look for metadata tables
+    statements = read_statements(pobj, statements)
+    inprogram = True
+    while statements is not None:
+        for index in xrange(len(statements)):
+            # End program
+            pmatch = endprogram_re.match(statements[index])
+            if pmatch is not None:
+                prog_name = pmatch.group(1)
+                pobj.leave_region('PROGRAM', region_name=prog_name)
+                inprogram = False
+            elif MetadataHeader.metadata_table_start(statements[index],
+                                                     context=pobj,
+                                                     syntax=FortranMetadataSyntax):
+                mheaders.append(MetadataHeader(pobj, spec_name=prog_name))
+                break
+            # End if
+        # End for
+        if not inprogram:
+            break
+        else:
+            statements = read_statements(pobj)
+        # End if
+    # End while
+    return statements[index+1:], mheaders
+
+########################################################################
+
+def parse_module(pobj, statements, logger=None):
+    # The first statement should be a module statement, grab the name
+    pmatch = module_re.match(statements[0])
+    if pmatch is None:
+        raise ParseSyntaxError('MODULE statement', statements[0])
+    # End if
+    mod_name = pmatch.group(1)
+    pobj.enter_region('MODULE', region_name=mod_name, nested_ok=False)
+    # After the module name is the specification part
+    statements, mheaders = parse_specification(pobj, statements[1:], mod_name=mod_name, logger=logger)
+    # Look for metadata tables
+    statements = read_statements(pobj, statements)
+    inmodule = True
+    while inmodule and (statements is not None):
+        for index in xrange(len(statements)):
+            # End module
+            pmatch = endmodule_re.match(statements[index])
+            if pmatch is not None:
+                mod_name = pmatch.group(1)
+                pobj.leave_region('MODULE', region_name=mod_name)
+                inmodule = False
+                break
+            elif MetadataHeader.metadata_table_start(statements[index],
+                                                     context=pobj,
+                                                     syntax=FortranMetadataSyntax):
+                mheaders.append(MetadataHeader(pobj, spec_name=mod_name, logger=logger))
+                break
+            # End if
+        # End for
+        if not inmodule:
+            break
+        else:
+            statements = read_statements(pobj)
+        # End if
+    # End while
+    return statements[index+1:], mheaders
+
+########################################################################
+
+def parse_fortran_file(filename, preproc_defs=None, logger=None):
+    mheaders = list()
+    pobj = read_file(filename, preproc_defs=preproc_defs)
+    pobj.reset_pos()
+    curr_line, clo = pobj.curr_line()
+    statements = line_statements(curr_line)
+    newstatements = True
+    while statements is not None:
+        for index in xrange(len(statements)):
+            statement = statements[index]
+            if program_re.match(statement) is not None:
+                statements, pheaders = parse_program(pobj, statements[index:], logger=logger)
+                mheaders.extend(pheaders)
+                newstatements = len(statements) == 0
+            elif module_re.match(statement) is not None:
+                statements, pheaders = parse_module(pobj, statements[index:], logger=logger)
+                mheaders.extend(pheaders)
+                newstatements = len(statements) == 0
+            # End if
+        # End for
+        if newstatements:
+            statements = read_statements(pobj)
+    # End while
+    return mheaders
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/host_cap.py
+++ b/scripts/host_cap.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+"""
+Parse a host-model registry XML file and return the captured variables.
+"""
+
+# Python library imports
+from __future__ import print_function
+import sys
+import os
+import os.path
+import subprocess
+import xml.etree.ElementTree as ET
+# CCPP framework imports
+from ccpp_suite    import COPYRIGHT, CCPP_STATE_MACH, API
+from metavar       import VarDictionary
+from fortran_tools import FortranWriter
+
+###############################################################################
+header = '''
+!>
+!! @brief Auto-generated cap for {host_model} calls to CCPP API
+!!
+!
+module {module}
+
+   use machine
+'''
+
+preamble='''
+   implicit none
+   private
+
+'''
+
+subhead = '''
+   subroutine {host_model}_ccpp_physics_{stage}({api_vars})
+'''
+
+subfoot = '''
+   end subroutine {host_model}_ccpp_physics_{stage}
+'''
+
+footer = '''
+end module {module}
+'''
+
+###############################################################################
+def write_host_cap(host_model, api, output_dir, logger):
+###############################################################################
+    module_name = "{}_ccpp_cap".format(host_model.name)
+    cap_filename = os.path.join(output_dir, '{}.F90'.format(module_name))
+    with FortranWriter(cap_filename, 'w') as cap:
+        cap.write(COPYRIGHT, 0)
+        cap.write(header.format(host_model=host_model.name,
+                                module=module_name), 0)
+        modules = host_model.variable_locations()
+        mlen = max([len(x[0]) for x in modules])
+        for mod in modules:
+            mspc = (mlen - len(mod[0]))*' '
+            cap.write("use {}, {}only: {}".format(mod[0], mspc, mod[1]), 1)
+        # End for
+        cap.write(preamble.format(host_model=host_model.name), 1)
+        # CCPP_STATE_MACH.transitions represents the host CCPP interface
+        for stage in CCPP_STATE_MACH.transitions():
+            cap.write("public :: {host_model}_ccpp_physics_{stage}".format(host_model=host_model.name, stage=stage), 1)
+        # End for
+        cap.write('\ncontains\n', 0)
+        for stage in CCPP_STATE_MACH.transitions():
+            loop_vars = stage == 'run'
+            # All interfaces need the suite name
+            apivars = [api.suite_name_var]
+            if loop_vars:
+                # Only the run phase needs a suite part name
+                apivars.append(api.suite_part_var)
+            # End if
+            hdvars = list() # Host interface dummy args
+            hmvars = list() # Host model to API dummy args
+            # Collect all the variables which do not have a <module> source.
+            # Only the run phase needs loop variables
+            for var in host_model.variable_list(loop_vars=loop_vars):
+                hmvars.append(var)
+                lname = var.get_prop_value('local_name')
+                if host_model.host_variable_module(lname) is None:
+                    hdvars.append(var)
+                # End if
+            # End for
+            lnames = [x.get_prop_value('local_name') for x in apivars + hdvars]
+            api_vlist = ", ".join(lnames)
+            cap.write(subhead.format(api_vars=api_vlist,
+                                     host_model=host_model.name,
+                                     stage=stage), 1)
+            cap.write('use {}, only: {}'.format(api.module,
+                                                API.interface_name(stage)), 2)
+            for var in apivars:
+                var.write_def(cap, 2, host_model)
+            # End for
+            for var in hdvars:
+                var.write_def(cap, 2, host_model)
+            # End for
+            cap.write('', 0)
+            # Now, call the real API with the host model's variable list
+            callstr = 'call ccpp_physics_{}({})'
+            lnames = [x.get_prop_value('local_name') for x in apivars + hmvars]
+            api_vlist = ", ".join(lnames)
+            cap.write(callstr.format(stage, api_vlist), 2)
+            cap.write(subfoot.format(host_model=host_model.name,
+                                     stage=stage), 1)
+        # End for
+        cap.write(footer.format(module=module_name), 0)
+    # End with
+    return cap_filename
+
+###############################################################################
+
+if __name__ == "__main__":
+    from parse_tools import initLog, setLogToNull
+    logger = initLog('host_registry')
+    setLogToNull(logger)
+    # Run doctest
+    import doctest
+    doctest.testmod()
+# No else:

--- a/scripts/host_model.py
+++ b/scripts/host_model.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+"""
+Parse a host-model registry XML file and return the captured variables.
+"""
+
+# Python library imports
+from __future__ import print_function
+import sys
+import os
+import os.path
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+# CCPP framework imports
+from metavar import Var, VarDDT, VarDictionary
+from parse_tools import ParseSource, ParseContext, CCPPError, ParseInternalError
+from parse_tools import read_xml_file, validate_xml_file, find_schema_version
+from parse_tools import check_fortran_intrinsic, FORTRAN_ID
+
+###############################################################################
+class HostModel(VarDictionary):
+    "Class to hold the data from a host model"
+
+    def __init__(self, name, ddt_defs, var_locations, variables, logger=None):
+        self._name = name
+        self._ddt_defs = ddt_defs
+        self._var_locations = var_locations
+        super(HostModel, self).__init__(self.name, variables=variables, logger=logger)
+        self._ddt_vars = {}
+        self._ddt_fields = {}
+        # Make sure we have a DDT definition for every DDT variable
+        self.check_ddt_vars(logger)
+        self.collect_ddt_fields(logger)
+
+    @property
+    def name(self):
+        'Return the host model name'
+        return self._name
+
+    def argument_list(self, loop_vars=True):
+        'Return a string representing the host model variable arg list'
+        args = self.prop_list('local_name', loop_vars=loop_vars)
+        return ', '.join(args)
+
+    def add_ddt_defs(new_ddt_defs, logger=None):
+        "Add new DDT metadata definitions to model"
+        if new_ddt_defs is not None:
+            for header in new_ddt_defs:
+                if header.title in self._ddt_defs:
+                    raise CCPPError("Duplicate DDT, {}, passed to add_ddt_defs".format(header.title))
+                else:
+                    if logger is not None:
+                        logger.debug('Adding ddt, {}'.format(header.title))
+                    # End if
+                    self._ddt_defs[header.title] = header
+                # End if
+            # End for
+            # Make sure we have a DDT definition for every DDT variable
+            self.check_ddt_vars()
+            self.collect_ddt_fields()
+        # End if
+
+    def add_variables(new_variables, logger=None):
+        "Add new variables definitions to model"
+        if new_variables is not None:
+            self.merge(new_variables)
+        # End if
+
+    def check_ddt_vars(self, logger=None):
+        "Check that we have a DDT definition for every DDT variable"
+        for vkey in self.keys():
+            var = self[vkey]
+            vtype = var.get_prop_value('type')
+            if not check_fortran_intrinsic(vtype):
+                vkind = var.get_prop_value('kind')
+                stdname = var.get_prop_value('standard_name')
+                if stdname in self._ddt_vars:
+                    # Make sure this is not a duplicate
+                    if self._ddt_vars[stdname] != self._ddt_defs[vkind]:
+                        raise CCPPError("Duplicate DDT definition for {}".format(vkind))
+                    # End if
+                else:
+                    self._ddt_vars[stdname] = self._ddt_defs[vkind]
+                # End if
+            # End if (no else, intrinsic types)
+        # End for
+
+    def collect_fields_from_ddt(self, ddt, source, logger=None):
+        "Collect all the reachable fields from one DDT definition"
+        for var in ddt.variable_list():
+            vtype = var.get_prop_value('type')
+            stdname = var.get_prop_value('standard_name')
+            if stdname in self._ddt_fields:
+                src = [x.get_prop_name('kind') for x in source]
+                raise CCPPError("Duplicate DDT standard name, {}, from {}".format(stdname), src)
+            else:
+                # Record this intrinsic variable
+                self._ddt_fields[stdname] = VarDDT(stdname, source + [var], logger)
+            # End if
+        # End for
+
+    def collect_ddt_fields(self, logger=None):
+        "Make sure we know the standard names of all reachable fields"
+        for stdname in self._ddt_vars.keys():
+            # The source for the fields in this DDT is the variable
+            ddt = self._ddt_vars[stdname]
+            svar = super(HostModel, self).find_variable(stdname)
+            if svar is None:
+                raise ParseInternalError('No host variable for DDT {} in {}'.format(stdname, self.name))
+            # End if
+            self.collect_fields_from_ddt(ddt, [svar], logger)
+        # End for
+
+    def host_variable_module(self, local_name):
+        "Return the module name for a host variable"
+        if local_name in self._var_locations:
+            return self._var_locations[local_name]
+        else:
+            return None
+        # End if
+
+    def variable_locations(self):
+        """Return a set of module-variable and module-type pairs.
+        These represent the locations of all host model data with a listed
+        source location (variables with no <module> source are omitted)."""
+        varset = set()
+        lnames = self.prop_list('local_name')
+        for name in lnames:
+            module = self.host_variable_module(name)
+            if (module is not None) and (len(module) > 0):
+                varset.add((module, name))
+            # No else, either no module or a zero-length module name
+            # End if
+        # End for
+        return varset
+
+    def find_variable(self, standard_name, any_scope=False, loop_subst=False):
+        """Return the host model variable matching <standard_name> or None
+        If loop_subst is True, substitute a begin:end range for an extent.
+        """
+        my_var = super(HostModel, self).find_variable(standard_name)
+        if (my_var is None) and (standard_name in self._ddt_fields):
+            # Found variable in a DDT element
+            my_var = self._ddt_fields[standard_name]
+        # End if
+        if (my_var is None) and loop_subst:
+            my_var = self.find_loop_subst(standard_name)
+        # End if
+        return my_var
+
+    def add_host_variable_module(self, local_name, module, logger=None):
+        "Add a module name location for a host variable"
+        if local_name in self._var_locations:
+            raise CCPPError("Host variable, {}, already located in module".format(self._var_locations[local_name]))
+        else:
+            if logger is not None:
+                logger.debug('Adding variable, {}, from module, {}'.format(local_name, module))
+            # End if
+            self._var_locations[local_name] = module
+        # End if
+
+    ###########################################################################
+    @classmethod
+    def parse_host_registry(cls, filename, logger, ddt_defs, host_model=None):
+        host_variables = {}
+        tree, root = read_xml_file(filename, logger=logger)
+        # We do not have line number information for the XML file
+        context = ParseContext(filename=filename)
+        version = find_schema_version(root, logger=logger)
+        res = validate_xml_file(filename, 'host_registry', version, logger=logger)
+        if not res:
+            abort("Invalid host registry file, '{}'".format(filename), logger)
+        # End if
+        host_name = root.get('name')
+        variables = VarDictionary(host_name, logger=logger)
+        logger.info("Reading host model registry for {}".format(host_name))
+        for child in root:
+            if (child.tag == 'variable') or (child.tag == 'constant'):
+                prop_dict = child.attrib
+                vname = prop_dict['local_name']
+                for var_prop in child:
+                    if var_prop.tag == 'module':
+                        # We need to keep track of where host variables come from
+                        host_variables[vname] = var_prop.text
+                        logger.debug("{} defined in {}".format(vname, host_variables[vname]))
+                    # End if
+                    if var_prop.tag == 'type':
+                        prop_dict['type'] = var_prop.text
+                        if 'kind' in var_prop.attrib:
+                            prop_dict['kind'] = var_prop.get('kind')
+                        # End if
+                        if 'units' in var_prop.attrib:
+                            prop_dict['units'] = var_prop.get('units')
+                        # End if
+                    else:
+                        # These elements should just have text, no attributes
+                        if len(var_prop.attrib) > 0:
+                            abort("Bad variable property, {} for variable, {}".format(var_prop.tag, vname), logger)
+                        elif var_prop.tag == 'dimensions':
+                            # We need to rebuild this text for compatibility
+                            dims = [x.strip() for x in var_prop.text.split(',')]
+                            prop_dict[var_prop.tag] = '({})'.format(', '.join(dims))
+                        else:
+                            prop_dict[var_prop.tag] = var_prop.text
+                        # End if
+                    # End if
+                # End for
+                if child.tag == 'constant':
+                    prop_dict['constant'] = '.true.'
+                # End if
+                if child.tag == 'variable':
+                    prop_dict['intent'] = 'inout'
+                # End if
+                newvar = Var(prop_dict, ParseSource(vname, 'REGISTRY', context))
+                variables.add_variable(newvar)
+            # Else
+            # End if
+        # End for
+        # Now that we have all the info from this XML, create a HostModel
+        # object or add to the one that is there:
+        if host_model is None:
+            host_model = HostModel(host_name, ddt_defs, host_variables, variables, logger=logger)
+        elif host_name != host_model.name:
+            raise CCPPError('Inconsistent host model names, {} and {}'.format(host_name, host_model.name))
+        else:
+            host_model.add_variables(variables, logger=logger)
+            host_model.add_ddt_defs(ddt_defs, logger=logger)
+            for var in host_variables.keys():
+                host_model.add_host_variable_module(var, host_variables[var], logger=logger)
+            # End for
+        # End if
+        return host_model
+
+###############################################################################
+
+if __name__ == "__main__":
+    from parse_tools import initLog, setLogToNull
+    logger = initLog('host_registry')
+    setLogToNull(logger)
+    # First, run doctest
+    import doctest
+    doctest.testmod()
+# No else:

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python
+"""
+The argument tables for schemes and variable definitions should
+have a section header line followed by variable declaration sections
+followed by a line containing only a blank comment line
+Each line begins with a special token. In Fortran, the token is a
+double exclamation mark.
+
+There are two styles of section header line:
+!! \section arg_table_<name>
+!> \section arg_table_<name>
+
+The second form is used to begin a new doxygen section
+
+<name> is the name of the file object which immediately follows the
+argument table. It is one of the following possibilities:
+- SubroutineName: the name of a subroutine (i.e., the name of
+                   a scheme interface function such as SchemeName_run)
+- DerivedTypeName: a derived type name for a type which will be used
+                   somewhere in the CCPP interface.
+- ModuleName: the name of the module whose module variables will be
+              used somewhere in the CCPP interface
+
+A variable declaration section begins with a variable name line (a local
+variable name enclosed in square brackets) followed by one or more
+variable attribute statements.
+A variable attribute statement is an attribute name and the value for
+that attribute separated by an equal sign. Whitespace is not
+significant except inside of strings.
+Variable attribute statements may be combined on a line if separated by
+a vertical bar.
+
+An example argument table is shown below (aside from the python comment
+character at the start of each line).
+
+!> \section arg_table_<name>
+!! [ im ]
+!! standard_name = horizontal_loop_extent
+!! long_name = horizontal loop extent, start at 1
+!! units = index
+!! type = integer
+!! dimensions = ()
+!! intent = in
+!! [ ix ]
+!! standard_name = horizontal_loop_dimension
+!! long_name = horizontal dimension
+!! units = index | type = integer | dimensions = ()
+!! intent = in
+!! ...
+!! [ errmsg]
+!! standard_name = ccpp_error_message
+!! long_name = error message for error handling in CCPP
+!! units = none
+!! type = character
+!! len = *
+!! dimensions = ()
+!! intent = out
+!! [ ierr ]
+!! standard_name = ccpp_error_flag
+!! long_name = error flag for error handling in CCPP
+!! type = integer
+!! dimensions = ()
+!! intent=out
+!!
+Notes on the input format:
+- SubroutineName must match the name of the subroutine that the argument
+  table describes
+- DerivedTypeName must match the name of the derived type that the argument
+  table describes
+- ModuleName must match the name of the module whose variables the argument
+  table describes
+- the table must be placed immediately before the subroutine / derived
+  data type, or immediately before the module variables (but within the
+  module structure)
+- each line of the table must begin with the language-dependent
+  doxygen-delimiter ('!!' for Fortran)
+- after the last row of the table, there must be a blank doxygen line
+  (only the delimiter) to denote the end of the table
+- for variable type definitions and module variables, the intent and
+  optional columns are not functional and should be omitted
+- each argument table (and its subroutine) must accept the following two arguments for error handling:
+     - character(len=512), intent(out) :: errmsg
+         - errmsg must be initialized as '' and contains the error message in case an error occurs
+     - integer, intent(out) :: ierr
+         - ierr must be initialized as 0 and set to >1 in case of errors
+Output: This routine converts the argument tables for all subroutines / typedefs / module variables into an XML file
+suitable to be used with mkcap.py (which generates the fortran code for the scheme cap)
+- the script generates a separate file for each module within the given files
+"""
+
+# Python library imports
+from __future__ import print_function
+import re
+# CCPP framework imports
+from metavar import Var, VarDictionary
+from parse_tools import ParseObject, ParseSource, register_fortran_ddt_name
+from parse_tools import ParseInternalError, ParseSyntaxError, CCPPError
+from parse_tools import MetadataSyntax, FortranMetadataSyntax
+from parse_tools import FORTRAN_ID, FORTRAN_SCALAR_REF
+
+########################################################################
+
+########################################################################
+
+class MetadataHeader(ParseSource):
+    """Class to hold all information from a metadata header
+    >>> MetadataHeader(ParseObject("foobar.txt",                              \
+                      ["!> \section arg_table_foobar", "!! [ im ]",           \
+                       "!! standard_name = horizontal_loop_extent",           \
+                       "!! long_name = horizontal loop extent, start at 1",   \
+                       "!! units = index | type = integer",                   \
+                       "!! dimensions = () |  intent = in"])).get_var(standard_name='horizontal_loop_extent') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: End of file parsing Metadata table, at foobar.txt:7
+    >>> MetadataHeader(ParseObject("foobar.txt",                              \
+                      ["!> \section arg_table_foobar", "!! [ im ]",           \
+                       "!! standard_name = horizontal_loop_extent",           \
+                       "!! long_name = horizontal loop extent, start at 1",   \
+                       "!! units = index | type = integer",                   \
+                       "!! dimensions = () |  intent = in",                   \
+                       "  subroutine foo()"])).get_var(standard_name='horizontal_loop_extent') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid Metadata table ending, '  subroutine foo()', at foobar.txt:7
+    >>> MetadataHeader(ParseObject("foobar.txt",                              \
+                      ["!> \section arg_table_foobar", "!! [ im ]",           \
+                       "!! standard_name = horizontal_loop_extent",           \
+                       "!! long_name = horizontal loop extent, start at 1",   \
+                       "!! units = index | type = integer",                   \
+                       "!! dimensions = () |  intent = in",                   \
+                       "!! "])).get_var(standard_name='horizontal_loop_extent') #doctest: +ELLIPSIS
+    <metavar.Var object at 0x...>
+    >>> MetadataHeader(ParseObject("foobar.txt",                              \
+                      ["!> \section arg_table_foobar", "!! [ im ]",           \
+                       "!! standard_name = horizontal_loop_extent",           \
+                       "!! long_name = horizontal loop extent, start at 1",   \
+                       "!! units = index | type = integer",                   \
+                       "!! dimensions = () |  intent = in",                   \
+                       "!! "], line_start=0),                                 \
+                       syntax=FortranMetadataSyntax).get_var(standard_name='horizontal_loop_extent').get_prop_value('local_name')
+    'im'
+    >>> MetadataHeader(ParseObject("foobar.txt",                              \
+                      ["!> \section arg_table_foobar", "!! [ im ]",           \
+                       "!! standard_name = horizontal loop extent",           \
+                       "!! long_name = horizontal loop extent, start at 1",   \
+                       "!! units = index | type = integer",                   \
+                       "!! dimensions = () |  intent = in",                   \
+                       "!! "], line_start=0)).get_var(standard_name='horizontal_loop_extent') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid variable property value, 'horizontal loop extent', at foobar.txt:2
+    >>> MetadataHeader._var_start.match('[ qval ]') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+    >>> MetadataHeader._var_start.match('[ qval(hi_mom) ]') #doctest: +ELLIPSIS
+    <_sre.SRE_Match object at 0x...>
+"""
+
+    _header_start = re.compile(r"\\section\s+arg_table_([A-Za-z][A-Za-z0-9_]*)")
+
+    _var_start = re.compile(r"^\[\s*("+FORTRAN_ID+r"|"+FORTRAN_SCALAR_REF+r")\s*\]$")
+
+    def __init__(self, parse_object, syntax=FortranMetadataSyntax, spec_name=None, logger=None):
+        self._pobj = parse_object
+        self._spec_name = spec_name
+        if syntax is None:
+            raise CCPPError('syntax may not be None')
+        # End if
+        self._syntax = syntax
+        "Initialize from the <lines> of <filename> beginning at <first_line>"
+        # Read the table preamble, assume the caller already figured out
+        #  the first line of the header using the metadata_table_start method.
+        curr_line, curr_line_num = self._pobj.curr_line()
+        self._table_title = MetadataHeader.metadata_table_start(curr_line, context=self._pobj, syntax=self._syntax)
+        if self._table_title is None:
+            raise ParseSyntaxError("metadata header start",
+                                   token=curr_line, context=self._pobj)
+        # End if
+        # Figure out the header type
+        if self._spec_name is not None:
+            if self._spec_name.lower() == self._table_title.lower():
+                # This is a module or program data header
+                self._header_type = 'MODULE'
+            else:
+                # This should be a derived data type
+                self._header_type = 'DDT'
+                register_fortran_ddt_name(self.title)
+            # End if
+        else:
+            # This has to be a scheme name
+            self._header_type = 'SCHEME'
+        # End if
+        # Tiem to initialize our ParseSource parent
+        super(MetadataHeader, self).__init__(self._table_title,
+                                             self._header_type, self._pobj)
+        curr_line, curr_line_num = self._pobj.next_line()
+        # Skip past any 'blank' lines
+        blanks_found = False
+        while self._syntax.blank_line(curr_line):
+            blanks_found = True
+            curr_line, curr_line_num = self._pobj.next_line()
+        # End while
+        # Read the variables
+        valid_lines =  True
+        self._variables = VarDictionary(self.title, logger=logger)
+        self._var_intents = {'in' : list(), 'out' : list(), 'inout' : list()}
+        while valid_lines:
+            newvar, curr_line = self.parse_variable(curr_line, spec_name)
+            valid_lines = newvar is not None
+            if valid_lines:
+                intent = newvar.get_prop_value('intent')
+                if intent is not None:
+                    self._var_intents[intent].append(newvar)
+                # End if
+                self._variables.add_variable(newvar)
+            else:
+                # We have hit the end of the table, check for blank line
+                if curr_line is None:
+                    raise ParseSyntaxError("End of file parsing Metadata table",
+                                           context=self._pobj)
+                elif not self._syntax.blank_line(curr_line):
+                    # First check if we have a valid empty table
+                    if (not blanks_found) or (len(self._variables) > 0):
+                        raise ParseSyntaxError("Metadata table ending",
+                                               curr_line, context=self._pobj)
+                    # End if
+                # End if
+            # End if
+        # End while
+
+    def parse_variable(self, curr_line, spec_name):
+        # The header line has the format [ <valid_fortran_symbol> ]
+        # Parse header
+        valid_line = curr_line is not None
+        if valid_line:
+            local_name = self.variable_start(curr_line) # caller handles exception
+        else:
+            local_name = None
+        # End if
+        if local_name is None:
+            # This is not a valid variable line, punt (should be end of table)
+            valid_line = False
+        # End if
+        # Parse lines until invalid line is found
+        # NB: Header variables cannot have embedded blank lines
+        if valid_line:
+            var_props = {}
+            var_props['local_name'] = local_name
+        else:
+            var_props = None
+        # End if
+        while valid_line:
+            curr_line, curr_line_num = self._pobj.next_line()
+            valid_line = ((curr_line is not None) and
+                          (not self._syntax.blank_line(curr_line)) and
+                          (self._syntax.strip(curr_line) is not None) and
+                          (self.variable_start(curr_line) is None))
+            # A valid line may have multiple properties (separated by '|')
+            if valid_line:
+                properties = self._syntax.strip(curr_line).split('|')
+                for property in properties:
+                    pitems = property.split('=', 1)
+                    if len(pitems) < 2:
+                        raise ParseSyntaxError("variable property syntax",
+                                               token=property,
+                                               context=self._pobj)
+                    # End if
+                    try:
+                        pname = pitems[0].strip()
+                        pval_str = pitems[1].strip()
+                        # Make sure this is a match
+                        hp = Var.get_prop(pname)
+                        if hp is not None:
+                            pval = hp.valid_value(pval_str)
+                        else:
+                            raise ParseSyntaxError("variable property name",
+                                                   token=pname,
+                                                   context=self._pobj)
+                        # End if
+                        if pval is None:
+                            raise ParseSyntaxError("'{}' property value".format(pname),
+                                                   token=pval_str,
+                                                   context=self._pobj)
+                        # End if
+                    except ParseSyntaxError as p:
+                        raise p
+                    # If we get this far, we have a valid property.
+                    var_props[pname] = pval
+                # End for
+            # End if
+        # End while
+        if var_props is None:
+            return None, curr_line
+        else:
+            try:
+                newvar = Var(var_props, source=self)
+            except CCPPError as ve:
+                raise ParseSyntaxError(ve, context=self._pobj)
+            return newvar, curr_line
+        # End if
+
+    def variable_list(self):
+        "Return an ordered list of the header's variables"
+        return self._variables.variable_list()
+
+    def get_var(self, standard_name=None, intent=None):
+        if standard_name is not None:
+            var = self._variables.find_variable(standard_name)
+            return var
+        elif intent is not None:
+            if intent not in self._var_intents:
+                raise ParseInternalError("Illegal intent type, '{}', in {}".format(intent, self._table_title), context=self._pobj)
+            # End if
+            return self._var_intents[intent]
+        else:
+            return None
+
+    def prop_list(self, prop_name):
+        "Return list of <prop_name> values for this scheme's arguments"
+        return self._variables.prop_list(prop_name)
+
+    def variable_start(self, line):
+        """Return variable name if <line> is an interface metadata table header
+        """
+        sline = self._syntax.strip(line)
+        if sline is None:
+            match = None
+        else:
+            match = MetadataHeader._var_start.match(sline)
+        # End if
+        if match is not None:
+            name = match.group(1)
+            if not self._syntax.is_scalar_reference(name):
+                raise ParseSyntaxError("local variable name",
+                                       token=name, context=self._pobj)
+            # End if
+        else:
+            name = None
+        # End if
+        return name
+
+    @property
+    def title(self):
+        'Return the name of the metadata arg_table'
+        return self._table_title
+
+    @property
+    def module(self):
+        'Return the module name for this header (if it exists)'
+        return self._spec_name
+
+    @classmethod
+    def metadata_table_start(cls, line, context=None, syntax=FortranMetadataSyntax):
+        """Return variable name if <line> is an interface metadata table header
+        """
+        ts = syntax.table_start(line)
+        if ts is not None:
+            match = MetadataHeader._header_start.match(syntax.strip(line))
+            if match is not None:
+                name = match.group(1)
+                if not syntax.is_variable_name(name):
+                    raise ParseSyntaxError("arg_table name",
+                                           token=name, context=context)
+                # End if
+            else:
+                name = None
+            # End if
+        else:
+            name = None
+        # End if
+        return name
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -1,0 +1,1048 @@
+#!/usr/bin/env python
+#
+# Class to hold all information on a CCPP metadata variable
+#
+
+# Python library imports
+from __future__ import print_function
+import re
+import xml.etree.ElementTree as ET
+from collections import OrderedDict
+# CCPP framework imports
+from parse_tools import check_fortran_ref, check_fortran_type, context_string
+from parse_tools import FORTRAN_DP_RE, FORTRAN_ID
+from parse_tools import registered_fortran_ddt_name
+from parse_tools import check_dimensions, check_cf_standard_name
+from parse_tools import ParseContext, ParseSource
+from parse_tools import ParseInternalError, ParseSyntaxError, CCPPError
+
+###############################################################################
+real_subst_re = re.compile(r"(.*\d)p(\d.*)")
+list_re = re.compile(r"[(]([^)]*)[)]\s*$")
+
+########################################################################
+def standard_name_to_long_name(prop_dict, context=None):
+########################################################################
+    """Translate a standard_name to its default long_name
+    >>> standard_name_to_long_name({'standard_name':'cloud_optical_depth_layers_from_0p55mu_to_0p99mu'})
+    'Cloud optical depth layers from 0.55mu to 0.99mu'
+    >>> standard_name_to_long_name({'local_name':'foo'}) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No standard name to convert foo to long name
+    >>> standard_name_to_long_name({}) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No standard name to convert to long name
+    >>> standard_name_to_long_name({'local_name':'foo'}, context=ParseContext(linenum=3, filename='foo.F90')) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No standard name to convert foo to long name at foo.F90:3
+    >>> standard_name_to_long_name({}, context=ParseContext(linenum=3, filename='foo.F90')) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No standard name to convert to long name at foo.F90:3
+    """
+    # We assume that standar_name has been checked for validity
+    # Make the first char uppercase and replace each underscore with a space
+    if 'standard_name' in prop_dict:
+        standard_name = prop_dict['standard_name']
+        long_name = standard_name[0].upper() + re.sub("_", " ", standard_name[1:])
+        # Next, substitute a decimal point for the p in [:digit]p[:digit]
+        match = real_subst_re.match(long_name)
+        while match is not None:
+            long_name = match.group(1) + '.' + match.group(2)
+            match = real_subst_re.match(long_name)
+        # End while
+    else:
+        long_name = ''
+        if 'local_name' in prop_dict:
+            lname = ' {}'.format(prop_dict['local_name'])
+        else:
+            lname = ''
+        # End if
+        ctxt = context_string(context)
+        raise CCPPError('No standard name to convert{} to long name{}'.format(lname, ctxt))
+    # End if
+    return long_name
+
+########################################################################
+def default_kind_val(prop_dict, context=None):
+########################################################################
+    """Choose a default kind based on a variable's type
+    >>> default_kind_val({'type':'REAL'})
+    'kind_phys'
+    >>> default_kind_val({'type':'complex'})
+    'kind_phys'
+    >>> default_kind_val({'type':'double precision'})
+    'kind_phys'
+    >>> default_kind_val({'type':'integer'})
+    ''
+    >>> default_kind_val({'type':'character'})
+    ''
+    >>> default_kind_val({'type':'logical'})
+    ''
+    >>> default_kind_val({'local_name':'foo'}) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No type to find default kind for foo
+    >>> default_kind_val({}) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No type to find default kind
+    >>> default_kind_val({'local_name':'foo'}, context=ParseContext(linenum=3, filename='foo.F90')) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No type to find default kind for foo at foo.F90:3
+    >>> default_kind_val({}, context=ParseContext(linenum=3, filename='foo.F90')) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: No type to find default kind at foo.F90:3
+    """
+    if 'type' in prop_dict:
+        vtype = prop_dict['type'].lower()
+        if vtype == 'real':
+            kind = 'kind_phys'
+        elif vtype == 'complex':
+            kind = 'kind_phys'
+        elif FORTRAN_DP_RE.match(vtype) is not None:
+            kind = 'kind_phys'
+        else:
+            kind = ''
+        # End if
+    else:
+        kind = ''
+        if 'local_name' in prop_dict:
+            lname = ' {}'.format(prop_dict['local_name'])
+        else:
+            lname = ''
+        # End if
+        ctxt = context_string(context)
+        raise CCPPError('No type to find default kind for {}{}'.format(lname, ctxt))
+    # End if
+    return kind
+
+########################################################################
+def ddt_modules(variable_list):
+########################################################################
+    ddt_mods = set()
+    for var in variable_list:
+        if var.is_ddt():
+            module = var.get_prop_value('module')
+            if len(module) > 0:
+                ddt_mods.add((module, var.get_prop_value('type')))
+            # End if
+        # End if
+    # End for
+    return ddt_mods
+
+########################################################################
+
+class VariableProperty(object):
+    """Class to represent a single property of a metadata header entry
+    >>> VariableProperty('local_name', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('standard_name', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('long_name', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('units', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('dimensions', list) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('type', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('kind', str) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('state_variable', str, valid_values_in=['True',   'False', '.true.', '.false.' ], optional_in=True, default_in=False) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('intent', str, valid_values_in=['in', 'out', 'inout']) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('optional', str, valid_values_in=['True',   'False', '.true.', '.false.' ], optional_in=True, default_in=False) #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at ...>
+    >>> VariableProperty('local_name', str).name
+    'local_name'
+    >>> VariableProperty('standard_name', str).type
+    <type 'str'>
+    >>> VariableProperty('units', str).is_match('units')
+    True
+    >>> VariableProperty('units', str).is_match('UNITS')
+    True
+    >>> VariableProperty('units', str).is_match('type')
+    False
+    >>> VariableProperty('value', int, valid_values_in=[1, 2 ]).valid_value('2')
+    2
+    >>> VariableProperty('value', int, valid_values_in=[1, 2 ]).valid_value('3')
+
+    >>> VariableProperty('value', int, valid_values_in=[1, 2 ]).valid_value('3', error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: Invalid value variable property, '3'
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('()')
+    []
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('(x)')
+    ['x']
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('x')
+
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('(x:y)')
+    ['x:y']
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('(w:x,y:z)')
+    ['w:x', 'y:z']
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('(w:x,x:y:z)', error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'x:y:z' is an invalid dimension range
+    >>> VariableProperty('dimensions', list, check_fn_in=check_dimensions).valid_value('(x:3y)', error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: '3y' is not a valid Fortran identifier
+    """
+
+    def __init__(self, name_in, type_in, valid_values_in=None, optional_in=False, default_in=None, default_fn_in=None, check_fn_in=None):
+        self._name = name_in
+        self._type = type_in
+        if self._type not in [ bool, int, list, str ]:
+            raise CCPPError("{} has invalid VariableProperty type, '{}'".format(name_in, type_in))
+        # End if
+        self._valid_values = valid_values_in
+        self._optional = optional_in
+        if self.optional:
+            if (default_in is None) and (default_fn_in is None):
+                raise CCPPError('default_in or default_fn_in is a required property for {} because it is optional'.format(name_in))
+            if (default_in is not None) and (default_fn_in is not None):
+                raise CCPPError('default_in and default_fn_in cannot both be provided')
+            self._default = default_in
+            self._default_fn = default_fn_in
+        elif default_in is not None:
+            raise CCPPError('default_in is not a valid property for {} because it is not optional'.format(name_in))
+        elif default_in is not None:
+            raise CCPPError('default_fn_in is not a valid property for {} because it is not optional'.format(name_in))
+        self._check_fn = check_fn_in
+
+    @property
+    def name(self):
+        'Return the name of the property'
+        return self._name
+
+    @property
+    def type(self):
+        'Return the type of the property'
+        return self._type
+
+    def get_default_val(self, prop_dict, context=None):
+        if self._default_fn is not None:
+            return self._default_fn(prop_dict, context)
+        elif self._default is not None:
+            return self._default
+        else:
+            ctxt = context_string(context)
+            raise CCPPError('No default for variable property {}{}'.format(self.name, ctxt))
+        # End if
+
+    @property
+    def optional(self):
+        return self._optional
+
+    def is_match(self, test_name):
+        "Return True iff <test_name> is the name of this property"
+        return self.name.lower() == test_name.lower()
+
+    def valid_value(self, test_value, error=False):
+        'Return True iff test_value is valid'
+        valid_val = None
+        if self.type is int:
+            try:
+                tv = int(test_value)
+                if self._valid_values is not None:
+                    if tv in self._valid_values:
+                        valid_val = tv
+                    else:
+                        valid_val = None # i.e. pass
+                else:
+                    valid_val = tv
+            except CCPPError:
+                valid_val = None # Redundant but more expressive than pass
+        elif self.type is list:
+            if isinstance(test_value, str):
+                match = list_re.match(test_value)
+                if match is None:
+                    tv = None
+                else:
+                    tv = [x.strip() for x in match.group(1).split(',')]
+                    if (len(tv) == 1) and (len(tv[0]) == 0):
+                        # Scalar
+                        tv = list()
+                    # End if
+                # End if
+            else:
+                tv = test_value
+            # End if
+            if isinstance(tv, list):
+                valid_val = tv
+            elif isinstance(tv, tuple):
+                valid_val = list(tv)
+            else:
+                valid_val = None
+            # End if
+            if (valid_val is not None) and (self._valid_values is not None):
+                # Special case for lists, _valid_values applies to elements
+                for item in valid_val:
+                    if item not in self._valid_values:
+                        valid_val = None
+                        break
+                    # End if
+                # End for
+            else:
+                pass
+        elif self.type is bool:
+            if isinstance(test_value, str):
+                valid_val = (test_value in ['True', 'False']) or (test_value.lower() in ['t', 'f', '.true.', '.false.'])
+            else:
+                valid_val = not not test_value
+        elif self.type is str:
+            if isinstance(test_value, str):
+                if self._valid_values is not None:
+                    if test_value in self._valid_values:
+                        valid_val = test_value
+                    else:
+                        valid_val = None # i.e., pass
+                else:
+                    valid_val = test_value
+                # End if
+            # End if
+        # End if
+        # Call a check function?
+        if valid_val and (self._check_fn is not None):
+            valid_val = self._check_fn(valid_val, error=error)
+        elif (valid_val is None) and error:
+            raise CCPPError("Invalid {} variable property, '{}'".format(self.name, test_value))
+        # End if
+        return valid_val
+
+###############################################################################
+
+class Var(object):
+    """ A class to hold a metadata variable
+    >>> Var.get_prop('standard_name') #doctest: +ELLIPSIS
+    <__main__.VariableProperty object at 0x...>
+    >>> Var.get_prop('standard')
+
+    >>> Var.get_prop('type').is_match('type')
+    True
+    >>> Var.get_prop('type').is_match('long_name')
+    False
+    >>> Var.get_prop('type').valid_value('character')
+    'character'
+    >>> Var.get_prop('type').valid_value('char')
+
+    >>> Var.get_prop('long_name').valid_value('hi mom')
+    'hi mom'
+    >>> Var.get_prop('dimensions').valid_value('hi mom')
+
+    >>> Var.get_prop('dimensions').valid_value(['Bob', 'Ray'])
+    ['Bob', 'Ray']
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext())).get_prop_value('long_name')
+    'Hi mom'
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext())).get_prop_value('intent')
+    'in'
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'ttype' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid metadata variable property, 'ttype', in <standard input>
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))
+    Traceback (most recent call last):
+    ParseSyntaxError: Required property, 'units', missing, in <standard input>
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'inout', 'constant' : '.true.'}, ParseSource('vname', 'SCHEME', ParseContext())) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: foo is marked constant but is intent inout, at <standard input>:1
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'ino'}, ParseSource('vname', 'SCHEME', ParseContext())) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid intent variable property, 'ino', at <standard input>:1
+    """
+
+    # __spec_props are for variables defined in a specification
+    __spec_props = [VariableProperty('local_name', str,
+                                     check_fn_in=check_fortran_ref),
+                    VariableProperty('standard_name', str,
+                                     check_fn_in=check_cf_standard_name),
+                    VariableProperty('long_name', str, optional_in=True,
+                                     default_fn_in=standard_name_to_long_name),
+                    VariableProperty('units', str),
+                    VariableProperty('dimensions', list,
+                                     check_fn_in=check_dimensions),
+                    VariableProperty('type', str,
+                                     check_fn_in=check_fortran_type),
+                    VariableProperty('kind', str,
+                                     optional_in=True,
+                                     default_fn_in=default_kind_val),
+                    VariableProperty('state_variable', bool,
+                                     optional_in=True, default_in=False),
+                    VariableProperty('optional', bool,
+                                     optional_in=True, default_in=False),
+                    VariableProperty('module', str,
+                                     optional_in=True, default_in=''),
+                    VariableProperty('constant', bool,
+                                     optional_in=True, default_in=False),
+                    VariableProperty('allocatable', bool,
+                                     optional_in=True, default_in=False),
+                    VariableProperty('persistence', str, optional_in=True,
+                                     valid_values_in=['timestep', 'run'],
+                                     default_in='timestep')]
+
+    # __var_props contains properties which are not in __spec_props
+    __var_props = [VariableProperty('intent', str,
+                                    valid_values_in=['in', 'out', 'inout'])]
+
+
+    __spec_propdict = {}
+    __var_propdict = {}
+    __required_spec_props = list()
+    __required_var_props = list()
+    for p in __spec_props:
+        __spec_propdict[p.name] = p
+        __var_propdict[p.name] = p
+        if not p.optional:
+            __required_spec_props.append(p.name)
+            __required_var_props.append(p.name)
+        # End if
+    # End for
+    for p in __var_props:
+        __var_propdict[p.name] = p
+        if not p.optional:
+            __required_var_props.append(p.name)
+        # End if
+    # End for
+
+    def __init__(self, prop_dict, source):
+        if source.type is 'SCHEME':
+            required_props = Var.__required_var_props
+            master_propdict = Var.__var_propdict
+        else:
+            required_props = Var.__required_spec_props
+            master_propdict = Var.__spec_propdict
+        # End if
+        self._source = source
+        # Grab a frozen copy of the context
+        self._context = ParseContext(context=source.context)
+        # First, check the input
+        if 'ddt_type' in prop_dict:
+            # Special case to bypass normal type rules
+            if 'type' not in prop_dict:
+                prop_dict['type'] = prop_dict['ddt_type']
+            # End if
+            if 'units' not in prop_dict:
+                prop_dict['units'] = ""
+            # End if
+            prop_dict['kind'] = prop_dict['ddt_type']
+            del prop_dict['ddt_type']
+        # End if
+        for key in prop_dict:
+            if Var.get_prop(key) is None:
+                raise ParseSyntaxError("Invalid metadata variable property, '{}'".format(key), context=self.context)
+            # End if
+        # End for
+        # Make sure required properties are present
+        for propname in required_props:
+            if propname not in prop_dict:
+                raise ParseSyntaxError("Required property, '{}', missing".format(propname), context=self.context)
+            # End if
+        # End for
+        # Check for any mismatch
+        if ('constant' in prop_dict) and ('intent' in prop_dict):
+            if prop_dict['intent'].lower() != 'in':
+                raise ParseSyntaxError("{} is marked constant but is intent {}".format(prop_dict['local_name'], prop_dict['intent']), context=self.context)
+            # End if
+        # End if
+        # Steal dict from caller
+        self._prop_dict = prop_dict
+        # Fill in default values for missing properties
+        for propname in master_propdict:
+            if (propname not in prop_dict) and master_propdict[propname].optional:
+                self._prop_dict[propname] = master_propdict[propname].get_default_val(self._prop_dict, context=self.context)
+            # End if
+        # End for
+        # Make sure all the variable values are valid
+        try:
+            for prop in self._prop_dict.keys():
+                check = Var.get_prop(prop).valid_value(self._prop_dict[prop],
+                                                       error=True)
+            # End for
+        except CCPPError as cp:
+            raise ParseSyntaxError("{}: {}".format(self._prop_dict['local_name'], cp),
+                                   context=self.context)
+        # End try
+
+    def compatible(self, other, logger=None):
+        # We accept character(len=*) as compatible with character(len=INTEGER_VALUE)
+        stype =     self.get_prop_value('type')
+        skind =     self.get_prop_value('kind')
+        sunits =    self.get_prop_value('units')
+        srank=      self.get_prop_value('tank')
+        sstd_name = self.get_prop_value('standard_name')
+        otype =     other.get_prop_value('type')
+        okind =     other.get_prop_value('kind')
+        ounits =    other.get_prop_value('units')
+        orank=      other.get_prop_value('tank')
+        ostd_name = other.get_prop_value('standard_name')
+        if stype == 'character':
+            kind_eq = ((skind == okind) or
+                       (skind == 'len=*' and okind.startswith('len=')) or
+                       (skind.startswith('len=') and okind == 'len=*'))
+        else:
+            kind_eq = skind == okind
+        # End if
+        if ((sstd_name == ostd_name) and kind_eq and
+            (sunits == ounits) and (stype == otype) and (srank == orank)):
+            return True
+        elif logger is not None:
+            if sstd_name != ostd_name:
+                logger.info("standard_name: '{}' != '{}'".format(sstd_name, ostd_name))
+            elif not kind_eq:
+                logger.info("kind: '{}' != '{}'".format(skind, okind))
+            elif sunits != ounits:
+                logger.info("units: '{}' != '{}'".format(sunits, ounits))
+            elif stype != otype:
+                logger.info("type: '{}' != '{}'".format(stype, otype))
+            elif srank != orank:
+                logger.info("rank: '{}' != '{}'".format(srank, orank))
+            else:
+                logger.error('Why are these variables not compatible?')
+            # End if
+            return False
+        else:
+            return False
+        # End if
+
+    @classmethod
+    def get_prop(cls, name, spec_type=None):
+        if (spec_type is None) and (name in Var.__var_propdict):
+            return Var.__var_propdict[name]
+        elif (spec_type is not None) and (name in Var.__spec_propdict):
+            return Var.__spec_propdict[name]
+        else:
+            return None
+
+    def get_prop_value(self, name):
+        if name in self._prop_dict:
+            return self._prop_dict[name]
+        else:
+            return None
+
+    @property
+    def context(self):
+        return self._context
+
+    @property
+    def source(self):
+        return self._source
+
+    def get_dimensions(self, loop_subst=False):
+        "Return the variable's dimension string"
+        dimval = self.get_prop_value('dimensions')
+        dims = Var.get_prop('dimensions').valid_value(dimval)
+        if loop_subst:
+            newdims = list()
+            for dim in dims:
+                # loop_subst_match swallows an entire dim string, even ranges
+                ldim = VarDictionary.loop_subst_match(dim)
+                if ldim is None:
+                    newdims.append(dim)
+                else:
+                    newdims.append(ldim)
+                # End if
+            # End for
+        else:
+            newdims = dims
+        # End if
+        return newdims
+
+    def write_def(self, outfile, indent, dict, allocatable=False, loop_subst=False):
+        '''Write the definition line for the variable.'''
+        vtype = self.get_prop_value('type')
+        kind = self.get_prop_value('kind')
+        name = self.get_prop_value('local_name')
+        dims = self.get_dimensions(loop_subst=loop_subst)
+        if (dims is not None) and (len(dims) > 0):
+            if allocatable:
+                dimstr = '(:' + ',:'*(len(dims) - 1) + ')'
+            else:
+                dimstr = '('
+                comma = ''
+                for dim in dims:
+                    # Only ranges or sizes go into declaration
+                    if VarDictionary.loop_var_match(dim):
+                        continue
+                    else:
+                        dstdnames = dim.split(':')
+                        dvars = [dict.find_variable(x) for x in dstdnames]
+                        if None in dvars:
+                            for dim in dstdnames:
+                                if dict.find_variable(dim) is None:
+                                    raise CCPPError("No variable found for '{}'".format(dim))
+                                # End if
+                            # End for
+                        # End if
+                        dnames = [x.get_prop_value('local_name') for x in dvars]
+                        dimstr = dimstr + comma + ':'.join(dnames)
+                        comma = ', '
+                    # End if
+                # End for
+                dimstr = dimstr + ')'
+                if dimstr == '()':
+                    dimstr = '' # It ends up being a scalar reference
+                # End if
+            # End if
+        else:
+            dimstr = ''
+        # End if
+        constant = self.get_prop_value('constant')
+        intent = self.get_prop_value('intent')
+        if constant and allocatable:
+            raise CCPPError('Cannot create allocatable variable from constant, {}'.format(name))
+        # End if
+        if constant:
+            intent_str = 'intent(in)   '
+        elif allocatable:
+            if len(dimstr) > 0:
+                intent_str = 'allocatable  '
+            else:
+                intent_str = ' '*13
+            # End if
+        elif intent is not None:
+            intent_str = 'intent({}){}'.format(intent, ' '*(5 - len(intent)))
+        else:
+            intent_str = ' '*13
+        # End if
+        if self.is_ddt():
+            str = "type({kind}){cspc}{intent} :: {name}{dims}"
+            cspc = ',' + ' '*(13 - len(kind))
+        else:
+            if (kind is not None) and (len(kind) > 0):
+                str = "{type}({kind}){cspc}{intent} :: {name}{dims}"
+                cspc = ',' + ' '*(17 - len(vtype) - len(kind))
+            else:
+                str = "{type}{cspc}{intent} :: {name}{dims}"
+                cspc = ',' + ' '*(19 - len(vtype))
+            # End if
+        # End if
+        outfile.write(str.format(type=vtype, kind=kind, intent=intent_str,
+                                 name=name, dims=dimstr, cspc=cspc), indent)
+
+    def is_ddt(self):
+        '''Return True iff <self> is a DDT type.'''
+        vtype = self.get_prop_value('type')
+        return registered_fortran_ddt_name(vtype) is not None
+
+    def host_arg_str(self, hvar, host_model, ddt):
+        '''Create the proper statement of a piece of a host-model variable.
+        If ddt is True, we can only have a single element selected
+        '''
+        hstr = hvar.get_prop_value('local_name')
+        # Turn the dimensions string into a proper list and take the correct one
+        hdims = hvar.get_dimensions()
+        dimsep = ''
+        # Does the local name have any extra indices?
+        match = array_ref_re.match(hstr.strip())
+        if match is not None:
+            hstr = match.group(1)
+            # Find real names for all the indices
+            tokens = [x.strip() for x in match.group(2).strip().split(',')]
+            for token in tokens:
+                hsdim = self.find_host_model_var(token, host_model)
+                dimstr = dimstr + dimsep + hsdim
+            # End for
+        # End if
+        if len(hdims) > 0:
+            dimstr = '('
+        else:
+            dimstr = ''
+        # End if
+        for hdim in hdims:
+            if ddt and (':' in hdim):
+                raise CCPPError("Invalid DDT dimension spec {}({})".format(hstr, hdimval))
+            else:
+                # Find the host model variable for each dim
+                hsdims = self.find_host_model_var(hdim, host_model)
+                dimstr = dimstr + dimsep + hsdims
+                dimsep = ', '
+            # End if
+        # End for
+        if len(hdims) > 0:
+            dimstr = dimstr + ')'
+        # End if
+        return hstr + dimstr
+
+    def print_debug(self):
+        '''Print the data retrieval line for the variable.'''
+        str='''Contents of {local_name} (* = mandatory for compatibility):
+        standard_name = {standard_name} *
+        long_name     = {long_name}
+        units         = {units} *
+        local_name    = {local_name}
+        type          = {type} *
+        dimensions    = {dimensions} *
+        kind          = {kind} *
+        intent        = {intent}
+        optional      = {optional}
+        '''
+        if self._context is not None:
+            str = str + '\n        context       = {}'.format(self._context)
+        # End if
+        return str.format(**self._prop_dict)
+
+    def __repr__(self):
+        '''Print representation or string for Var objects'''
+        return "<{standard_name}: {local_name}>".format(**self._prop_dict)
+
+###############################################################################
+
+class VarDDT(Var):
+    """A class to store a variable that is a component of a DDT (at any
+    DDT nesting level).
+    """
+
+    def __init__(self, standard_name, var_ref_list, logger=None):
+        self._standard_name = standard_name
+        self._var_ref_list = list()
+        for var in var_ref_list:
+            self._var_ref_list.append(var)
+        # End for
+        self._vlen = len(self._var_ref_list)
+        if logger is not None:
+            lnames = [x.get_prop_value('local_name') for x in self._var_ref_list]
+            logger.debug('Adding DDT field, {}, {}'.format(standard_name, lnames))
+        # End if
+
+    def compatible(self, other, logger=None):
+        "Compare <other> to the intrinsic variable the end of the DDT chain"
+        self._var_ref_list[-1].compare(other)
+
+    def get_prop_value(self, name, index=0):
+        "Return the indicated property value, defauling to the top-level DDT"
+        if abs(index) >= self._vlen:
+            raise ParseInternalError("VarDDT.get_prop_value index ({}) out of range".format(index))
+        # End if
+        return self._var_ref_list[index].get_prop_value(name)
+
+    @property
+    def context(self):
+        "Return the context of the variable source (DDT root)"
+        return self._var_ref_list[0].context
+
+    @property
+    def source(self):
+        "Return the source of the variable source (DDT root)"
+        return self._var_ref_list[0].source
+
+    def get_dimensions(self, loop_subst=False, index=0):
+        "Return the dimensions of the indicated var, defauling to the top-level DDT"
+        if abs(index) >= self._vlen:
+            raise ParseInternalError("VarDDT.get_prop_value index ({}) out of range".format(index))
+        # End if
+        return self._var_ref_list[index].get_dimensions(loop_subst)
+
+    def write_def(self, outfile, indent, dict, allocatable=False, loop_subst=False):
+        '''Write the definition line for the variable.'''
+        pass
+
+    def is_ddt(self):
+        '''Return True iff <self> is a DDT type.'''
+        return True
+
+    def host_arg_str(self, hvar, host_model, ddt):
+        '''Create the proper statement of a piece of a host-model variable.
+        If ddt is True, we can only have a single element selected
+        '''
+        pass
+
+    def print_debug(self):
+        for var in self._var_ref_list:
+            var.print(debug)
+        # End for
+
+    def __repr__(self):
+        '''Print representation or string for VarDDT objects'''
+        return "<{}>".format('%'.join([x.__repr__() for x in self._var_ref_list]))
+
+###############################################################################
+
+class VarDictionary(OrderedDict):
+    """
+    A class to store and cross-check variables from one or more metadata
+    headers. The class also serves as a scoping construct so that a variable
+    can be found in an innermost available scope.
+    The dictionary is organized by standard_name. It is an error to try
+    to add a variable if its standard name is already in the dictionary.
+    Scoping is a tree of VarDictionary objects.
+    >>> VarDictionary('foo')
+    VarDictionary(foo)
+    >>> VarDictionary('bar', variables={})
+    VarDictionary(bar)
+    >>> VarDictionary('baz', Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))) #doctest: +ELLIPSIS
+    VarDictionary(baz, [('hi_mom', <__main__.Var object at 0x...>)])
+    >>> print("{}".format(VarDictionary('baz', Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext())))))
+    VarDictionary(baz, ['hi_mom'])
+    >>> VarDictionary('qux', [Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))]) #doctest: +ELLIPSIS
+    VarDictionary(qux, [('hi_mom', <__main__.Var object at 0x...>)])
+    >>> VarDictionary('boo').add_variable(Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext())))
+
+    >>> VarDictionary('who', variables=[Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))]).prop_list('local_name')
+    ['foo']
+    >>> VarDictionary('glitch', Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()))).add_variable(Var({'local_name' : 'bar', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname2', 'DDT', ParseContext()))) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid Duplicate standard name, 'hi_mom', at <standard input>:
+    """
+
+    # Loop variables
+    __ccpp_loop_vars__ = ['horizontal_loop_begin', 'horizontal_loop_end',
+                          'thread_block_number', 'horizontal_loop_extent']
+    # Loop substitutions
+    __ccpp_loop_subst__ = {'horizontal_loop_extent' :
+                           ('horizontal_loop_begin', 'horizontal_loop_end'),
+                           'thread_block_begin:thread_block_end' :
+                           'thread_block_number'}
+    # Dimension substitutions
+    __ccpp_dim_subst__ = {'horizontal_loop_extent' : 'horizontal_dimension'}
+
+    # Variable representing the constant integer, 1
+    __var_one = Var({'local_name' : 'ccpp_one', 'constant' : 'True',
+                     'standard_name' : 'ccpp_constant_one',
+                     'units' : '1', 'dimensions' : '()', 'type' : 'integer'},
+                    ParseSource('VarDictionary', 'REGISTRY', ParseContext()))
+
+    def __init__(self, name, variables=None, parent_dict=None, logger=None):
+        "Unlike dict, VarDictionary only takes a Var or Var list"
+        super(VarDictionary, self).__init__()
+        self._name = name
+        self._logger = logger
+        self._parent_dict = parent_dict
+        if parent_dict is not None:
+            parent_dict.add_sub_scope(self)
+        # End if
+        self._sub_dicts = list()
+        if isinstance(variables, Var):
+            self.add_variable(variables)
+        elif isinstance(variables, list):
+            for var in variables:
+                self.add_variable(var)
+            # End for
+        elif isinstance(variables, VarDictionary):
+            for stdname in variables.keys():
+                self[stdname] = variables[stdname]
+            # End for
+        elif isinstance(variables, dict):
+            # variables will not be in 'order', but we accept them anyway
+            for stdname in variables.keys():
+                self[stdname] = variables[stdname]
+            # End for
+        elif variables is not None:
+            raise ParseInternalError('Illegal type for variables, {} in {}'.format(type(variables), self.name))
+        # End if
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def parent(self):
+        return self._parent_dict
+
+    def include_var_in_list(self, var, std_vars, loop_vars, consts):
+        '''Return True iff <var> is of a type allowed by the logicals,
+        <std_vars> (not constants or loop_vars),
+        <loop_vars> a variable ending in "_extent", "_begin", "_end", or
+        <consts> a variable with the "constant" property.
+        '''
+        const_val = var.get_prop_value('constant')
+        const_var = Var.get_prop('constant').valid_value(const_val)
+        include_var = consts and const_var
+        if not include_var:
+            standard_name = var.get_prop_value('standard_name')
+            loop_var = VarDictionary.loop_var_match(standard_name)
+            include_var = loop_var and loop_vars
+            if not include_var:
+                std_var = not (loop_var or const_var)
+                include_var = std_vars and std_var
+            # End if
+        # End if
+        return include_var
+
+    def variable_list(self, recursive=False,
+                      std_vars=True, loop_vars=True, consts=True):
+        "Return a list of all variables"
+        if recursive and (self._parent_dict is not None):
+            vlist = self._parent_dict.variable_list(recursive=recursive,
+                                                    std_vars=std_vars,
+                                                    loop_vars=loop_vars,
+                                                    consts=consts)
+        else:
+            vlist = list()
+        # End if
+        for sn in self.keys():
+            var = self[sn]
+            if self.include_var_in_list(var, std_vars=std_vars,
+                                        loop_vars=loop_vars, consts=consts):
+                vlist.append(var)
+            # End if
+        # End for
+        return vlist
+
+    def add_variable(self, newvar, exists_ok=False):
+        """Add a variable if it does not conflict with existing entries"""
+        standard_name = newvar.get_prop_value('standard_name')
+        if (standard_name in self) and (not exists_ok):
+            # We already have a matching variable, error!
+            if self._logger is not None:
+                self._logger.error("Attempt to add duplicate variable, {} from {}".format(standard_name, newvar.source.name))
+            # End if
+            raise ParseSyntaxError("Duplicate standard name in {}".format(self.name),
+                                   token=standard_name, context=newvar._context)
+        # End if
+        cvar = self.find_variable(standard_name)
+        if (cvar is not None) and (not cvar.compatible(newvar, self._logger)):
+            if self._logger is not None:
+                self._logger.error("Attempt to add incompatible variable, {} from {}".format(standard_name, newvar.source.name))
+            # End if
+            errstr = "Standard name incompatible with {}"
+            raise ParseSyntaxError(errstr.format(cvar.context),
+                                   token=standard_name,
+                                   context=newvar.source.context)
+        # End if
+        # If we make it to here without an exception, add the variable
+        self[standard_name] = newvar
+
+    def find_variable(self, standard_name, any_scope=True, loop_subst=False):
+        """Return the variable matching <standard_name> or None
+        If any_scope is True, search parent scopes if not in current scope.
+        """
+        if standard_name in self:
+            var = self[standard_name]
+        elif any_scope and (self._parent_dict is not None):
+            var = self._parent_dict.find_variable(standard_name, any_scope)
+        else:
+            var = None
+        # End if
+        if (var is None) and loop_subst:
+            var = self.find_loop_subst(standard_name, any_scope=any_scope)
+        # End if
+        return var
+
+    def add_sub_scope(self, sub_dict):
+        'Add a child dictionary to enable traversal'
+        self._sub_dicts.append(sub_dict)
+
+    def prop_list(self, prop_name, std_vars=True, loop_vars=True, consts=True):
+        '''Return a list of the <prop_name> property for each variable.
+        std_vars are variables which are neither constants nor loop variables.
+        '''
+        plist = list()
+        for standard_name in self.keys():
+            var = self.find_variable(standard_name, any_scope=False, loop_subst=False)
+            if self.include_var_in_list(var, std_vars=std_vars, loop_vars=loop_vars, consts=consts):
+                plist.append(self[standard_name].get_prop_value(prop_name))
+            # End if
+        # End for
+        return plist
+
+    def declare_variables(self, outfile, indent,
+                          std_vars=True, loop_vars=True, consts=True):
+        "Write out the declarations for this dictionary's variables"
+        for standard_name in self.keys():
+            var = self.find_variable(standard_name, any_scope=False, loop_subst=False)
+            if self.include_var_in_list(var, std_vars=std_vars, loop_vars=loop_vars, consts=consts):
+                self[standard_name].write_def(outfile, indent, self)
+            # End if
+        # End for
+
+    def merge(self, other_dict):
+        "Add new entries from <other_dict>"
+        for ovar in other_dict.variable_list():
+            self.add_variable(ovar)
+        # End for
+
+    def __str__(self):
+        return "VarDictionary({}, {})".format(self.name, self.keys())
+
+    def __repr__(self):
+        srepr = super(VarDictionary, self).__repr__()
+        vstart = len("VarDictionary") + 1
+        if len(srepr) > vstart + 1:
+            comma = ", "
+        else:
+            comma = ""
+        # End if
+        return "VarDictionary({}{}{}".format(self.name, comma, srepr[vstart:])
+
+    @classmethod
+    def loop_var_match(cls, standard_name):
+        'Return True iff <standard_name> is a loop variable'
+        return standard_name in cls.__ccpp_loop_vars__
+
+    @classmethod
+    def loop_subst_match(cls, standard_name):
+        'Return a loop substitution match, if any, for <standard_name>'
+        if standard_name in cls.__ccpp_loop_subst__:
+            return cls.__ccpp_loop_subst__[standard_name]
+        else:
+            return None
+        # End if
+
+    def find_loop_subst(self, standard_name, any_scope=True, context=None):
+        """If <standard_name> is of the form <standard_name>_extent and that
+        variable is not in the dictionary, substitute a tuple of variables,
+        (<standard_name>_begin, <standard_name>_end), if those variables are
+        in the dictionary.
+        If <standard_name>_extent *is* present, return that variable as a
+        range, (__var_one, <standard_name>_extent)
+        In other cases, return None
+        """
+        loop_var = VarDictionary.loop_subst_match(standard_name)
+        logger_str = None
+        if loop_var is not None:
+            # Let us see if we can fix a loop variable
+            dict_var = self.find_variable(standard_name,
+                                          any_scope=any_scope, loop_subst=False)
+            if dict_var is not None:
+                my_var = (VarDictionary.__var_one, dict_var)
+                if self._logger is not None:
+                    logger_str = "loop_subst: found {}{}".format(standard_name, context_string(context))
+                # End if
+            else:
+                my_vars = [self.find_variable(x) for x in loop_var]
+                if None not in my_vars:
+                    my_var = tuple(my_vars)
+                    if self._logger is not None:
+                        names = [x.get_prop_value('local_name') for x in my_vars]
+                        logger_str = "loop_subst: {} ==> (){}".format(standard_name, ', '.join(names), context_string(context))
+                    # End if
+                else:
+                    if self._logger is not None:
+                        logger_str = "loop_subst: {} ==> ({}, {}) FAILED{}".format(standard_name, beg_name, end_name, context_string(context))
+                    # End if
+                    my_var = None
+                # End if
+            # End if
+        else:
+            if self._logger is not None:
+                logger_str = "loop_subst: {} is not a loop variable{}".format(standard_name, context_string(context))
+            # End if
+            my_var = None
+        # End if
+        if logger_str is not None:
+            self._logger.debug(logger_str)
+        # End if
+        return my_var
+
+    def find_dimension_subst(self, standard_name, any_scope=True, context=None):
+        """If <standard_name> is of the form <standard_name>_loop_extent
+        attempt to find a variable of the form <standard_name>_dimension
+        and return that. If such a variable is not found, raise an exception.
+        If <standard_name> is not of the form <standard_name>_extent, return
+        None.
+        """
+        loop_var = standard_name in VarDictionary.__ccpp_dim_subst__
+        logger_str = None
+        if loop_var:
+            # Let us see if we can replace the variable
+            dim_name = VarDictionary.__ccpp_dim_subst__[standard_name]
+            my_var = self.find_variable(dim_name, any_scope=any_scope)
+            if my_var is None:
+                raise CCPPError("Dimension variable, {} not found{}".format(dim_name, context_string(context)))
+            # End if
+        else:
+            my_var = None
+        # End if
+        return my_var
+
+###############################################################################
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/parse_tools/__init__.py
+++ b/scripts/parse_tools/__init__.py
@@ -1,0 +1,74 @@
+"""Public API for the parse_tools library
+"""
+__all__ = [
+    'CCPPError',
+    'check_cf_standard_name',
+    'check_dimensions',
+    'check_fortran_id',
+    'check_fortran_intrinsic',
+    'check_fortran_ref',
+    'check_fortran_type',
+    'context_string',
+    'find_schema_version',
+    'FORTRAN_DP_RE',
+    'FortranMetadataSyntax',
+    'FORTRAN_ID',
+    'FORTRAN_SCALAR_REF',
+    'initLog',
+    'MetadataSyntax',
+    'ParseContext',
+    'ParseInternalError',
+    'ParseSource',
+    'ParseSyntaxError',
+    'ParseObject',
+    'register_fortran_ddt_name',
+    'read_xml_file',
+    'registered_fortran_ddt_name',
+    'setLogLevel',
+    'setLogToFile',
+    'setLogToNull',
+    'setLogToStdout',
+    'validate_xml_file'
+]
+
+import six
+if six.PY3:
+    from parse_tools.parse_tools    import ParseContext, ParseSource
+    from parse_tools.parse_tools    import ParseSyntaxError, ParseInternalError
+    from parse_tools.parse_tools    import CCPPError, context_string
+    from parse_tools.parse_object   import MetadataSyntax, FortranMetadataSyntax
+    from parse_tools.parse_object   import ParseObject
+    from parse_tools.parse_checkers import check_fortran_id, FORTRAN_ID
+    from parse_tools.parse_checkers import FORTRAN_DP_RE
+    from parse_tools.parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
+    from parse_tools.parse_checkers import check_fortran_intrinsic
+    from parse_tools.parse_checkers import check_fortran_type
+    from parse_tools.parse_checkers import registered_fortran_ddt_name
+    from parse_tools.parse_checkers import register_fortran_ddt_name
+    from parse_tools.parse_checkers import check_dimensions
+    from parse_tools.parse_checkers import check_cf_standard_name
+    from parse_tools.parse_log      import initLog, setLogLevel
+    from parse_tools.parse_log      import setLogToStdout, setLogToNull
+    from parse_tools.parse_log      import setLogToFile
+    from parse_tools.xml_tools      import find_schema_version
+    from parse_tools.xml_tools      import read_xml_file, validate_xml_file
+else:
+    from parse_tools    import ParseContext, ParseSource
+    from parse_tools    import ParseSyntaxError, ParseInternalError
+    from parse_tools    import CCPPError, context_string
+    from parse_object   import MetadataSyntax, FortranMetadataSyntax
+    from parse_object   import ParseObject
+    from parse_checkers import check_fortran_id, FORTRAN_ID
+    from parse_checkers import FORTRAN_DP_RE
+    from parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
+    from parse_checkers import check_fortran_intrinsic
+    from parse_checkers import check_fortran_type
+    from parse_checkers import registered_fortran_ddt_name
+    from parse_checkers import register_fortran_ddt_name
+    from parse_checkers import check_dimensions, check_cf_standard_name
+    from parse_log      import initLog, setLogLevel
+    from parse_log      import setLogToStdout, setLogToNull
+    from parse_log      import setLogToFile
+    from xml_tools      import find_schema_version, validate_xml_file
+    from xml_tools      import read_xml_file
+# End if

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+
+"""Helper functions to validate parsed input"""
+
+# Python library imports
+import re
+# CCPP framework imports
+from parse_tools import CCPPError
+
+########################################################################
+
+def check_dimensions(test_val, max_len=0, error=False):
+    """Return <test_val> if a valid dimensions list, otherwise, None
+    If <max_len> > 0, each string in <test_val> must not be longer than
+    <max_len>.
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_dimensions(["dim1", "dim2name"])
+    ['dim1', 'dim2name']
+    >>> check_dimensions([":", ":"])
+    [':', ':']
+    >>> check_dimensions([":", "dim2"])
+    [':', 'dim2']
+    >>> check_dimensions(["dim1", ":"])
+    ['dim1', ':']
+    >>> check_dimensions(['start1:end1', 'start2:end2'])
+    ['start1:end1', 'start2:end2']
+    >>> check_dimensions(['start1:', 'start2:end2'])
+    ['start1:', 'start2:end2']
+    >>> check_dimensions(["dim1", "dim2name"], max_len=5)
+
+    >>> check_dimensions(["dim1", "dim2name"], error=True, max_len=5)
+    Traceback (most recent call last):
+    CCPPError: 'dim2name' is too long (> 5 chars)
+    >>> check_dimensions("hi_mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is invalid; not a list
+    """
+    if type(test_val) != list:
+        if error:
+            raise CCPPError("'{}' is invalid; not a list".format(test_val))
+        else:
+            test_val = None
+        # End if
+    else:
+        for item in test_val:
+            isplit = item.split(':')
+            # Check for too many colons
+            if (len(isplit) > 2):
+                if error:
+                    raise CCPPError("'{}' is an invalid dimension range".format(item))
+                else:
+                    test_val = None
+                # End if
+                break
+            # End if
+            # Check possible dim styles (a, a:b, a:, :b, :)
+            tdims = [x for x in isplit if len(x) > 0]
+            tvs = [check_fortran_id(x, max_len=max_len, error=error) for x in tdims]
+            if None in tvs:
+                if error:
+                    raise CCPPError("'{}' is an invalid dimension name".format(item))
+                else:
+                    test_val = None
+                # End if
+                break
+            # End if
+        # End for
+    # End if
+    return test_val
+
+########################################################################
+
+# CF_ID is a string representing the regular expression for CF Standard Names
+CF_ID = r"[a-z][a-z0-9_]*"
+__CFID_RE = re.compile(CF_ID+r"$")
+
+def check_cf_standard_name(test_val, error=False):
+    """Return <test_val> if a valid CF Standard Name, otherwise, None
+    http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_cf_standard_name("hi_mom")
+    'hi_mom'
+    >>> check_cf_standard_name("hi mom")
+
+    >>> check_cf_standard_name("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is not a valid CF Standard Name
+    >>> check_cf_standard_name("")
+
+    >>> check_cf_standard_name("_hi_mom")
+
+    >>> check_cf_standard_name("2pac")
+
+    >>> check_cf_standard_name("Agood4tranID")
+
+    >>> check_cf_standard_name("agoodcfid")
+    'agoodcfid'
+    """
+    match = __CFID_RE.match(test_val)
+    if match is None:
+        if error:
+            raise CCPPError("'{}' is not a valid CF Standard Name".format(test_val))
+        else:
+            test_val = None
+        # End if
+    # End if
+    return test_val
+
+########################################################################
+
+### Fortran-specific parsing helper variables and functions
+
+########################################################################
+
+# FORTRAN_ID is a string representing the regular expression for Fortran names
+FORTRAN_ID = r"([A-Za-z][A-Za-z0-9_]*)"
+__FID_RE = re.compile(FORTRAN_ID+r"$")
+# Note that the scalar array reference expressions below are not really for
+# scalar references because a colon can be a placeholder, unlike in Fortran code
+FORTRAN_SCALAR_ARREF = r"\([ ]*(?:"+FORTRAN_ID+r"|[:])[ ]*(?:,[ ]*(?:"+FORTRAN_ID+r"|[:])[ ]*){0,6}\)"
+FORTRAN_SCALAR_REF = r"(?:"+FORTRAN_ID+r"[ ]*"+FORTRAN_SCALAR_ARREF+r")"
+_FORTRAN_SCALAR_REF_RE = re.compile(FORTRAN_SCALAR_REF+r"$")
+FORTRAN_INTRINSIC_TYPES = [ "integer", "real", "logical", "complex",
+                            "double precision", "character" ]
+FORTRAN_DP_RE = re.compile(r"(?i)double\s*precision")
+FORTRAN_TYPE_RE = re.compile(r"(?i)type\s*\(\s*("+FORTRAN_ID+r")\s*\)")
+
+_REGISTERED_FORTRAN_DDT_NAMES = list()
+
+########################################################################
+
+def check_fortran_id(test_val, max_len=0, error=False):
+    """Return <test_val> if a valid Fortran identifier, otherwise, None
+    If <max_len> > 0, <test_val> must not be longer than <max_len>.
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_fortran_id("hi_mom")
+    'hi_mom'
+    >>> check_fortran_id("hi_mom", max_len=5)
+
+    >>> check_fortran_id("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is too long (> 5 chars)
+    >>> check_fortran_id("hi mom")
+
+    >>> check_fortran_id("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is not a valid Fortran identifier
+    >>> check_fortran_id("")
+
+    >>> check_fortran_id("_hi_mom")
+
+    >>> check_fortran_id("2pac")
+
+    >>> check_fortran_id("Agood4tranID")
+    'Agood4tranID'
+    """
+    match = __FID_RE.match(test_val)
+    if match is None:
+        if error:
+            raise CCPPError("'{}' is not a valid Fortran identifier".format(test_val))
+        else:
+            test_val = None
+        # End if
+    elif (max_len > 0) and (len(test_val) > max_len):
+        if error:
+            raise CCPPError("'{}' is too long (> {} chars)".format(test_val, max_len))
+        else:
+            test_val = None
+        # End if
+    # End if
+    return test_val
+
+########################################################################
+
+def check_fortran_ref(test_val, max_len=0, error=False):
+    """Return <test_val> if a valid simple Fortran variable reference,
+    otherwise, None. A simple Fortran variable reference is defined as
+    a scalar id or a scalar array reference.
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_fortran_ref("hi_mom")
+    'hi_mom'
+    >>> check_fortran_ref("hi_mom", max_len=5)
+
+    >>> check_fortran_ref("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is too long (> 5 chars)
+    >>> check_fortran_ref("hi mom")
+
+    >>> check_fortran_ref("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'hi_mom' is not a valid Fortran identifier
+    >>> check_fortran_ref("")
+
+    >>> check_fortran_ref("_hi_mom")
+
+    >>> check_fortran_ref("2pac")
+
+    >>> check_fortran_ref("Agood4tranID")
+    'Agood4tranID'
+    >>> check_fortran_ref("foo(bar)")
+    'foo(bar)'
+    >>> check_fortran_ref("foo( bar, baz )")
+    'foo( bar, baz )'
+    >>> check_fortran_ref("foo( bar, )")
+
+    >>> check_fortran_ref("foo( bar, )", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'foo( bar, )' is not a valid Fortran scalar reference
+    >>> check_fortran_ref("foo()", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'foo()' is not a valid Fortran scalar reference
+    >>> check_fortran_ref("foo(bar, bazz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'bazz' is too long (> 3 chars) in foo(bar, bazz)
+    >>> check_fortran_ref("foo(barr, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'bazr' is too long (> 3 chars) in foo(barr, baz)
+    >>> check_fortran_ref("fooo(bar, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'foo' is too long (> 3 chars) in fooo(bar, baz)
+    """
+    idval = check_fortran_id(test_val, max_len=max_len, error=False)
+    if idval is None:
+        match = _FORTRAN_SCALAR_REF_RE.match(test_val)
+        if match is None:
+            if error:
+                raise CCPPError("'{}' is not a valid Fortran scalar reference".format(test_val))
+            else:
+                test_val = None
+            # End if
+        elif max_len > 0:
+            tokens = test_val.strip().rstrip(')').split('(')
+            tokens = [tokens[0].strip()] + [x.strip() for x in tokens[1].split(',')]
+            for token in tokens:
+                if len(token) > max_len:
+                    if error:
+                        raise CCPPError("'{}' is too long (> {} chars) in {}".format(token, max_len, test_val))
+                    else:
+                        test_val = None
+                        break
+                    # End if
+                # End if
+            # End for
+        # End if
+    # End if
+    return test_val
+
+########################################################################
+
+def check_fortran_intrinsic(typestr, error=False):
+    """Return <test_val> if a valid Fortran intrinsic type, otherwise, None
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_fortran_intrinsic("real")
+    'real'
+    >>> check_fortran_intrinsic("complex")
+    'complex'
+    >>> check_fortran_intrinsic("integer")
+    'integer'
+    >>> check_fortran_intrinsic("InteGer")
+    'InteGer'
+    >>> check_fortran_intrinsic("logical")
+    'logical'
+    >>> check_fortran_intrinsic("character")
+    'character'
+    >>> check_fortran_intrinsic("double precision")
+    'double precision'
+    >>> check_fortran_intrinsic("double   precision")
+    'double   precision'
+    >>> check_fortran_intrinsic("doubleprecision")
+    'doubleprecision'
+    >>> check_fortran_intrinsic("char", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'char' is not a valid Fortran type
+    >>> check_fortran_intrinsic("int")
+
+    >>> check_fortran_intrinsic("char", error=False)
+
+    >>> check_fortran_intrinsic("type")
+
+    >>> check_fortran_intrinsic("complex(kind=r8)")
+
+    """
+    match = typestr.strip().lower() in FORTRAN_INTRINSIC_TYPES
+    if (not match) and (typestr.lower()[0:6] == 'double'):
+        # Special case for double precision
+        match = FORTRAN_DP_RE.match(typestr.strip()) is not None
+    # End if
+    if not match:
+        if error:
+            raise CCPPError("'{}' is not a valid Fortran type".format(typestr))
+        else:
+            typestr = None
+        # End if
+    # End if
+    return typestr
+
+########################################################################
+
+def check_fortran_type(typestr, error=False):
+    """Return <typestr> if a valid Fortran type, otherwise, None
+    if <error> is True, raise an Exception if <typestr> is not valid.
+    >>> check_fortran_type("real")
+    'real'
+    >>> check_fortran_type("integer")
+    'integer'
+    >>> check_fortran_type("InteGer")
+    'InteGer'
+    >>> check_fortran_type("character")
+    'character'
+    >>> check_fortran_type("double precision")
+    'double precision'
+    >>> check_fortran_type("double   precision")
+    'double   precision'
+    >>> check_fortran_type("doubleprecision")
+    'doubleprecision'
+    >>> check_fortran_type("complex")
+    'complex'
+    >>> check_fortran_type("char", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'char' is not a valid Fortran type
+    >>> check_fortran_type("int")
+
+    >>> check_fortran_type("char", error=False)
+
+    >>> check_fortran_type("type")
+
+    >>> check_fortran_type("type", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'char' is not a valid derived Fortran type
+    >>> check_fortran_type("type(hi mom)", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: 'type(hi mom)' is not a valid derived Fortran type
+    """
+    dt = ""
+    match = check_fortran_intrinsic(typestr, error=False)
+    if match is None:
+        match = registered_fortran_ddt_name(typestr)
+        dt = " derived"
+    # End if
+    if match is None:
+        if error:
+            raise CCPPError("'{}' is not a valid{} Fortran type".format(typestr, dt))
+        else:
+            typestr = None
+        # End if
+    # End if
+    return typestr
+
+########################################################################
+
+def registered_fortran_ddt_name(name):
+    if name in _REGISTERED_FORTRAN_DDT_NAMES:
+        return name
+    else:
+        return None
+
+########################################################################
+
+def register_fortran_ddt_name(name):
+    if name not in _REGISTERED_FORTRAN_DDT_NAMES:
+        _REGISTERED_FORTRAN_DDT_NAMES.append(name)
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/parse_tools/parse_log.py
+++ b/scripts/parse_tools/parse_log.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""Shared logger for parse processes"""
+
+# Python library imports
+import logging
+# CCPP framework imports
+
+def initLog(name, level=None):
+    logger = logging.getLogger(name)
+    # Turn logging to WARNING if not set
+    llevel = logger.getEffectiveLevel()
+    if (level is None) and (llevel == logging.NOTSET):
+        logger.setLevel(logging.WARNING)
+    # End if
+    setLogToStdout(logger)
+    return logger
+
+def setLogLevel(logger, level):
+    logger.setLevel(level)
+
+def removeHandlers(logger):
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+
+def setLogToStdout(logger):
+    removeHandlers(logger)
+    logger.addHandler(logging.StreamHandler())
+
+def setLogToNull(logger):
+    removeHandlers(logger)
+    logger.addHandler(logging.NullHandler())
+
+def setLogToFile(logger, filename):
+    removeHandlers(logger)
+    logger.addHandler(logging.StreamHandler())

--- a/scripts/parse_tools/parse_object.py
+++ b/scripts/parse_tools/parse_object.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python
+"""A module for the base, ParseObject class"""
+
+# Python library imports
+import re
+# CCPP framework imports
+import six
+if six.PY3:
+    from parse_tools.parse_tools    import ParseContext, CCPPError
+    from parse_tools.parse_checkers import check_fortran_ref
+else:
+    from parse_tools    import ParseContext, CCPPError
+    from parse_checkers import check_fortran_ref
+# End if
+
+########################################################################
+
+## classes to check language-dependent metadata syntax
+class MetadataSyntax():
+    """MetadataSyntax serves as a base class for metadata syntax checking.
+    It uses the most common comment type used by Python and shell languages.
+    Note that this is not a complete class (missing functions).
+    >>> MetadataSyntax.line_start("## Hi mom")
+    '## '
+    >>> MetadataSyntax.line_start("##Hi mom")
+
+    >>> MetadataSyntax.line_start("#> Hi mom")
+
+    >>> MetadataSyntax.table_start("#> ")
+    '#> '
+    >>> MetadataSyntax.table_start("#>Hi mom")
+
+    >>> MetadataSyntax.table_start("#> Hi mom")
+    '#> '
+    >>> MetadataSyntax.table_start("## Hi mom")
+    '## '
+    >>> MetadataSyntax.table_start("##Hi mom")
+
+    >>> MetadataSyntax.line_start("!! Hi mom")
+
+    >>> MetadataSyntax.table_start("!> Hi mom")
+
+    >>> MetadataSyntax.blank_line("##")
+    True
+    >>> MetadataSyntax.blank_line("##   ")
+    True
+    >>> MetadataSyntax.blank_line("## Hi mom")
+    False
+    >>> MetadataSyntax.blank_line("!!")
+    False
+    >>> MetadataSyntax.strip("##   ")
+    ''
+    >>> MetadataSyntax.strip("##  Hi mom")
+    'Hi mom'
+    >>> MetadataSyntax.strip("#>\defgroup")
+
+    >>> MetadataSyntax.strip("#  Hi mom")
+
+    >>> foo = MetadataSyntax() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    NotImplementedError: Cannot create MetadataSyntax instances
+    >>> MetadataSyntax.is_variable_name('V_123')
+    True
+    >>> MetadataSyntax.is_variable_name('v_v_a2')
+    True
+    >>> MetadataSyntax.is_variable_name('i')
+    True
+    >>> MetadataSyntax.is_variable_name('')
+    False
+    >>> MetadataSyntax.is_variable_name('_hi_mom')
+    True
+    >>> MetadataSyntax.is_variable_name('2i')
+    False
+    >>> MetadataSyntax.is_scalar_reference('hi[mom') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    AttributeError: class MetadataSyntax has no attribute 'is_scalar_reference'
+    """
+    _blank_line = re.compile(r"^##\s*$")
+    _variable_name = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    _table_start = re.compile(r"^(#[#>]\s+)")
+    _line_start  = re.compile(r"^(##\s+)")
+
+    @classmethod
+    def line_start(cls, line):
+        """Return True iff line begins with the proper metadata syntax"""
+        match = cls._line_start.match(line)
+        if match is not None:
+            return match.group(1)
+        else:
+            return None
+
+    @classmethod
+    def table_start(cls, line):
+        """Return True iff line begins with the proper metadata table syntax"""
+        match = cls._table_start.match(line)
+        if match is not None:
+            return match.group(1)
+        else:
+            return None
+
+    @classmethod
+    def blank_line(cls, line):
+        """Return True iff line is the proper metadata blank format"""
+        return (len(line) == 0) or (cls._blank_line.match(line) is not None)
+
+    @classmethod
+    def strip(cls, line):
+        """Strip line-beginning syntax from line"""
+        sline = None
+        ls = cls.line_start(line)
+        if ls is not None:
+            sline = line[len(ls):].strip()
+        # End if
+        if sline is None:
+            ts = cls.table_start(line)
+            if ts is not None:
+                sline = line[len(ts):].strip()
+            # End if
+        # End if
+        return sline
+
+    @classmethod
+    def is_variable_name(cls, name):
+        return cls._variable_name.match(name) is not None
+
+    @classmethod
+    def __init__(cls):
+        raise NotImplementedError("Cannot create {} instances".format(cls.__name__))
+
+########################################################################
+
+class FortranMetadataSyntax(MetadataSyntax):
+    """FortranMetadataSyntax is a class for Fortran metadata syntax checking.
+    >>> FortranMetadataSyntax.line_start("!! Hi mom")
+    '!! '
+    >>> FortranMetadataSyntax.line_start("!!Hi mom")
+
+    >>> FortranMetadataSyntax.line_start("!> Hi mom")
+
+    >>> FortranMetadataSyntax.table_start("!>Hi mom")
+
+    >>> FortranMetadataSyntax.table_start("#>Hi mom")
+
+    >>> FortranMetadataSyntax.table_start("!! Hi mom")
+    '!! '
+    >>> FortranMetadataSyntax.line_start("## Hi mom")
+
+    >>> FortranMetadataSyntax.table_start("#>Hi mom")
+
+    >>> FortranMetadataSyntax.blank_line("!!")
+    True
+    >>> FortranMetadataSyntax.blank_line("!!   ")
+    True
+    >>> FortranMetadataSyntax.blank_line("!! Hi mom")
+    False
+    >>> FortranMetadataSyntax.blank_line("##")
+    False
+    >>> FortranMetadataSyntax.strip("!!   ")
+    ''
+    >>> FortranMetadataSyntax.strip("!!  Hi mom")
+    'Hi mom'
+    >>> FortranMetadataSyntax.strip("!>\defgroup")
+
+    >>> FortranMetadataSyntax.strip("!  Hi mom")
+
+    >>> foo = FortranMetadataSyntax() #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    NotImplementedError: Cannot create FortranMetadataSyntax instances
+    >>> FortranMetadataSyntax.is_variable_name('V_123')
+    True
+    >>> FortranMetadataSyntax.is_variable_name('v_v_a2')
+    True
+    >>> FortranMetadataSyntax.is_variable_name('i')
+    True
+    >>> FortranMetadataSyntax.is_variable_name('')
+    False
+    >>> FortranMetadataSyntax.is_variable_name('_hi_mom')
+    False
+    >>> FortranMetadataSyntax.is_variable_name('2i')
+    False
+    >>> FortranMetadataSyntax.is_scalar_reference('hi_mom')
+    True
+    >>> FortranMetadataSyntax.is_scalar_reference('hi(mom)')
+    True
+    >>> FortranMetadataSyntax.is_scalar_reference('hi(mom, dad)')
+    True
+    """
+
+    _blank_line = re.compile(r"!!\s*$")
+    _table_start = re.compile(r"(![!>]\s+)")
+    _line_start  = re.compile(r"(!!\s+)")
+    _variable_name = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+    @classmethod
+    def is_scalar_reference(cls, test_val):
+        return check_fortran_ref(test_val) is not None
+
+########################################################################
+
+class ParseObject(ParseContext):
+    """ParseObject is a simple class that keeps track of an object's
+    place in a file and safely produces lines from an array of lines
+    >>> ParseObject('foobar.F90', 1) #doctest: +ELLIPSIS
+    <__main__.ParseObject object at 0x...>
+    >>> ParseObject('foobar.F90', 1).filename
+    'foobar.F90'
+    >>> ParseObject('foobar.F90', ["##hi mom",], line_start=1).curr_line()
+    (None, 1)
+    >>> ParseObject('foobar.F90', ["first line","## hi mom"], line_start=1).curr_line()
+    ('## hi mom', 1)
+    >>> ParseObject('foobar.F90', ["##hi mom",], line_start=1).next_line()
+    (None, 1)
+    >>> ParseObject('foobar.F90', ["##first line","## hi mom"], line_start=1).next_line()
+    ('## hi mom', 1)
+    >>> ParseObject('foobar.F90', ["## hi \\\\","## mom"], line_start=0).next_line()
+    ('## hi mom', 0)
+    >>> ParseObject('foobar.F90', ["line1","##line2","## hi mom"], line_start=2).next_line()
+    ('## hi mom', 2)
+    >>> ParseObject('foobar.F90', ["## hi \\\\","## there \\\\","## mom"], line_start=0).next_line()
+    ('## hi there mom', 0)
+    >>> ParseObject('foobar.F90', ["!! line1","!! hi mom"], line_start=1).next_line()
+    ('!! hi mom', 1)
+    """
+
+    def __init__(self, filename, lines_in, line_start=0, syntax=MetadataSyntax):
+        self._filename = filename
+        self._lines = lines_in
+        self._line_start = line_start
+        self._line_end = line_start
+        self._line_next = line_start
+        self._syntax = syntax
+        super(ParseObject, self).__init__(linenum=line_start, filename=filename)
+
+    @property
+    def first_line_num(self):
+        'Return the first line parsed'
+        return self._first_line
+
+    @property
+    def last_line_num(self):
+        'Return the last line parsed'
+        return self._line_end
+
+    @property
+    def syntax(self):
+        'Return the syntax class for this ParseObject'
+        if self._syntax is None:
+            return "None"
+        else:
+            return self._syntax.__name__
+
+    def curr_line(self):
+        valid_line = self.line_num < len(self._lines)
+        _curr_line = None
+        _my_curr_lineno = self.line_num
+        if valid_line:
+            try:
+                # Do not strip the comment syntax from first line
+                _curr_line = self._lines[self.line_num].rstrip()
+                self._line_next = self.line_num + 1
+                self._line_end = self._line_next
+            except CCPPError as exc:
+                valid_line = False
+        # End if
+        # We allow continuation self._lines (ending with a single backslash)
+        if valid_line and _curr_line.endswith('\\'):
+            if self._syntax is None:
+                next_line, lnum = self.next_line()
+            else:
+                next_line, nlnum = self.next_line()
+                if next_line is not None:
+                    next_line = self._syntax.strip(next_line)
+            # End if
+            if next_line is None:
+                # We ran out of lines, just strip the backslash
+                _curr_line = _curr_line[0:len(_curr_line)-1]
+            else:
+                _curr_line = _curr_line[0:len(_curr_line)-1] + next_line
+            # End if
+        # End if
+        # curr_line should not change the line number
+        self.line_num = _my_curr_lineno
+        return _curr_line, self.line_num
+
+    def next_line(self):
+        self.line_num = self._line_next
+        return self.curr_line()
+
+    def peek_line(self, line_num):
+        if (line_num >= 0) and (line_num < len(self._lines)):
+            return self._lines[line_num]
+        else:
+            return None
+        # End if
+
+    def reset_pos(self, line_start=0):
+        if (line_start < 0) or (line_start >= len(self._lines)):
+            raise CCPPError('Attempt to reset_pos to non-existent line, {}'.format(line_start))
+        else:
+            self.line_num = line_start
+            self._line_next = line_start
+        # End if
+
+    def write_line(self, line_num, line):
+        "Overwrite line, <line_num> with <line>"
+        if (line_num < 0) or (line_num >= len(self._lines)):
+            raise CCPPError('Attempt to write non-existent line, {}'.format(line_num))
+        else:
+            self._lines[line_num] = line
+        # End if
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/parse_tools/parse_tools.py
+++ b/scripts/parse_tools/parse_tools.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+
+"""Classes to aid the parsing process"""
+
+# Python library imports
+import collections
+import copy
+# CCPP framework imports
+
+###############################################################################
+def context_string(context=None, with_comma=True):
+###############################################################################
+    """Return a context string if <context> is not None otherwise, return
+    an empty string.
+    if with_comma is True, prepend string with ', at ' or ', in '.
+    >>> context_string()
+    ''
+    >>> context_string(with_comma=True)
+    ''
+    >>> context_string(context= ParseContext(linenum=32, filename="source.F90"), with_comma=False)
+    'source.F90:33'
+    >>> context_string(context= ParseContext(linenum=32, filename="source.F90"), with_comma=True)
+    ', at source.F90:33'
+    >>> context_string(context= ParseContext(linenum=32, filename="source.F90"))
+    ', at source.F90:33'
+    >>> context_string(context= ParseContext(filename="source.F90"), with_comma=False)
+    'source.F90'
+    >>> context_string(context= ParseContext(filename="source.F90"), with_comma=True)
+    ', in source.F90'
+    >>> context_string(context= ParseContext(filename="source.F90"))
+    ', in source.F90'
+    """
+    if context is None:
+        cstr = ""
+    elif with_comma:
+        if context.line_num < 0:
+            cstr = ", in {}".format(context)
+        else:
+            cstr = ", at {}".format(context)
+        # End if
+    else:
+        cstr = "{}".format(context)
+    # End if
+    return cstr
+
+###############################################################################
+class CCPPError(ValueError):
+    "Class so programs can log user errors without backtrace"
+    def __init__(self, message):
+        super(CCPPError, self).__init__(message)
+
+########################################################################
+
+class ParseSyntaxError(CCPPError):
+    """Exception that is aware of parsing context"""
+    def __init__(self, token_type, token=None, context=None):
+        cstr = context_string(context)
+        if token is None:
+            message = "{}{}".format(token_type, cstr)
+        else:
+            message = "Invalid {}, '{}'{}".format(token_type, token, cstr)
+        # End if
+        super(ParseSyntaxError, self).__init__(message)
+
+########################################################################
+
+class ParseInternalError(Exception):
+    """Exception for internal parser use errors
+    Note that this error will not be trapped by programs such as ccpp_capgen
+    """
+    def __init__(self, errmsg, context=None):
+        message = "{}{}".format(errmsg, context_string(context))
+        super(ParseInternalError, self).__init__(message)
+
+########################################################################
+
+class ParseContextError(CCPPError):
+    """Exception for errors using ParseContext"""
+    def __init__(self, errmsg, context):
+        message = "{}{}".format(errmsg, context_string(context))
+        super(ParseContextError, self).__init__(message)
+
+########################################################################
+
+class ContextRegion(collections.Iterable):
+    """Class to imitate the LIFO nature of program language blocks"""
+
+    def __init__(self):
+        self._lifo = list()
+
+    def push(self, rtype, rname):
+        """Push a new region onto the stack"""
+        self._lifo.append([rtype, rname])
+
+    def pop(self):
+        """Remove the top item from the stack"""
+        return self._lifo.pop()
+
+    def __iter__(self):
+        for item in self._lifo:
+            yield item[0]
+
+    def __len__(self):
+        return len(self._lifo)
+
+    def __getitem__(self, index):
+        return self._lifo[index]
+
+########################################################################
+
+class ParseContext(object):
+    """A class for keeping track of a parsing position
+    >>> ParseContext(32, "source.F90") #doctest: +ELLIPSIS
+    <__main__.ParseContext object at 0x...>
+    >>> ParseContext("source.F90", 32)
+    Traceback (most recent call last):
+    CCPPError: ParseContext linenum must be an int
+    >>> ParseContext(32, 90) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: ParseContext filenum must be a string
+    >>> "{}".format(ParseContext(32, "source.F90"))
+    'source.F90:33'
+    >>> "{}".format(ParseContext())
+    '<standard input>'
+    >>> ParseContext(linenum=32, filename="source.F90").increment(13)
+
+    """
+
+    def __init__(self, linenum=None, filename=None, context=None):
+        if context is not None:
+            # If context is passed, ignore linenum
+            linenum = context.line_num
+        elif linenum is None:
+            linenum = -1
+        elif not isinstance(linenum, int):
+            raise CCPPError('ParseContext linenum must be an int')
+        # End if
+        if context is not None:
+            # If context is passed, ignore filename
+            filename = context.filename
+        elif filename is None:
+            filename = "<standard input>"
+        elif not isinstance(filename, str):
+            raise CCPPError('ParseContext filename must be a string')
+        # End if
+        self._linenum = linenum
+        self._filename = filename
+        if context is not None:
+            self.regions = copy.deepcopy(context.regions)
+        else:
+            self.regions = ContextRegion()
+        # End if
+
+    @property
+    def line_num(self):
+        'Return the current line'
+        return self._linenum
+
+    @line_num.setter
+    def line_num(self, newnum):
+        self._linenum = newnum
+
+    @property
+    def filename(self):
+        "'Return the object's filename"
+        return self._filename
+
+    def __str__(self):
+        """Return a string representing the location in a file
+        Note that self._linenum is zero based.
+        """
+        if self._linenum >= 0:
+            return "{}:{}".format(self._filename, self._linenum+1)
+        else:
+            return "{}".format(self._filename)
+
+    def increment(self, inc=1):
+        "Increment the location within a file"
+        if self._linenum < 0:
+            self._linenum = 0
+        # End if
+        self._linenum = self._linenum + inc
+
+    def enter_region(self, region_type, region_name=None, nested_ok=True):
+        """Mark the entry of a region (e.g., DDT, module, function).
+        If nested_ok == False, throw an exception if the context is already
+        inside a region with the same type."""
+        if (not nested_ok) and (region_type in self.regions):
+            raise ParseContextError("Cannot enter a nested {} region".format(region_type), self)
+        else:
+            self.regions.push(region_type, region_name)
+
+    def leave_region(self, region_type, region_name=None):
+        """Mark the exit from a region. Check region name if possible"""
+        if len(self.regions) == 0:
+            raise ParseContextError("Cannot exit, not currently in any region", self)
+        else:
+            curr_type, curr_name = self.regions.pop()
+            if curr_type != region_type:
+                raise ParseContextError("Trying to exit {} region while currently in {} region".format(region_type, curr_type), self)
+            elif (region_name is not None) and (curr_name is not None):
+                if region_name != curr_name:
+                    raise ParseContextError("Trying to exit {} {} while currently in {} {}".format(region_type, region_name, curr_type, curr_name), self)
+                # End if
+            elif (region_name is not None) and (curr_name is None):
+                raise ParseContextError("Trying to exit {} {} while currently in unnamed {} region".format(region_type, region_name, curr_type), self)
+            # End if
+        # End if
+
+    def curr_region(self):
+        """Return the innermost current region"""
+        return self.regions[-1]
+
+    def region_str(self):
+        """Create a string describing the current region"""
+        rgn_str = ""
+        for index in len(self.regions):
+            rtype, rname = self.regions[index]
+            if len(rgn_str) > 0:
+                rgn_str = rgn_str + " ==> "
+            # End if
+            rgn_str = rgh_str + "{}".format(rtype)
+            if rname is not None:
+                rgn_str = rgh_str + "{}".format(rname)
+            # End if
+        # End for
+        return rgn_str
+
+########################################################################
+
+class ParseSource(object):
+    """
+    A simple object for providing source information
+    >>> ParseSource("myname", "mytype", ParseContext(13, "foo.F90")) #doctest: +ELLIPSIS
+    <__main__.ParseSource object at 0x...>
+    >>> ParseSource("myname", "mytype", ParseContext(13, "foo.F90")).type
+    'mytype'
+    >>> ParseSource("myname", "mytype", ParseContext(13, "foo.F90")).name
+    'myname'
+    >>> print("{}".format(ParseSource("myname", "mytype", ParseContext(13, "foo.F90")).context))
+    foo.F90:14
+    """
+
+    def __init__(self, name_in, type_in, context_in):
+        self._name = name_in
+        self._type = type_in
+        self._context = context_in
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def context(self):
+        return self._context
+
+########################################################################
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/scripts/parse_tools/six.py
+++ b/scripts/parse_tools/six.py
@@ -1,0 +1,890 @@
+# Copyright (c) 2010-2017 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.11.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+
+"""
+Parse a host-model registry XML file and return the captured variables.
+"""
+
+# Python library imports
+from __future__ import print_function
+import os
+import os.path
+import subprocess
+import xml.etree.ElementTree as ET
+try:
+    from distutils.spawn import find_executable
+    xmllint = find_executable('xmllint')
+except ImportError as ie:
+    xmllint = None
+# End try
+# CCPP framework imports
+import six
+from parse_tools import CCPPError
+
+###############################################################################
+def call_command(commands, logger, silent=False):
+###############################################################################
+    """
+    Try a command line and return the output on success (None on failure)
+    >>> call_command(['ls', 'really__improbable_fffilename.foo'], logger) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: Execution of 'ls really__improbable_fffilename.foo' failed:
+    [Errno 2] No such file or directory
+    >>> call_command(['ls', 'really__improbable_fffilename.foo'], logger, silent=True)
+    False
+    >>> call_command(['ls'], logger)
+    True
+    """
+    result = False
+    try:
+        outstr = subprocess.check_output(commands, stderr=subprocess.STDOUT)
+        result = True
+    except (OSError, CCPPError, subprocess.CalledProcessError) as err:
+        if silent:
+            result = False
+        else:
+            cmd = ' '.join(commands)
+            outstr = "Execution of '{}' failed:\n".format(cmd)
+            outstr = outstr + "{}".format(err)
+            raise CCPPError(outstr)
+        # End if
+    # End of try
+    return result
+
+###############################################################################
+def find_schema_version(root, logger):
+###############################################################################
+    """
+    Find the version of the host registry file represented by root
+    >>> find_schema_version(ET.fromstring('<model name="CAM" version="1.0"></model>'), logger)
+    [1, 0]
+    >>> find_schema_version(ET.fromstring('<model name="CAM" version="1.a"></model>'), logger) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: Illegal version string, '1.a'
+    Format must be <integer>.<integer>
+    >>> find_schema_version(ET.fromstring('<model name="CAM" version="0.0"></model>'), logger) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: Illegal version string, '0.0'
+    Major version must be at least 1
+    >>> find_schema_version(ET.fromstring('<model name="CAM" version="0.-1"></model>'), logger) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    CCPPError: Illegal version string, '0.0'
+    Minor version must be at least 0
+    """
+    verbits = None
+    if 'version' not in root.attrib:
+        raise CCPPError("version attribute required")
+    else:
+        version = root.attrib['version']
+        versplit = version.split('.')
+        try:
+            if len(versplit) != 2:
+                raise CCPPError('oops')
+            # End if (no else needed)
+            try:
+                verbits = [int(x) for x in versplit]
+            except ValueError as ve:
+                raise CCPPError(ve)
+            # End try
+            if verbits[0] < 1:
+                raise CCPPError('Major version must be at least 1')
+            elif verbits[1] < 0:
+                raise CCPPError('Minor version must be non-negative')
+            # End if (no else needed)
+        except CCPPError as ve:
+            errstr = """Illegal version string, '{}'
+Format must be <integer>.<integer>"""
+            ve_str = str(ve)
+            if len(ve_str) > 0:
+                errstr = ve_str + '\n' + errstr
+            # End if
+            raise CCPPError(errstr.format(version))
+        # End try
+    # End if
+    return verbits
+
+###############################################################################
+def validate_xml_file(filename, schema_root, version, logger):
+###############################################################################
+    """
+    Find the appropriate schema and validate the XML file, <filename>,
+    against it using xmllint
+    """
+    # Check the filename
+    if not os.path.isfile(filename):
+        raise CCPPError("read_xml_file: Filename, '{}', does not exist".format(filename))
+    elif not os.access(filename, os.R_OK):
+        raise CCPPError("read_xml_file: Cannot open '{}'".format(filename))
+    # End if
+    # Find the schema, based on the model version
+    thispath = os.path.abspath(__file__)
+    pdir = os.path.dirname(os.path.dirname(os.path.dirname(thispath)))
+    schema_path = os.path.join(pdir, 'schema')
+    verstring = '_'.join([str(x) for x in version])
+    schema_file = os.path.join(schema_path,
+                               "{}_v{}.xsd".format(schema_root, verstring))
+    if not os.path.isfile(schema_file):
+        verstring = '.'.join([str(x) for x in version])
+        raise CCPPError("""read_xml_file: Cannot find schema for version {},
+{} does not exist""".format(verstring, schema_file))
+    elif not os.access(schema_file, os.R_OK):
+        raise CCPPError("read_xml_file: Cannot open schema, '{}'".format(schema_file))
+    # End if
+    if xmllint is not None:
+        logger.debug("Checking file {} against schema {}".format(filename, schema_file))
+        cmd = [xmllint, '--noout', '--schema', schema_file, filename]
+        result = call_command(cmd, logger)
+        return result
+    else:
+        logger.warning("xmllint not found, could not validate file {}".format(filename))
+        return True # We could not check but still need to proceed
+
+###############################################################################
+def read_xml_file(filename, logger=None):
+###############################################################################
+    if os.path.isfile(filename) and os.access(filename, os.R_OK):
+        if six.PY3:
+            file_open = (lambda x: open(x, 'r', encoding='utf-8'))
+        else:
+            file_open = (lambda x: open(x, 'r'))
+        # End if
+        with file_open(filename) as fd:
+            tree = ET.parse(fd)
+            root = tree.getroot()
+    elif not os.access(filename, os.R_OK):
+        raise CCPPError("read_xml_file: Cannot open '{}'".format(filename))
+    else:
+        raise CCPPError("read_xml_file: Filename, '{}', does not exist".format(filename))
+    # End if
+    return tree, root
+
+###############################################################################
+
+if __name__ == "__main__":
+    from parse_log import initLog, setLogToNull
+    logger = initLog('xml_tools')
+    setLogToNull(logger)
+    try:
+        # First, run doctest
+        import doctest
+        doctest.testmod()
+        # We are in a subdir, find framework root and host root
+        thispath = os.path.abspath(__file__)
+        hdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(thispath))))
+        cam6 = os.path.join(hdir, "cam_driver", "src", "cam6_registry.xml")
+        cam7 = os.path.join(hdir, "cam_driver", "src", "cam7_registry.xml")
+        for cpath in [cam6, cam7]:
+            if os.path.exists(cpath):
+                cbase = os.path.basename(cpath).split('.')[0].split('_')
+                cname = cbase[0].upper() + ' ' + cbase[1]
+                tree, root = read_xml_file(cpath, logger)
+                version = find_schema_version(root, logger)
+                res = validate_xml_file(cpath, 'host_registry', version, logger)
+                print("{} {}".format(cname, "validates" if res else "does not validate"))
+            else:
+                print("Could not find CAM7 registry, {}".format(cam7))
+            # End if
+        # End for
+    except CCPPError as ca:
+        print("{}".format(ca))
+# No else:

--- a/scripts/state_machine.py
+++ b/scripts/state_machine.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+#
+
+"""Classes and methods to implement a simple state machine."""
+
+# Python library imports
+import re
+from collections import OrderedDict
+# CCPP framework imports
+from parse_tools import FORTRAN_ID
+
+###############################################################################
+
+class StateMachine(object):
+    """Class and methods to implement a simple state machine.
+    Note, a collections.UserDict would be nice here but it is not in python 2.
+    >>> StateMachine()
+    StateMachine()
+    >>> StateMachine([('ab','a','b','a')])
+    StateMachine(ab)
+    >>> StateMachine([('ab','a','b','a'),('cd','c','d','c')])
+    StateMachine(ab, cd)
+    >>> StateMachine([('ab','a','b','a')]).add_transition('cd','c','d','c')
+
+    >>> StateMachine([('ab','a','b','a')])['cd'] = ('c','d','c')
+    >>> StateMachine([('ab','a','b','a'),('cd','c','d','c')]).transitions()
+    ['ab', 'cd']
+    >>> StateMachine([('ab','a','b','a')]).initial_state('ab')
+    'a'
+    >>> StateMachine([('ab','a','b','a')]).final_state('ab')
+    'b'
+    >>> StateMachine([('ab','a','b','a')]).transition_regex('ab') #doctest: +ELLIPSIS
+    <_sre.SRE_Pattern object at 0x...>
+    >>> StateMachine([('ab','a','b','a')]).transition_match('foo_a', transition='ab')
+    ('foo', 'a', 'ab')
+    >>> StateMachine([('ab','a','b',r'ax?')]).transition_match('foo_a', transition='ab')
+    ('foo', 'a', 'ab')
+    >>> StateMachine([('ab','a','b',r'ax?')]).transition_match('foo_ax', transition='ab')
+    ('foo', 'ax', 'ab')
+    >>> StateMachine([('ab','a','b','a')]).transition_match('foo_ab', transition='ab')
+    (None, None, None)
+    >>> StateMachine([('ab','a','b','a'),('cd','c','d','c')]).transition_match('foo_c')
+    ('foo', 'c', 'cd')
+    >>> StateMachine([('ab','a','b',r'ax?')]).group_match('a')
+    'ab'
+    >>> StateMachine([('ab','a','b',r'ax?')]).group_match('ax')
+    'ab'
+    >>> StateMachine([('ab','a','b',r'ax?')]).group_match('axx')
+
+    >>> StateMachine([('ab','a','b','a')]).group_match('ab')
+
+    >>> StateMachine([('ab','a','b','a'),('cd','c','d','c')]).group_match('c')
+    'cd'
+    >>> StateMachine([('ab','a','b','a')]).add_transition('ab','c','d','c') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: ERROR: transition, 'ab', already exists
+    >>> StateMachine(('ab','a','b','a')) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: Invalid initial_data transition ('ab'), should be of the form (name, inital_state, final_state, regex).
+    >>> StateMachine([('ab','a','b','a')])['cd'] = ('c','d') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: Invalid transition (('c', 'd')), should be of the form (inital_state, final_state, regex).
+    """
+
+    def __init__(self, initial_data=None):
+        """Implement a finite state machine.
+        <initial_data> is an iterable where each item has four elements:
+        (transition_name, <initial_state>, <final_state>, <transition_regex>)
+        <transition_regex> is a string representing allowable names for
+        functions which form part of the transition action.
+        """
+        # Implement the State Transition Table as a tuple and use accessors
+        self.__stt__ = OrderedDict()
+        if initial_data is not None:
+            for trans in initial_data:
+                if len(trans) != 4:
+                    raise ValueError("Invalid initial_data transition ({}), should be of the form (name, inital_state, final_state, regex).".format(trans))
+                else:
+                    self.add_transition(trans[0], trans[1], trans[2], trans[3])
+                # End if
+            # End for
+        # End if
+
+    def add_transition(self, name, init_state, final_state, regex):
+        self[name] = (init_state, final_state, regex)
+
+    def transitions(self):
+        return self.__stt__.keys()
+
+    def initial_state(self, transition):
+        return self.__stt__[transition][0]
+
+    def final_state(self, transition):
+        return self.__stt__[transition][1]
+
+    def transition_regex(self, transition):
+        return self.__stt__[transition][2]
+
+    def group_regex(self, transition):
+        return self.__stt__[transition][3]
+
+    def transition_match(self, test_str, transition=None):
+        """Return a function ID, transition identifier, and matched
+        transition if found.
+        If <transition> is None, look for a match in any transition,
+        otherwise, only look for a specific match to that transition.
+        """
+        if transition is None:
+            trans_list = self.transitions()
+        else:
+            trans_list = [transition]
+        # End if
+        func_id = None
+        trans_id = None
+        match_trans = None
+        for trans in trans_list:
+            regex = self.transition_regex(trans)
+            match = regex.match(test_str)
+            if match is not None:
+                func_id = match.group(1)
+                trans_id = match.group(2)
+                match_trans = trans
+                break
+            # End if
+        # End for
+        return func_id, trans_id, match_trans
+
+    def group_match(self, test_str):
+        """Return the matched transition, if found.
+        """
+        match_trans = None
+        for trans in self.transitions():
+            regex = self.group_regex(trans)
+            match = regex.match(test_str)
+            if match is not None:
+                match_trans = trans
+                break
+            # End if
+        # End for
+        return match_trans
+
+    def __getitem__(self, key):
+        return self.__stt__[key]
+
+    def __setitem__(self, key, value):
+        if key in self.__stt__:
+            raise ValueError("ERROR: transition, '{}', already exists".format(key))
+        elif len(value) != 3:
+            raise ValueError("Invalid transition ({}), should be of the form (inital_state, final_state, regex).".format(value))
+        else:
+            regex = re.compile(FORTRAN_ID + r"_(" + value[2] + r")$")
+            group = re.compile(value[2] + r"$")
+            self.__stt__[key] = (value[0], value[1], regex, group)
+        # End if
+
+    def __delitem__(self, key):
+        del self.__stt__[key]
+
+    def __iter__(self):
+        return iter(self.__stt__)
+
+    def __len__(self):
+        return len(self.__stt__)
+
+    def __str__(self):
+        return "StateMachine({})".format(", ".join(self.transitions()))
+
+    def __repr__(self):
+        return str(self)
+
+###############################################################################
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/tests/test_capgen.py
+++ b/tests/test_capgen.py
@@ -1,0 +1,115 @@
+#! /usr/bin/env python
+"""
+Test script to check ability to parse and generate caps.
+"""
+
+import os.path
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    import os
+    tdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sdir = os.path.join(tdir, "scripts")
+    if not os.path.exists(sdir):
+        raise ImportError("Cannot find scripts directory")
+    # End if
+    sys.path.append(sdir)
+# End if
+import re
+import convert_metadata
+from fortran_tools import parse_fortran_file
+from parse_tools import register_fortran_ddt_name
+
+arg_table_re = re.compile(r"[\s]*!.*section.*arg_table_")
+
+########################################################################
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        pdir = sys.argv[2]
+    else:
+        pdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        pdir = os.path.join(pdir, 'tests', 'cap_tests')
+        if not os.path.exists(pdir):
+            pdir = os.getcwd()
+        # End if
+  # End if
+    if len(sys.argv) > 1:
+        sdir = sys.argv[1]
+    else:
+        sdir = os.path.join(os.path.dirname(pdir), 'ccpp-physics')
+    # End if
+    print("Converting physics files from {} with output to {}".format(sdir, pdir))
+# XXgoldyXX: v debug only
+    # Temporary DDT registration
+    register_fortran_ddt_name('GFS_control_type')
+    register_fortran_ddt_name('GFS_statein_type')
+    register_fortran_ddt_name('GFS_stateout_type')
+    register_fortran_ddt_name('GFS_sfcprop_type')
+    register_fortran_ddt_name('GFS_coupling_type')
+    register_fortran_ddt_name('GFS_grid_type')
+    register_fortran_ddt_name('GFS_tbd_type')
+    register_fortran_ddt_name('GFS_cldprop_type')
+    register_fortran_ddt_name('GFS_radtend_type')
+    register_fortran_ddt_name('GFS_diag_type')
+    register_fortran_ddt_name('GFS_interstitial_type')
+    register_fortran_ddt_name('GFS_data_type')
+    register_fortran_ddt_name('cmpfsw_type')
+    register_fortran_ddt_name('topflw_type')
+    register_fortran_ddt_name('sfcflw_type')
+    register_fortran_ddt_name('proflw_type')
+    register_fortran_ddt_name('topfsw_type')
+    register_fortran_ddt_name('sfcfsw_type')
+    register_fortran_ddt_name('profsw_type')
+    register_fortran_ddt_name('CCPP_interstitial_type')
+# XXgoldyXX: ^ debug only
+    tfilenames = list()
+    # Find files with arg tables
+    for dir in ['physics', 'stochastic_physics']:
+        for file in os.listdir(os.path.join(sdir, dir)):
+            has_arg_table = False
+            pathname = os.path.join(sdir, dir, file)
+            if os.path.isfile(pathname):
+                with open(pathname, 'r') as infile:
+                    preamble = True
+                    for line in infile:
+                        if preamble:
+                            if line.strip().lower() == 'contains':
+                                preamble = False
+                            # End if
+                        # End if
+                        if arg_table_re.match(line) is not None:
+                            has_arg_table = True
+                            break
+                        # End if
+                    # End for
+                # End with
+            # End if
+            if has_arg_table:
+                tfilenames.append(pathname)
+            # End if
+        # End for
+    # End for
+    print("Found {} files with arg tables".format(len(tfilenames)))
+    total_headers = 0
+    for tfile in tfilenames:
+        try:
+            file = os.path.join(pdir, os.path.basename(tfile))
+            if not os.path.exists(file):
+                infile = tfile
+                if not os.path.exists(infile):
+                    print("WARNING: Cannot find '{}'".format(infile))
+                else:
+                    convert_metadata.convert_file(infile, file)
+                # End if
+            # End if
+            if os.path.exists(file):
+                mh = parse_fortran_file(file)
+                print("{} metadata headers parsed in {}".format(len(mh), file))
+                total_headers = total_headers + len(mh)
+            # End if
+        except ValueError as ve:
+            print("{}: {}".format(infile, ve))
+        # End except
+    # End for
+    print("Found {} total metadata headers".format(total_headers))
+# End if __main__


### PR DESCRIPTION
Add a tool (`convert_metadata.py`) to convert from table-style metadata to config style.
Add a tool  (`parse_fortran_file`) to parse and return data from metadata headers.
Fixes #171 