### PR TITLE
Add clean option to ccpp_prebuild.py

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -18,6 +18,10 @@ CCPP_INTERNAL_VARIABLES = {
 STANDARD_VARIABLE_TYPES = [ 'character', 'integer', 'logical', 'real' ]
 STANDARD_CHARACTER_TYPE = 'character'
 
+# For static build
+CCPP_STATIC_API_MODULE = 'ccpp_static_api'
+CCPP_STATIC_SUBROUTINE_NAME = 'ccpp_physics_{stage}'
+
 def execute(cmd, abort = True):
     """Runs a local command in a shell. Waits for completion and
     returns status, stdout and stderr. If abort = True, abort in

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 from common import decode_container, encode_container
 from common import CCPP_ERROR_FLAG_VARIABLE, CCPP_ERROR_MSG_VARIABLE, CCPP_LOOP_COUNTER
 from common import CCPP_TYPE, STANDARD_VARIABLE_TYPES, STANDARD_CHARACTER_TYPE
+from common import CCPP_STATIC_API_MODULE, CCPP_STATIC_SUBROUTINE_NAME
 from mkcap import Var
 
 ###############################################################################
@@ -22,9 +23,6 @@ from mkcap import Var
 #CCPP_ERROR_FLAG_VARIABLE = 'error_flag'
 
 CCPP_STAGES = [ 'init', 'run', 'finalize' ]
-
-CCPP_STATIC_API_MODULE = 'ccpp_static_api'
-CCPP_STATIC_SUBROUTINE_NAME = 'ccpp_physics_{stage}'
 
 # Maximum number of dimensions of an array allowed by the Fortran 2008 standard
 FORTRAN_ARRAY_MAX_DIMS = 15


### PR DESCRIPTION
This PR adds a clean option `--clean` to ccpp_prebuild.py which removes all files created by the same command without `--clean` and then exits.

See https://github.com/NCAR/NEMSfv3gfs/pull/158 for a description of related changes and testing.
