### PR TITLE
ccpp_prebuild version of multi-suite static build, cleanup validation of SDF used

### DIFF
--- a/doc/DevelopersGuide/chap_schemes.tex
+++ b/doc/DevelopersGuide/chap_schemes.tex
@@ -150,7 +150,7 @@ OPTIONAL_ARGUMENTS = {
 \item Place new scheme in the same location as existing schemes in the CCPP directory structure, e.\,g. \execout{../some\_relative\_path/new\_scheme.F90}.
 \item Edit the runtime suite definition file and add the new scheme at the place it should be run. SDFs are located in
 \begin{lstlisting}[language=Python]
-ccpp/suites/suite_FV3_GFS_2017_updated*.xml # FV3
+ccpp/suites/suite_FV3_GFS_2017*.xml # FV3
 ccpp/suites/suite_SCM_GFS_2017_updated*.xml # SCM
 \end{lstlisting}
 \item Done. Note that no further modifications of the build system are required, since the CCPP framework will auto-generate the necessary makefiles that allow the host model to compile the scheme.

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -534,7 +534,7 @@ end module {module}
         """Create caps for all groups in the suite and for the entire suite
         (calling the group caps one after another)"""
         # Set name of module and filename of cap
-        self._module = 'ccpp_suite_{suite_name}_cap'.format(suite_name=self._name)
+        self._module = 'ccpp_{suite_name}_cap'.format(suite_name=self._name)
         self._filename = '{module_name}.F90'.format(module_name=self._module)
         # Init
         self._subroutines = []
@@ -721,7 +721,7 @@ end module {module}
         ccpp_error_msg_target_name = metadata_request[CCPP_ERROR_MSG_VARIABLE][0].target
         #
         module_use = ''
-        self._module = 'ccpp_suite_{suite}_group_{name}_cap'.format(name=self._name, suite=self._suite)
+        self._module = 'ccpp_{suite}_{name}_cap'.format(name=self._name, suite=self._suite)
         self._filename = '{module_name}.F90'.format(module_name=self._module)
         self._subroutines = []
         local_subs = ''

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -156,7 +156,6 @@ class API(object):
 module {module}
 
 {module_use}
-
    implicit none
 
    private
@@ -166,22 +165,25 @@ module {module}
 '''
 
     sub = '''
-   subroutine {subroutine}({ccpp_var_name}, group_name, ierr)
+   subroutine {subroutine}({ccpp_var_name}, suite_name, group_name, ierr)
 
       use ccpp_types, only : ccpp_t
 
       implicit none
 
       type(ccpp_t),               intent(inout) :: {ccpp_var_name}
+      character(len=*),           intent(in)    :: suite_name
       character(len=*), optional, intent(in)    :: group_name
       integer,                    intent(out)   :: ierr
 
       ierr = 0
 
-      if (present(group_name)) then
-{group_calls}
+{suite_switch}
       else
-{suite_call}
+
+         write({ccpp_var_name}%errmsg,'(*(a))'), 'Invalid suite ' // trim(suite_name)
+         ierr = 1
+
       end if
 
       {ccpp_var_name}%errflg = ierr
@@ -197,7 +199,7 @@ end module {module}
         self._filename    = CCPP_STATIC_API_MODULE + '.F90'
         self._module      = CCPP_STATIC_API_MODULE
         self._subroutines = None
-        self._suite       = None
+        self._suites      = []
         for key, value in kwargs.items():
             setattr(self, "_"+key, value)
 
@@ -222,16 +224,18 @@ end module {module}
 
     def write(self):
         """Write API for static build"""
-        if not self._suite:
-            raise Exception("No suite specified for generating API")
-        suite = self._suite
+        if not self._suites:
+            raise Exception("No suites specified for generating API")
+        suites = self._suites
 
         # Module use statements for suite and group caps
-        module_use = '   use {module}, only: {subroutines}\n'.format(module=suite.module,
-                                                  subroutines=','.join(suite.subroutines))
-        for group in suite.groups:
-            module_use += '   use {module}, only: {subroutines}\n'.format(module=group.module,
-                                                      subroutines=','.join(group.subroutines))
+        module_use = ''
+        for suite in suites:
+            for subroutine in suite.subroutines:
+                module_use += '   use {module}, only: {subroutine}\n'.format(module=suite.module, subroutine=subroutine)
+            for group in suite.groups:
+                for subroutine in group.subroutines:
+                    module_use += '   use {module}, only: {subroutine}\n'.format(module=group.module, subroutine=subroutine)
 
         # Add all variables required to module use statements. This is for the API only,
         # because the static API imports all variables from modules instead of receiving them
@@ -240,17 +244,19 @@ end module {module}
         ccpp_var = None
         parent_standard_names = []
         for ccpp_stage in CCPP_STAGES:
-            for parent_standard_name in suite.parents[ccpp_stage].keys():
-                if not parent_standard_name in parent_standard_names:
-                    parent_var = suite.parents[ccpp_stage][parent_standard_name]
-                    # Identify which variable is of type CCPP_TYPE (need local name)
-                    if parent_var.type == CCPP_TYPE:
-                        if ccpp_var and not ccpp_var.local_name==parent_var.local_name:
-                            raise Exception('There can be only one variable of type {0}, found {1} and {2}'.format(
-                                            CCPP_TYPE, ccpp_var.local_name, parent_var.local_name))
-                        ccpp_var = parent_var
-                        continue
-                    module_use += '   {0}\n'.format(parent_var.print_module_use())
+            for suite in suites:
+                for parent_standard_name in suite.parents[ccpp_stage].keys():
+                    if not parent_standard_name in parent_standard_names:
+                        parent_var = suite.parents[ccpp_stage][parent_standard_name]
+                        # Identify which variable is of type CCPP_TYPE (need local name)
+                        if parent_var.type == CCPP_TYPE:
+                            if ccpp_var and not ccpp_var.local_name==parent_var.local_name:
+                                raise Exception('There can be only one variable of type {0}, found {1} and {2}'.format(
+                                                CCPP_TYPE, ccpp_var.local_name, parent_var.local_name))
+                            ccpp_var = parent_var
+                            continue
+                        module_use += '   {0}\n'.format(parent_var.print_module_use())
+                        parent_standard_names.append(parent_standard_name)
         if not ccpp_var:
             raise Exception('No variable of type {0} found - need a scalar instance.'.format(CCPP_TYPE))
         elif not ccpp_var.rank == '':
@@ -261,46 +267,63 @@ end module {module}
         self._subroutines=[]
         subs = ''
         for ccpp_stage in CCPP_STAGES:
+            suite_switch = ''
+            for suite in suites:
+                # Calls to groups of schemes for this stage
+                group_calls = ''
+                for group in suite.groups:
+                    # The <init></init> and <finalize></finalize> groups require special treatment,
+                    # since they can only be run in the respective stage (init/finalize)
+                    if (group.init and not ccpp_stage == 'init') or \
+                        (group.finalize and not ccpp_stage == 'finalize'):
+                        continue
+                    if not group_calls:
+                        clause = 'if'
+                    else:
+                        clause = 'else if'
+                    argument_list_group = create_argument_list_wrapped_explicit(group.arguments[ccpp_stage])
+                    group_calls += '''
+            {clause} (trim(group_name)=="{group_name}") then
+               ierr = {suite_name}_{group_name}_{stage}_cap({arguments})'''.format(clause=clause,
+                                                                                   suite_name=group.suite,
+                                                                                   group_name=group.name,
+                                                                                   stage=ccpp_stage,
+                                                                                   arguments=argument_list_group)
+                group_calls += '''
+            else
+               write({ccpp_var_name}%errmsg, '(*(a))') "Group " // trim(group_name) // " not found"
+               ierr = 1
+            end if
+'''.format(ccpp_var_name=ccpp_var.local_name, group_name=group.name)
 
-            # Calls to groups of schemes for this stage
-            group_calls = ''
-            for group in suite.groups:
-                # The <init></init> and <finalize></finalize> groups require special treatment,
-                # since they can only be run in the respective stage (init/finalize)
-                if (group.init and not ccpp_stage == 'init') or \
-                    (group.finalize and not ccpp_stage == 'finalize'):
-                    continue
-                if not group_calls:
+                # Call to entire suite for this stage
+
+                # Create argument list for calling the full suite
+                argument_list_suite = create_argument_list_wrapped_explicit(suite.arguments[ccpp_stage])
+                suite_call = '''
+           ierr = {suite_name}_{stage}_cap({arguments})
+'''.format(suite_name=suite.name, stage=ccpp_stage, arguments=argument_list_suite)
+
+                # Add call to all groups of this suite and to the entire suite
+                if not suite_switch:
                     clause = 'if'
                 else:
                     clause = 'else if'
-                argument_list_group = create_argument_list_wrapped_explicit(group.arguments[ccpp_stage])
-                group_calls += '''
-         {clause} (trim(group_name)=="{group_name}") then
-            ierr = {group_name}_{stage}_cap({arguments})'''.format(clause=clause,
-                                                                   group_name=group.name,
-                                                                   stage=ccpp_stage,
-                                                                   arguments=argument_list_group)
-            group_calls += '''
+                suite_switch += '''
+      {clause} (trim(suite_name)=="{suite_name}") then
+
+         if (present(group_name)) then
+{group_calls}
          else
-            write({ccpp_var_name}%errmsg, '(*(a))') "Group " // trim(group_name) // " not found"
-            ierr = 1
-        end if
-'''.format(ccpp_var_name=ccpp_var.local_name, group_name=group.name)
+{suite_call}
+         end if
+'''.format(clause=clause, suite_name=suite.name, group_calls=group_calls, suite_call=suite_call)
 
-            # Call to entire suite for this stage
-
-            # Create argument list for calling the full suite
-            argument_list_suite = create_argument_list_wrapped_explicit(suite.arguments[ccpp_stage])
-            suite_call = '''
-        ierr = suite_{stage}_cap({arguments})
-'''.format(stage=ccpp_stage, arguments=argument_list_suite)
             subroutine = CCPP_STATIC_SUBROUTINE_NAME.format(stage=ccpp_stage)
             self._subroutines.append(subroutine)
             subs += API.sub.format(subroutine=subroutine,
-                                   ccpp_var_name=ccpp_var.local_name, 
-                                   group_calls=group_calls,
-                                   suite_call=suite_call)
+                                   ccpp_var_name=ccpp_var.local_name,
+                                   suite_switch=suite_switch)
 
         # Write output to stdout or file
         if (self._filename is not sys.stdout):
