### PR TITLE
ccpp-prebuild metadata parser: workaround to skip 'type is' statements

### DIFF
--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -187,10 +187,15 @@ def parse_variable_tables(filename):
                 # and that a name exists afterwards. It is assumed that definitions
                 # (not usage) of derived types cannot be nested - reasonable for Fortran.
                 #
+                # DH* 20190508 - workaround to skip 'type is' statements inside
+                # the Fortran 2003 'select type' group
+                if (words[j].lower() == 'type' and j<len(words)-1 and \
+                        (words[j+1].lower() == 'is' or words[j+1].lower().startswith('is('))):
+                    continue
                 # DH* 20190420 - workaround to parse additional type definitions like
                 #     type, extends(GFS_data_sub_type) :: GFS_data_type
                 # use Ftype_type_decl class routine type_def_line and extract type_name
-                if (words[j].lower() == 'type' or words[j].lower() == 'type,') and j == 0 and 'extends' in line:
+                elif (words[j].lower() == 'type' or words[j].lower() == 'type,') and j == 0 and 'extends' in line:
                     type_declaration = Ftype_type_decl.type_def_line(line.strip())
                     if in_type:
                         raise Exception('Nested definitions of derived types not supported')


### PR DESCRIPTION
The Fortran 2003 standard defines a `select type` construct, where the individual cases are selected using
```
select type (my_type)
   type is (XYZ)
   type is(ABC)
end select
```
If such a `select type` statement occurs inside a variable definition file (i.e. a file that is parsed by `ccpp_prebuild.py` for host model variable definitions, then this leads to an error. The workaround proposed here skips line where the first (and not last) word is `type`, and the second word is either `is` or starts with `is(`.

This has been tested by compiling the NEMSfv3gs code manually on MacOSX/GNU and Theia/Intel with such a variable definition file included.

Reference for `select type` statement: https://www.ibm.com/support/knowledgecenter/en/SSGH4D_16.1.0/com.ibm.xlf161.aix.doc/language_ref/typecon.html

Note: this line may also parsed incorrectly by the new metadata parser (in my manual tests, the `Ftype_type_decl` class routine `type_def_line` returns a type `['is', None, (XYZ)]` in this case; I have not tested if this is filtered out higher up in the `Ftype_type_decl` class).