### PR TITLE
ccpp_prebuild.py: bugfix when removing optional arguments

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -258,7 +258,9 @@ def check_optional_arguments(metadata, arguments, optional_arguments):
                         # Remove this var instance from list of var instances for this var_name
                         metadata[var_name].remove(var)
                         # Remove var_name from list of calling arguments for that subroutine
-                        arguments[module_name][scheme_name][subroutine_name].remove(var_name)
+                        # (unless that module has been filtered out for the static build)
+                        if module_name in arguments.keys():
+                            arguments[module_name][scheme_name][subroutine_name].remove(var_name)
                 elif optional_arguments[module_name][subroutine_name] == 'all':
                     logging.debug('optional argument {0} to subroutine {1} in module {2} is required, keep in list'.format(
                                                                                    var_name, subroutine_name, module_name))


### PR DESCRIPTION
This PR fixes a bug in ccpp_prebuild.py where an exception is raised when trying to remove optional arguments from the argument list of modules that were filtered out for the static build. This PR is a prerequisite for https://github.com/NCAR/NEMSfv3gfs/pull/117 and associated PRs and is tested together with these (see https://github.com/NCAR/NEMSfv3gfs/pull/117 for the status of the regression tests).