@@ -426,9 +449,9 @@ end module {module}
                 schemes = [group_xml.text]
                 subcycles.append(Subcycle(loop=1, schemes=schemes))
                 if group_xml.tag.lower() == 'init':
-                    self._groups.append(Group(name=group_xml.tag.lower(), subcycles=subcycles, init=True))
+                    self._groups.append(Group(name=group_xml.tag.lower(), subcycles=subcycles, suite=self._name, init=True))
                 elif group_xml.tag.lower() == 'finalize':
-                    self._groups.append(Group(name=group_xml.tag.lower(), subcycles=subcycles, finalize=True))
+                    self._groups.append(Group(name=group_xml.tag.lower(), subcycles=subcycles, suite=self._name, finalize=True))
                 continue
 
             # Parse subcycles of all regular groups
@@ -442,7 +465,7 @@ end module {module}
                         self._all_subroutines_called.append(scheme_xml.text + '_' + ccpp_stage)
                 subcycles.append(Subcycle(loop=loop, schemes=schemes))
 
-            self._groups.append(Group(name=group_xml.get('name'), subcycles=subcycles))
+            self._groups.append(Group(name=group_xml.get('name'), subcycles=subcycles, suite=self._name))
 
         # Remove duplicates from list of all subroutines an schemes
         self._all_schemes_called = list(set(self._all_schemes_called))
