### PR TITLE
Update host_cap_template.F90 for documentation

### DIFF
--- a/doc/DevelopersGuide/host_cap_template.F90
+++ b/doc/DevelopersGuide/host_cap_template.F90
@@ -1,14 +1,12 @@
 module example_ccpp_host_cap
 
-  use ccpp_api, only: ccpp_t, ccpp_field_add, ccpp_init, ccpp_finalize, &
-               ccpp_physics_init, ccpp_physics_run, ccpp_physics_finalize
-  use iso_c_binding, only: c_loc
-! Include auto-generated list of modules for ccpp
-#include "ccpp_modules.inc"
+  use ccpp_api,           only: ccpp_t, ccpp_init, ccpp_finalize
+  use ccpp_static_api,    only: ccpp_physics_init, ccpp_physics_run,     &
+                                ccpp_physics_finalize
 
   implicit none
 
-! CCPP data structure
+  ! CCPP data structure
   type(ccpp_t), save, target :: cdata
 
   public :: physics_init, physics_run, physics_finalize
@@ -21,46 +19,47 @@ contains
     ierr = 0
 
     ! Initialize the CCPP framework, parse SDF
-    call ccpp_init(ccpp_suite_name, cdata, ierr=ierr)
+    call ccpp_init(trim(ccpp_suite_name), cdata, ierr=ierr)
     if (ierr/=0) then
       write(*,'(a)') "An error occurred in ccpp_init"
       stop
     end if
-! Include auto-generated list of calls to ccpp_field_add
-#include "ccpp_fields.inc"
+
     ! Initialize CCPP physics (run all _init routines)
-    call ccpp_physics_init(cdata, ierr=ierr)
+    call ccpp_physics_init(cdata, suite_name=trim(ccpp_suite_name),      &
+                           ierr=ierr)
     ! error handling as above
 
   end subroutine physics_init
-
-  subroutine physics_run(group, scheme)
-    ! Optional arguments group and scheme can be used
-    ! to run a group of schemes or an individual scheme
+  
+  subroutine physics_run(ccpp_suite_name, group)
+    ! Optional argument group can be used to run a group of schemes      &
     ! defined in the SDF. Otherwise, run entire suite.
+    character(len=*),           intent(in) :: ccpp_suite_name
     character(len=*), optional, intent(in) :: group
-    character(len=*), optional, intent(in) :: scheme
 
     integer :: ierr
     ierr = 0
-
-    if (present(scheme)) then
-       call ccpp_physics_run(cdata, scheme_name=scheme, ierr=ierr)
-    else if (present(group)) then
-       call ccpp_physics_run(cdata, group_name=group, ierr=ierr)
+    
+    if (present(group)) then
+       call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite_name),    &
+                             group_name=group, ierr=ierr)
     else
-       call ccpp_physics_run(cdata, ierr=ierr)
+       call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite_name),    &
+                             ierr=ierr)
     end if
     ! error handling as above
 
   end subroutine physics_run
-
-  subroutine physics_finalize()
+  
+  subroutine physics_finalize(ccpp_suite_name)
+    character(len=*), intent(in) :: ccpp_suite_name
     integer :: ierr
     ierr = 0
 
     ! Finalize CCPP physics (run all _finalize routines)
-    call ccpp_physics_finalize(cdata, ierr=ierr)
+    call ccpp_physics_finalize(cdata, suite_name=trim(ccpp_suite_name),  &
+                               ierr=ierr)
     ! error handling as above
     call ccpp_finalize(cdata, ierr=ierr)
     ! error handling as above


### PR DESCRIPTION
Updated the host_cap_template.F90 file used for documentation to use the static build only:

- used ccpp_static_api for ccpp_physics_{init,run,finalize}
- passed ccpp_suite_name into the subroutines that need it
- removed scheme optional argument in the physics_run subroutine