@@ -511,7 +534,7 @@ end module {module}
         """Create caps for all groups in the suite and for the entire suite
         (calling the group caps one after another)"""
         # Set name of module and filename of cap
-        self._module = 'ccpp_suite_cap'
+        self._module = 'ccpp_suite_{suite_name}_cap'.format(suite_name=self._name)
         self._filename = '{module_name}.F90'.format(module_name=self._module)
         # Init
         self._subroutines = []
@@ -521,7 +544,8 @@ end module {module}
         module_use = ''
         for group in self._groups:
             group.write(metadata_request, metadata_define, arguments)
-            module_use += '   use {m}, only: {s}\n'.format(m=group.module, s=','.join(group.subroutines))
+            for subroutine in group.subroutines:
+                module_use += '   use {m}, only: {s}\n'.format(m=group.module, s=subroutine)
             for ccpp_stage in CCPP_STAGES:
                 for parent_standard_name in group.parents[ccpp_stage].keys():
                     if parent_standard_name in self.parents[ccpp_stage]:
@@ -552,11 +576,11 @@ end module {module}
 
                 # Write to body that calls the groups for this stage
                 body += '''
-      ierr = {group_name}_{stage}_cap({arguments})
+      ierr = {suite_name}_{group_name}_{stage}_cap({arguments})
       if (ierr/=0) return
-'''.format(group_name=group.name, stage=ccpp_stage, arguments=argument_list_group)
+'''.format(suite_name=self._name, group_name=group.name, stage=ccpp_stage, arguments=argument_list_group)
             # Add name of subroutine in the suite cap to list of subroutine names
-            subroutine = 'suite_{stage}_cap'.format(stage=ccpp_stage)
+            subroutine = '{name}_{stage}_cap'.format(name=self._name, stage=ccpp_stage)
             self._subroutines.append(subroutine)
             # Add subroutine to output
             subs += Suite.sub.format(subroutine=subroutine,
@@ -572,7 +596,7 @@ end module {module}
             f = sys.stdout
         f.write(Suite.header.format(module=self._module,
                                     module_use=module_use,
-                                    subroutines=','.join(self._subroutines)))
+                                    subroutines=', &\n             '.join(self._subroutines)))
         f.write(subs)
         f.write(Suite.footer.format(module=self._module))
         if (f is not sys.stdout):
@@ -583,12 +607,6 @@ end module {module}
         for group in self._groups:
             self._caps.append(group.filename)
 
-
-    def create_sdf_name_include_file(self, incfilename):
-        # Create include file for framework that contains the name of the sdf used for static build
-        f = open(incfilename, "w")
-        f.write('character(len=*), parameter :: ccpp_suite_static_name = "{suite_name}"\n'.format(suite_name = self._name))
-        f.close()
 
 ###############################################################################
 class Group(object):
@@ -679,6 +697,7 @@ end module {module}
 
     def __init__(self, **kwargs):
         self._name = ''
+        self._suite = None
         self._filename = 'sys.stdout'
         self._init = False
         self._finalize = False
@@ -702,7 +721,7 @@ end module {module}
         ccpp_error_msg_target_name = metadata_request[CCPP_ERROR_MSG_VARIABLE][0].target
         #
         module_use = ''
-        self._module = 'ccpp_group_{name}_cap'.format(name=self._name)
+        self._module = 'ccpp_suite_{suite}_group_{name}_cap'.format(name=self._name, suite=self._suite)
         self._filename = '{module_name}.F90'.format(module_name=self._module)
         self._subroutines = []
         local_subs = ''
@@ -858,7 +877,7 @@ end module {module}
                                                                      self.parents[ccpp_stage], metadata_define)
             sub_argument_list = create_argument_list_wrapped(self.arguments[ccpp_stage])
 
-            subroutine = self._name + '_' + ccpp_stage + '_cap'
+            subroutine = self._suite + '_' + self._name + '_' + ccpp_stage + '_cap'
             self._subroutines.append(subroutine)
             # Test and set blocks for initialization status
             initialized_test_block = Group.initialized_test_blocks[ccpp_stage].format(
@@ -886,7 +905,7 @@ end module {module}
         f.write(Group.header.format(group=self._name,
                                     module=self._module,
                                     module_use=module_use,
-                                    subroutines=','.join(self._subroutines)))
+                                    subroutines=', &\n             '.join(self._subroutines)))
         f.write(local_subs)
         f.write(Group.footer.format(module=self._module))
         if (f is not sys.stdout):
@@ -933,6 +952,11 @@ end module {module}
         if not type(value) == types.BooleanType:
             raise Exception("Invalid type {0} of argument value, boolean expected".format(type(value)))
         self._finalize = value
+
+    @property
+    def suite(self):
+        '''Get the suite name.'''
+        return self._suite
 
     @property
     def module(self):

--- a/src/ccpp_suite.F90
+++ b/src/ccpp_suite.F90
@@ -68,12 +68,6 @@ module ccpp_suite
         character(len=*), parameter           :: err_msg =             &
             'Please validate the suite xml file: '
 
-#ifdef STATIC
-! Include code snippet that contains the name of the
-! suite that was used for the static build of CCPP.
-#include "ccpp_suite_static.inc"
-#endif
-
         ierr = 0
         tmp = c_null_ptr
 
@@ -93,16 +87,6 @@ module ccpp_suite
             return
         end if
 
-#ifdef STATIC
-        if (trim(suite%name).ne.trim(ccpp_suite_static_name)) then
-            call ccpp_error('Suite used for static build ' // trim(ccpp_suite_static_name) // &
-                            ' does not match runtime choice ' // trim(suite%name))
-            ierr = 1
-        else
-            call ccpp_info('Using suite ' //trim(suite%name))
-        end if
-        return
-#else
         call ccpp_info('Parsing suite ' //trim(suite%name))
         ! Find the init subroutine
         call ccpp_xml_ele_find(root, ccpp_cstr(CCPP_XML_ELE_INIT), tmp, ierr)
@@ -263,7 +247,6 @@ module ccpp_suite
 
         ierr = ccpp_xml_unload(xml)
         call ccpp_suite_load(suite, ierr)
-#endif
 
     end subroutine ccpp_suite_init
 


### PR DESCRIPTION
This PR and associated PRs enable building the CCPP code in static mode and use multiple suites at the same time with the existing ccpp_prebuild.py script. This capability allows us to move forward with the discussion to remove the dynamic build options without having to move to the new metadata standard and to cap_gen and will save us valuable time for the transition in the future.

The changes are:
- a suite with name `XYZ` in the xml name attribute `<suite name='XYZ' ...> ... </suite>` must have the filename `suite_XYZ.xml`
- the `MAKEOPT` string `SUITE=suite_XYZ.xml` is replaced by `SUITES=XYZ,ABC,DEF`
- the `ccpp_suite` option in `input.nml` is now `ccpp_suite='XYZ'` to select suite `XYZ`
    - in static build mode, this string is used to select the correct physics init/run/finalize calls in the auto-generated `ccpp_static_api.F90` file, if an invalid name is chosen in input.nml, the code will exit with an error
    - in dynamic build mode, this string is expanded to a filename `suite_XYZ.xml` which is expected in the model run directory
- for the static build, the calls to `ccpp_physics_{init,run,finalize}` require an additional argument `suite_name`, thus breaking the idea that the API is the same for the static and dynamic builds
- all CCPP regression tests need updating in order to use the correct suite name and filename because of the changes described above
- rename SDFs and suites: remove "_updated" to shorten module names in auto-generated Fortran code (Fortran 2003 has 63-character limit)
- reinstate calculation of pwat in GFS_physics_driver.F90 that was accidentally removed in an earlier commit 
- cleanup: remove old ldiag3d test configurations (from ./parm, ./tests/tests, ./tests/fv3_conf/, and ./tests/rt*.conf), remove duplicate entry for sppt_wts from GFS_diagnostics.F90