### PR TITLE
Allow comments in type definition lines

### DIFF
--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -8,7 +8,7 @@ import re
 from parse_tools import ParseSyntaxError, ParseInternalError
 from parse_tools import ParseContext, ParseSource, context_string
 from parse_tools import check_fortran_intrinsic, check_fortran_type
-from parse_tools import check_balanced_paren, unique_standard_name
+from parse_tools import check_balanced_paren
 from metavar import Var
 
 # A collection of types and tools for parsing Fortran code to support
@@ -34,7 +34,7 @@ _var_id_re_ = re.compile(r"("+_fortran_id_+r")\s*(\(\s*"+_dims_list_+r"\s*\))?$"
 class Ftype(object):
     """Ftype is the base class for all Fortran types
     It is also the final type for intrinsic types except for character
-    >>> Ftype('integer').typestr()
+    >>> Ftype('integer').typestr
     'integer'
     >>> Ftype('integer', kind_in='( kind= I8').__str__() #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
@@ -72,6 +72,8 @@ class Ftype(object):
                      'intent', 'intrinsic', 'bind', 'optional', 'parameter',
                      'pointer', 'private', 'protected', 'public', 'save',
                      'target', 'value', 'volatile']
+
+    __sname_num__ = 0 # Counter for unique standard names
 
     def __init__(self, typestr_in=None, kind_in=None, line_in=None, context=None):
         if context is None:
@@ -216,9 +218,16 @@ class Ftype(object):
         # End for
         return properties
 
+    @classmethod
+    def unique_standard_name(cls):
+        cls.__sname_num__ = cls.__sname_num__ + 1
+        return 'enter_standard_name_{}'.format(cls.__sname_num__)
+
+    @property
     def typestr(self):
         return self._typestr
 
+    @property
     def kind(self):
         return self._kind
 
@@ -229,12 +238,12 @@ class Ftype(object):
     def __str__(self):
         """Return a string of the declaration of the type"""
         if self.default_kind:
-            return self.typestr()
-        elif check_fortran_intrinsic(self.typestr()):
-            return "{}(kind={})".format(self.typestr(), self._kind)
+            return self.typestr
+        elif check_fortran_intrinsic(self.typestr):
+            return "{}(kind={})".format(self.typestr, self._kind)
         else:
             # Derived type
-            return "{}({})".format(self.typestr(), self._kind)
+            return "{}({})".format(self.typestr, self._kind)
 
 ########################################################################
 
@@ -257,8 +266,6 @@ class Ftype_character(Ftype):
     'CHARACTER(len=*)'
     >>> Ftype_character('CHARACTER(len=:)', None).__str__()
     'CHARACTER(len=:)'
-    >>> Ftype_character('Character(len=512)', None).__str__()
-    'Character(len=512)'
     >>> Ftype_character('character(*)', None).__str__()
     'character(len=*)'
     >>> Ftype_character('character*7', None).__str__() #doctest: +IGNORE_EXCEPTION_DETAIL
@@ -374,19 +381,16 @@ class Ftype_character(Ftype):
         else:
             raise ParseSyntaxError("length_selector when len= is required", token=lenselect, context=context)
 
-    def kind(self):
-        if self.default_kind:
-            kind_str = ""
-        else:
-            kind_str = ", kind={}".format(super(Ftype_character, self).kind())
-        # End if
-        return "len={}{}".format(self.lenstr, kind_str)
-
     def __str__(self):
         """Return a string of the declaration of the type
         For characters, we will always print an explicit len modifier
         """
-        return "{}({})".format(self.typestr(), self.kind())
+        if self.default_kind:
+            kind_str = ""
+        else:
+            kind_str = ", kind={}".format(self.kind)
+        # End if
+        return "{}(len={}{})".format(self.typestr, self.lenstr, kind_str)
 
 ########################################################################
 
@@ -405,7 +409,7 @@ class Ftype_type_decl(Ftype):
     ['GFS_statein_type', ['public', 'extends(foo)'], None]
     >>> Ftype_type_decl.type_def_line('type(foo) :: bar')
 
-    >>> Ftype_type_decl.type_def_line('type foo ! This is a comment')
+    >>> Ftype_type_decl.type_def_line('type foo ! this is a comment')
     ['foo', None, None]
     """
 
@@ -422,7 +426,7 @@ class Ftype_type_decl(Ftype):
             self._match_len = len(match.group(0))
             self._class = match.group(1)
             self._typestr = match.group(2)
-            self._kind = self.typestr()
+            self._kind = self.typestr
         # End if
 
     @classmethod
@@ -466,7 +470,7 @@ class Ftype_type_decl(Ftype):
         return type_def
 
     def __str__(self):
-        return '{}({})'.format(self._class, self.typestr())
+        return '{}({})'.format(self._class, self.typestr)
 
 ########################################################################
 def Ftype_factory(line, context):
@@ -559,33 +563,28 @@ def parse_fortran_var_decl(line, source, logger=None):
     '(8)'
     >>> _var_id_re_.match("foo(::,a:b,a:,:b)").group(2)
     '(::,a:b,a:,:b)'
-    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
     'foo'
-    >>> parse_fortran_var_decl("integer :: foo = 0", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("integer :: foo = 0", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
     'foo'
-    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('optional')
+    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('optional')
     False
-    >>> parse_fortran_var_decl("integer, optional :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('optional')
+    >>> parse_fortran_var_decl("integer, optional :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('optional')
     'True'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
     '(:)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(bar)", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(bar)", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
     '(bar)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
     '(:,:)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'module', ParseContext()))[1].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'MODULE', ParseContext()))[1].get_prop_value('dimensions')
     '(:)'
-    >>> parse_fortran_var_decl("real (kind=kind_phys), pointer :: phii  (:,:) => null()   !< interface geopotential height", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("real (kind=kind_phys), pointer :: phii  (:,:) => null()   !< interface geopotential height", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
     '(:,:)'
-    >>> parse_fortran_var_decl("real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: qgrs", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: qgrs", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
     '(im, levs, ntrac)'
-    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
     'errmsg'
-    >>> parse_fortran_var_decl("character(len=512), intent(out) :: errmsg", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('kind')
-    'len=512'
-    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name') #doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ParseSyntaxError: Invalid variable declaration, character(len=*), intent(out) :: errmsg, intent not allowed in module variable, in <standard input>
     """
     context = source.context
     sline = line.strip()
@@ -606,21 +605,7 @@ def parse_fortran_var_decl(line, source, logger=None):
             varprops = Ftype.parse_attr_specs(elements[0].strip(), context)
             for prop in varprops:
                 if prop[0:6] == 'intent':
-                    if source.type != 'scheme':
-                        typ = source.type
-                        errmsg = 'Invalid variable declaration, {}, intent'
-                        errmsg = errmsg + ' not allowed in {} variable'
-                        if logger is not None:
-                            ctx = context_string(context)
-                            errmsg = "WARNING: " + errmsg + "{}"
-                            logger.warning(errmsg.format(var, typ, ctx))
-                        else:
-                            raise ParseSyntaxError(errmsg.format(sline, typ),
-                                                   context=context)
-                        # End if
-                    else:
-                        intent = prop[6:].strip()[1:-1].strip()
-                    # End if
+                    intent = prop[6:].strip()[1:-1].strip()
                 elif prop[0:9:] == 'dimension':
                     dimensions = prop[9:].strip()
                 # End if
@@ -652,26 +637,20 @@ def parse_fortran_var_decl(line, source, logger=None):
                 if (begin < 0) or (end < 0):
                     if logger is not None:
                         ctx = context_string(context)
-                        errmsg = "WARNING: Invalid variable declaration, {}{}"
-                        logger.warning(errmsg.format(var, ctx))
+                        logger.warning("WARNING: Invalid variable declaration, {}{}".format(var, ctx))
                     else:
-                        raise ParseSyntaxError('variable declaration',
-                                               token=var, context=context)
+                        raise ParseSyntaxError('variable declaration', token=var, context=context)
                     # End if
                 else:
                     dimspec = var[begin:end+1]
                 # End if
             # End if
             prop_dict['local_name'] = varname
-            prop_dict['standard_name'] = unique_standard_name()
+            prop_dict['standard_name'] = Ftype.unique_standard_name()
             prop_dict['units'] = ''
-            if isinstance(tobject, Ftype_type_decl):
-                prop_dict['ddt_type'] = tobject.typestr()
-            else:
-                prop_dict['type'] = tobject.typestr()
-            # End if
-            if tobject.kind() is not None:
-                prop_dict['kind'] = tobject.kind()
+            prop_dict['type'] = tobject.typestr
+            if tobject.kind is not None:
+                prop_dict['kind'] = tobject.kind
             # End if
             if 'optional' in varprops:
                 prop_dict['optional'] = 'True'

--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -8,7 +8,7 @@ import re
 from parse_tools import ParseSyntaxError, ParseInternalError
 from parse_tools import ParseContext, ParseSource, context_string
 from parse_tools import check_fortran_intrinsic, check_fortran_type
-from parse_tools import check_balanced_paren
+from parse_tools import check_balanced_paren, unique_standard_name
 from metavar import Var
 
 # A collection of types and tools for parsing Fortran code to support
@@ -34,7 +34,7 @@ _var_id_re_ = re.compile(r"("+_fortran_id_+r")\s*(\(\s*"+_dims_list_+r"\s*\))?$"
 class Ftype(object):
     """Ftype is the base class for all Fortran types
     It is also the final type for intrinsic types except for character
-    >>> Ftype('integer').typestr
+    >>> Ftype('integer').typestr()
     'integer'
     >>> Ftype('integer', kind_in='( kind= I8').__str__() #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
@@ -72,8 +72,6 @@ class Ftype(object):
                      'intent', 'intrinsic', 'bind', 'optional', 'parameter',
                      'pointer', 'private', 'protected', 'public', 'save',
                      'target', 'value', 'volatile']
-
-    __sname_num__ = 0 # Counter for unique standard names
 
     def __init__(self, typestr_in=None, kind_in=None, line_in=None, context=None):
         if context is None:
@@ -218,16 +216,9 @@ class Ftype(object):
         # End for
         return properties
 
-    @classmethod
-    def unique_standard_name(cls):
-        cls.__sname_num__ = cls.__sname_num__ + 1
-        return 'enter_standard_name_{}'.format(cls.__sname_num__)
-
-    @property
     def typestr(self):
         return self._typestr
 
-    @property
     def kind(self):
         return self._kind
 
@@ -238,12 +229,12 @@ class Ftype(object):
     def __str__(self):
         """Return a string of the declaration of the type"""
         if self.default_kind:
-            return self.typestr
-        elif check_fortran_intrinsic(self.typestr):
-            return "{}(kind={})".format(self.typestr, self._kind)
+            return self.typestr()
+        elif check_fortran_intrinsic(self.typestr()):
+            return "{}(kind={})".format(self.typestr(), self._kind)
         else:
             # Derived type
-            return "{}({})".format(self.typestr, self._kind)
+            return "{}({})".format(self.typestr(), self._kind)
 
 ########################################################################
 
@@ -266,6 +257,8 @@ class Ftype_character(Ftype):
     'CHARACTER(len=*)'
     >>> Ftype_character('CHARACTER(len=:)', None).__str__()
     'CHARACTER(len=:)'
+    >>> Ftype_character('Character(len=512)', None).__str__()
+    'Character(len=512)'
     >>> Ftype_character('character(*)', None).__str__()
     'character(len=*)'
     >>> Ftype_character('character*7', None).__str__() #doctest: +IGNORE_EXCEPTION_DETAIL
@@ -381,16 +374,19 @@ class Ftype_character(Ftype):
         else:
             raise ParseSyntaxError("length_selector when len= is required", token=lenselect, context=context)
 
+    def kind(self):
+        if self.default_kind:
+            kind_str = ""
+        else:
+            kind_str = ", kind={}".format(super(Ftype_character, self).kind())
+        # End if
+        return "len={}{}".format(self.lenstr, kind_str)
+
     def __str__(self):
         """Return a string of the declaration of the type
         For characters, we will always print an explicit len modifier
         """
-        if self.default_kind:
-            kind_str = ""
-        else:
-            kind_str = ", kind={}".format(self.kind)
-        # End if
-        return "{}(len={}{})".format(self.typestr, self.lenstr, kind_str)
+        return "{}({})".format(self.typestr(), self.kind())
 
 ########################################################################
 
@@ -409,6 +405,8 @@ class Ftype_type_decl(Ftype):
     ['GFS_statein_type', ['public', 'extends(foo)'], None]
     >>> Ftype_type_decl.type_def_line('type(foo) :: bar')
 
+    >>> Ftype_type_decl.type_def_line('type foo ! This is a comment')
+    ['foo', None, None]
     """
 
     __type_decl_re__ = re.compile(r"(?i)(type)\s*\(\s*([A-Z][A-Z0-9_]*)\s*\)?")
@@ -424,7 +422,7 @@ class Ftype_type_decl(Ftype):
             self._match_len = len(match.group(0))
             self._class = match.group(1)
             self._typestr = match.group(2)
-            self._kind = self.typestr
+            self._kind = self.typestr()
         # End if
 
     @classmethod
@@ -440,7 +438,11 @@ class Ftype_type_decl(Ftype):
         of a type definition"""
         type_def = None
         if not cls.type_match(line):
-            sline = line.strip()
+            if '!' in line:
+                sline = line[0:line.index('!')].strip()
+            else:
+                sline = line.strip()
+            # End if
             if sline.lower()[0:4] == 'type':
                 if '::' in sline:
                     elements = sline.split('::')
@@ -464,7 +466,7 @@ class Ftype_type_decl(Ftype):
         return type_def
 
     def __str__(self):
-        return '{}({})'.format(self._class, self.typestr)
+        return '{}({})'.format(self._class, self.typestr())
 
 ########################################################################
 def Ftype_factory(line, context):
@@ -557,28 +559,33 @@ def parse_fortran_var_decl(line, source, logger=None):
     '(8)'
     >>> _var_id_re_.match("foo(::,a:b,a:,:b)").group(2)
     '(::,a:b,a:,:b)'
-    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name')
     'foo'
-    >>> parse_fortran_var_decl("integer :: foo = 0", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("integer :: foo = 0", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name')
     'foo'
-    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('optional')
+    >>> parse_fortran_var_decl("integer :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('optional')
     False
-    >>> parse_fortran_var_decl("integer, optional :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('optional')
+    >>> parse_fortran_var_decl("integer, optional :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('optional')
     'True'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
     '(:)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(bar)", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(bar)", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
     '(bar)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
     '(:,:)'
-    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'MODULE', ParseContext()))[1].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("integer, dimension(:) :: foo(:,:), baz", ParseSource('foo.F90', 'module', ParseContext()))[1].get_prop_value('dimensions')
     '(:)'
-    >>> parse_fortran_var_decl("real (kind=kind_phys), pointer :: phii  (:,:) => null()   !< interface geopotential height", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("real (kind=kind_phys), pointer :: phii  (:,:) => null()   !< interface geopotential height", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('dimensions')
     '(:,:)'
-    >>> parse_fortran_var_decl("real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: qgrs", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('dimensions')
+    >>> parse_fortran_var_decl("real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: qgrs", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('dimensions')
     '(im, levs, ntrac)'
-    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'MODULE', ParseContext()))[0].get_prop_value('local_name')
+    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('local_name')
     'errmsg'
+    >>> parse_fortran_var_decl("character(len=512), intent(out) :: errmsg", ParseSource('foo.F90', 'scheme', ParseContext()))[0].get_prop_value('kind')
+    'len=512'
+    >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'module', ParseContext()))[0].get_prop_value('local_name') #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid variable declaration, character(len=*), intent(out) :: errmsg, intent not allowed in module variable, in <standard input>
     """
     context = source.context
     sline = line.strip()
@@ -599,7 +606,21 @@ def parse_fortran_var_decl(line, source, logger=None):
             varprops = Ftype.parse_attr_specs(elements[0].strip(), context)
             for prop in varprops:
                 if prop[0:6] == 'intent':
-                    intent = prop[6:].strip()[1:-1].strip()
+                    if source.type != 'scheme':
+                        typ = source.type
+                        errmsg = 'Invalid variable declaration, {}, intent'
+                        errmsg = errmsg + ' not allowed in {} variable'
+                        if logger is not None:
+                            ctx = context_string(context)
+                            errmsg = "WARNING: " + errmsg + "{}"
+                            logger.warning(errmsg.format(var, typ, ctx))
+                        else:
+                            raise ParseSyntaxError(errmsg.format(sline, typ),
+                                                   context=context)
+                        # End if
+                    else:
+                        intent = prop[6:].strip()[1:-1].strip()
+                    # End if
                 elif prop[0:9:] == 'dimension':
                     dimensions = prop[9:].strip()
                 # End if
@@ -631,20 +652,26 @@ def parse_fortran_var_decl(line, source, logger=None):
                 if (begin < 0) or (end < 0):
                     if logger is not None:
                         ctx = context_string(context)
-                        logger.warning("WARNING: Invalid variable declaration, {}{}".format(var, ctx))
+                        errmsg = "WARNING: Invalid variable declaration, {}{}"
+                        logger.warning(errmsg.format(var, ctx))
                     else:
-                        raise ParseSyntaxError('variable declaration', token=var, context=context)
+                        raise ParseSyntaxError('variable declaration',
+                                               token=var, context=context)
                     # End if
                 else:
                     dimspec = var[begin:end+1]
                 # End if
             # End if
             prop_dict['local_name'] = varname
-            prop_dict['standard_name'] = Ftype.unique_standard_name()
+            prop_dict['standard_name'] = unique_standard_name()
             prop_dict['units'] = ''
-            prop_dict['type'] = tobject.typestr
-            if tobject.kind is not None:
-                prop_dict['kind'] = tobject.kind
+            if isinstance(tobject, Ftype_type_decl):
+                prop_dict['ddt_type'] = tobject.typestr()
+            else:
+                prop_dict['type'] = tobject.typestr()
+            # End if
+            if tobject.kind() is not None:
+                prop_dict['kind'] = tobject.kind()
             # End if
             if 'optional' in varprops:
                 prop_dict['optional'] = 'True'

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -5,39 +5,39 @@
 # Python library imports
 import re
 # CCPP framework imports
-from .parse_source import CCPPError, ParseInternalError
+from parse_source import CCPPError
 
 ########################################################################
 
-def check_dimensions(test_val, prop_dict, error, max_len=0):
+def check_dimensions(test_val, max_len=0, error=False):
     """Return <test_val> if a valid dimensions list, otherwise, None
     If <max_len> > 0, each string in <test_val> must not be longer than
     <max_len>.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_dimensions(["dim1", "dim2name"], None, False)
+    >>> check_dimensions(["dim1", "dim2name"])
     ['dim1', 'dim2name']
-    >>> check_dimensions([":", ":"], None, False)
+    >>> check_dimensions([":", ":"])
     [':', ':']
-    >>> check_dimensions([":", "dim2"], None, False)
+    >>> check_dimensions([":", "dim2"])
     [':', 'dim2']
-    >>> check_dimensions(["dim1", ":"], None, False)
+    >>> check_dimensions(["dim1", ":"])
     ['dim1', ':']
-    >>> check_dimensions(["8", "::"], None, False)
+    >>> check_dimensions(["8", "::"])
     ['8', '::']
-    >>> check_dimensions(['start1:end1', 'start2:end2'], None, False)
+    >>> check_dimensions(['start1:end1', 'start2:end2'])
     ['start1:end1', 'start2:end2']
-    >>> check_dimensions(['start1:', 'start2:end2'], None, False)
+    >>> check_dimensions(['start1:', 'start2:end2'])
     ['start1:', 'start2:end2']
-    >>> check_dimensions(["dim1", "dim2name"], None, False, max_len=5)
+    >>> check_dimensions(["dim1", "dim2name"], max_len=5)
 
-    >>> check_dimensions(["dim1", "dim2name"], None, True, max_len=5)
+    >>> check_dimensions(["dim1", "dim2name"], error=True, max_len=5)
     Traceback (most recent call last):
     CCPPError: 'dim2name' is too long (> 5 chars)
-    >>> check_dimensions("hi_mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_dimensions("hi_mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is invalid; not a list
     """
-    if not isinstance(test_val, list):
+    if type(test_val) != list:
         if error:
             raise CCPPError("'{}' is invalid; not a list".format(test_val))
         else:
@@ -49,8 +49,7 @@ def check_dimensions(test_val, prop_dict, error, max_len=0):
             # Check for too many colons
             if (len(isplit) > 3):
                 if error:
-                    errmsg = "'{}' is an invalid dimension range"
-                    raise CCPPError(errmsg.format(item))
+                    raise CCPPError("'{}' is an invalid dimension range".format(item))
                 else:
                     test_val = None
                 # End if
@@ -64,13 +63,11 @@ def check_dimensions(test_val, prop_dict, error, max_len=0):
                     valid = isinstance(int(tdim), int)
                 except ValueError as ve:
                     # Not an integer, try a Fortran ID
-                    valid = check_fortran_id(tdim, None,
-                                             error, max_len=max_len) is not None
+                    valid = check_fortran_id(tdim, max_len=max_len, error=error) is not None
                 # End try
                 if not valid:
                     if error:
-                        errmsg = "'{}' is an invalid dimension name"
-                        raise CCPPError(errmsg.format(item))
+                        raise CCPPError("'{}' is an invalid dimension name".format(item))
                     else:
                         test_val = None
                     # End if
@@ -84,30 +81,30 @@ def check_dimensions(test_val, prop_dict, error, max_len=0):
 ########################################################################
 
 # CF_ID is a string representing the regular expression for CF Standard Names
-CF_ID = r"(?i)[a-z][a-z0-9_]*"
+CF_ID = r"[a-z][a-z0-9_]*"
 __CFID_RE = re.compile(CF_ID+r"$")
 
-def check_cf_standard_name(test_val, prop_dict, error):
+def check_cf_standard_name(test_val, error=False):
     """Return <test_val> if a valid CF Standard Name, otherwise, None
     http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_cf_standard_name("hi_mom", None, False)
+    >>> check_cf_standard_name("hi_mom")
     'hi_mom'
-    >>> check_cf_standard_name("hi mom", None, False)
+    >>> check_cf_standard_name("hi mom")
 
-    >>> check_cf_standard_name("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_cf_standard_name("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid CF Standard Name
-    >>> check_cf_standard_name("", None, False) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_cf_standard_name("") #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: CCPP Standard Name cannot be blank
-    >>> check_cf_standard_name("_hi_mom", None, False)
+    >>> check_cf_standard_name("_hi_mom")
 
-    >>> check_cf_standard_name("2pac", None, False)
+    >>> check_cf_standard_name("2pac")
 
-    >>> check_cf_standard_name("Agood4tranID", None, False)
-    'agood4tranid'
-    >>> check_cf_standard_name("agoodcfid", None, False)
+    >>> check_cf_standard_name("Agood4tranID")
+
+    >>> check_cf_standard_name("agoodcfid")
     'agoodcfid'
     """
     if len(test_val) == 0:
@@ -117,13 +114,10 @@ def check_cf_standard_name(test_val, prop_dict, error):
     # End if
     if match is None:
         if error:
-            errmsg = "'{}' is not a valid CCPP Standard Name"
-            raise CCPPError(errmsg.format(test_val))
+            raise CCPPError("'{}' is not a valid CCPP Standard Name".format(test_val))
         else:
             test_val = None
         # End if
-    else:
-        test_val = test_val.lower()
     # End if
     return test_val
 
@@ -138,12 +132,9 @@ FORTRAN_ID = r"([A-Za-z][A-Za-z0-9_]*)"
 __FID_RE = re.compile(FORTRAN_ID+r"$")
 # Note that the scalar array reference expressions below are not really for
 # scalar references because a colon can be a placeholder, unlike in Fortran code
-__FORTRAN_AID = r"(?:[A-Za-z][A-Za-z0-9_]*)"
-__FORT_DIM = r"(?:"+__FORTRAN_AID+r"|[:])"
-__REPEAT_DIM = r"(?:,\s*"+__FORT_DIM+r"\s*)"
-__FORTRAN_SCALAR_ARREF = r"[(]\s*("+__FORT_DIM+r"\s*"+__REPEAT_DIM+r"{0,6})[)]"
-FORTRAN_SCALAR_REF = r"(?:"+FORTRAN_ID+r"\s*"+__FORTRAN_SCALAR_ARREF+r")"
-FORTRAN_SCALAR_REF_RE = re.compile(FORTRAN_SCALAR_REF+r"$")
+FORTRAN_SCALAR_ARREF = r"\(\s*(?:"+FORTRAN_ID+r"|[:])\s*(?:,\s*(?:"+FORTRAN_ID+r"|[:])\s*){0,6}\)"
+FORTRAN_SCALAR_REF = r"(?:"+FORTRAN_ID+r"\s*"+FORTRAN_SCALAR_ARREF+r")"
+_FORTRAN_SCALAR_REF_RE = re.compile(FORTRAN_SCALAR_REF+r"$")
 FORTRAN_INTRINSIC_TYPES = [ "integer", "real", "logical", "complex",
                             "double precision", "character" ]
 FORTRAN_DP_RE = re.compile(r"(?i)double\s*precision")
@@ -153,29 +144,29 @@ _REGISTERED_FORTRAN_DDT_NAMES = list()
 
 ########################################################################
 
-def check_fortran_id(test_val, prop_dict, error, max_len=0):
+def check_fortran_id(test_val, max_len=0, error=False):
     """Return <test_val> if a valid Fortran identifier, otherwise, None
     If <max_len> > 0, <test_val> must not be longer than <max_len>.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_fortran_id("hi_mom", None, False)
+    >>> check_fortran_id("hi_mom")
     'hi_mom'
-    >>> check_fortran_id("hi_mom", None, False, max_len=5)
+    >>> check_fortran_id("hi_mom", max_len=5)
 
-    >>> check_fortran_id("hi_mom", None, True, max_len=5) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_id("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is too long (> 5 chars)
-    >>> check_fortran_id("hi mom", None, False)
+    >>> check_fortran_id("hi mom")
 
-    >>> check_fortran_id("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_id("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid Fortran identifier
-    >>> check_fortran_id("", None, False)
+    >>> check_fortran_id("")
 
-    >>> check_fortran_id("_hi_mom", None, False)
+    >>> check_fortran_id("_hi_mom")
 
-    >>> check_fortran_id("2pac", None, False)
+    >>> check_fortran_id("2pac")
 
-    >>> check_fortran_id("Agood4tranID", None, False)
+    >>> check_fortran_id("Agood4tranID")
     'Agood4tranID'
     """
     match = __FID_RE.match(test_val)
@@ -196,84 +187,69 @@ def check_fortran_id(test_val, prop_dict, error, max_len=0):
 
 ########################################################################
 
-def check_fortran_ref(test_val, prop_dict, error, max_len=0):
+def check_fortran_ref(test_val, max_len=0, error=False):
     """Return <test_val> if a valid simple Fortran variable reference,
     otherwise, None. A simple Fortran variable reference is defined as
     a scalar id or a scalar array reference.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(1)
-    'foo'
-    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2)
-    'bar, baz '
-    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2).split(',')[0].strip()
-    'bar'
-    >>> FORTRAN_SCALAR_REF_RE.match("foo( :, baz )").group(2).split(',')[0].strip()
-    ':'
-    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2).split(',')[1].strip()
-    'baz'
-    >>> check_fortran_ref("hi_mom", None, False)
+    >>> check_fortran_ref("hi_mom")
     'hi_mom'
-    >>> check_fortran_ref("hi_mom", None, False, max_len=5)
+    >>> check_fortran_ref("hi_mom", max_len=5)
 
-    >>> check_fortran_ref("hi_mom", None, True, max_len=5) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is too long (> 5 chars)
-    >>> check_fortran_ref("hi mom", None, False)
+    >>> check_fortran_ref("hi mom")
 
-    >>> check_fortran_ref("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid Fortran identifier
-    >>> check_fortran_ref("", None, False)
+    >>> check_fortran_ref("")
 
-    >>> check_fortran_ref("_hi_mom", None, False)
+    >>> check_fortran_ref("_hi_mom")
 
-    >>> check_fortran_ref("2pac", None, False)
+    >>> check_fortran_ref("2pac")
 
-    >>> check_fortran_ref("Agood4tranID", None, False)
+    >>> check_fortran_ref("Agood4tranID")
     'Agood4tranID'
-    >>> check_fortran_ref("foo(bar)", None, False)
+    >>> check_fortran_ref("foo(bar)")
     'foo(bar)'
-    >>> check_fortran_ref("foo( bar, baz )", None, False)
+    >>> check_fortran_ref("foo( bar, baz )")
     'foo( bar, baz )'
-    >>> check_fortran_ref("foo( :, baz )", None, False)
-    'foo( :, baz )'
-    >>> check_fortran_ref("foo( bar, )", None, False)
+    >>> check_fortran_ref("foo( bar, )")
 
-    >>> check_fortran_ref("foo( bar, )", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo( bar, )", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo( bar, )' is not a valid Fortran scalar reference
-    >>> check_fortran_ref("foo()", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo()", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo()' is not a valid Fortran scalar reference
-    >>> check_fortran_ref("foo(bar, bazz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo(bar, bazz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'bazz' is too long (> 3 chars) in foo(bar, bazz)
-    >>> check_fortran_ref("foo(barr, baz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo(barr, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'bazr' is too long (> 3 chars) in foo(barr, baz)
-    >>> check_fortran_ref("fooo(bar, baz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("fooo(bar, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo' is too long (> 3 chars) in fooo(bar, baz)
     """
-    idval = check_fortran_id(test_val, prop_dict, False, max_len=max_len)
+    idval = check_fortran_id(test_val, max_len=max_len, error=False)
     if idval is None:
-        match = FORTRAN_SCALAR_REF_RE.match(test_val)
+        match = _FORTRAN_SCALAR_REF_RE.match(test_val)
         if match is None:
             if error:
-                emsg = "'{}' is not a valid Fortran scalar reference"
-                raise CCPPError(emsg.format(test_val))
+                raise CCPPError("'{}' is not a valid Fortran scalar reference".format(test_val))
             else:
                 test_val = None
             # End if
         elif max_len > 0:
             tokens = test_val.strip().rstrip(')').split('(')
-            tokens = [tokens[0].strip()] + [x.strip()
-                                            for x in tokens[1].split(',')]
+            tokens = [tokens[0].strip()] + [x.strip() for x in tokens[1].split(',')]
             for token in tokens:
                 if len(token) > max_len:
                     if error:
-                        emsg = "'{}' is too long (> {} chars) in {}"
-                        raise CCPPError(emsg.format(token, max_len, test_val))
+                        raise CCPPError("'{}' is too long (> {} chars) in {}".format(token, max_len, test_val))
                     else:
                         test_val = None
                         break
@@ -286,68 +262,10 @@ def check_fortran_ref(test_val, prop_dict, error, max_len=0):
 
 ########################################################################
 
-def check_local_name(test_val, prop_dict, error, max_len=0):
-    """Return <test_val> if a valid simple Fortran variable reference,
-    or Fortran constant, otherwise, None.
-    A simple Fortran variable reference is defined as a scalar id or a
-    scalar array reference.
-    A constant is only valid if <prop_dict> is not None, the 'protected'
-    property is present and True, and the 'type' property matches the
-    type of <test_val>.
-    if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_local_name("hi_mom", None, error=False)
-    'hi_mom'
-    >>> check_local_name('122', {'protected':True,'type':'integer'}, error=False)
-    '122'
-    >>> check_local_name('122', None, error=False)
-
-    >>> check_local_name('122', {}, error=False)
-
-    >>> check_local_name('122', {'protected':False,'type':'integer'}, error=False)
-
-    >>> check_local_name('122', {'protected':True,'type':'real'}, error=False)
-
-    >>> check_local_name('-122.e4', {'protected':True,'type':'real'}, error=False)
-    '-122.e4'
-    >>> check_local_name('-122.', {'protected':True,'type':'real','kind':'kp'}, error=False)
-
-    >>> check_local_name('-122._kp', {'protected':True,'type':'real','kind':'kp'}, error=False)
-    '-122._kp'
-    >>> check_local_name('q(:,:,index_of_water_vapor_specific_humidity)', {}, error=False)
-    'q(:,:,index_of_water_vapor_specific_humidity)'
-    """
-    valid_val = None
-    # First check for a constant
-    if (prop_dict is not None) and ('protected' in prop_dict):
-        protected = prop_dict['protected']
-    else:
-        protected = False
-    # End if
-    if (prop_dict is not None) and ('type' in prop_dict):
-        vtype = prop_dict['type']
-    else:
-        vtype = ""
-    # End if
-    if (prop_dict is not None) and ('kind' in prop_dict):
-        kind = prop_dict['kind']
-    else:
-        kind = ""
-    # End if
-    if protected and vtype and check_fortran_literal(test_val, vtype, kind):
-        valid_val = test_val
-    # End if
-    if valid_val is None:
-        valid_val = check_fortran_ref(test_val, prop_dict, error, max_len=max_len)
-    # End if
-    return valid_val
-
-
-########################################################################
-
 def check_fortran_intrinsic(typestr, error=False):
     """Return <test_val> if a valid Fortran intrinsic type, otherwise, None
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_fortran_intrinsic("real", error=False)
+    >>> check_fortran_intrinsic("real")
     'real'
     >>> check_fortran_intrinsic("complex")
     'complex'
@@ -393,38 +311,38 @@ def check_fortran_intrinsic(typestr, error=False):
 
 ########################################################################
 
-def check_fortran_type(typestr, prop_dict, error):
+def check_fortran_type(typestr, error=False):
     """Return <typestr> if a valid Fortran type, otherwise, None
     if <error> is True, raise an Exception if <typestr> is not valid.
-    >>> check_fortran_type("real", None, False)
+    >>> check_fortran_type("real")
     'real'
-    >>> check_fortran_type("integer", None, False)
+    >>> check_fortran_type("integer")
     'integer'
-    >>> check_fortran_type("InteGer", None, False)
+    >>> check_fortran_type("InteGer")
     'InteGer'
-    >>> check_fortran_type("character", None, False)
+    >>> check_fortran_type("character")
     'character'
-    >>> check_fortran_type("double precision", None, False)
+    >>> check_fortran_type("double precision")
     'double precision'
-    >>> check_fortran_type("double   precision", None, False)
+    >>> check_fortran_type("double   precision")
     'double   precision'
-    >>> check_fortran_type("doubleprecision", None, False)
+    >>> check_fortran_type("doubleprecision")
     'doubleprecision'
-    >>> check_fortran_type("complex", None, False)
+    >>> check_fortran_type("complex")
     'complex'
-    >>> check_fortran_type("char", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_type("char", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'char' is not a valid Fortran type
-    >>> check_fortran_type("int", None, False)
+    >>> check_fortran_type("int")
 
-    >>> check_fortran_type("char", {}, False)
+    >>> check_fortran_type("char", error=False)
 
-    >>> check_fortran_type("type", None, False)
+    >>> check_fortran_type("type")
 
-    >>> check_fortran_type("type", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_type("type", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    CCPPError: 'type' is not a valid derived Fortran type
-    >>> check_fortran_type("type(hi mom)", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    CCPPError: 'char' is not a valid derived Fortran type
+    >>> check_fortran_type("type(hi mom)", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'type(hi mom)' is not a valid derived Fortran type
     """
@@ -442,181 +360,6 @@ def check_fortran_type(typestr, prop_dict, error):
         # End if
     # End if
     return typestr
-
-########################################################################
-
-def check_fortran_literal(value, typestr, kind):
-    """Return True iff <value> is a valid Fortran literal of type, <typestr>.
-    Note: no attempt is made to handle the older D syntax for real literals.
-    To promote clean coding, real values MUST have a decimal point, however,
-       this check is not available for the complex type so we just require
-       the two components to either both be integers or both be reals.
-    If <kind> is not an empty string, it is required to be present (i.e., if
-    <kind> == 'kind_phys', <value> should be of the form, 123.4_kind_phys)
-    >>> check_fortran_literal("123", "integer", "")
-    True
-    >>> check_fortran_literal("123", "INTEGER", "")
-    True
-    >>> check_fortran_literal("-123", "integer", "")
-    True
-    >>> check_fortran_literal("+123", "integer", "")
-    True
-    >>> check_fortran_literal("+123", "integer", "kind_int")
-    False
-    >>> check_fortran_literal("+123_kind_int", "integer", "kind_int")
-    True
-    >>> check_fortran_literal("+123_int", "integer", "kind_int")
-    False
-    >>> check_fortran_literal("123", "real", "")
-    False
-    >>> check_fortran_literal("123.", "real", "")
-    True
-    >>> check_fortran_literal("123.45", "real", "kind_phys")
-    False
-    >>> check_fortran_literal("123.45_8", "real", "kind_phys")
-    False
-    >>> check_fortran_literal("123.45_kind_phys", "real", "kind_phys")
-    True
-    >>> check_fortran_literal("123", "double precision", "")
-    False
-    >>> check_fortran_literal("123.", "doubleprecision", "")
-    True
-    >>> check_fortran_literal("123.45", "double   precision", "kind_phys")
-    False
-    >>> check_fortran_literal("123.45_8", "doubleprecision", "kind_phys")
-    False
-    >>> check_fortran_literal("123.45_kp", "doubleprecision", "kp")
-    True
-    >>> check_fortran_literal("123", "logical", "")
-    False
-    >>> check_fortran_literal(".true.", "logical", "")
-    True
-    >>> check_fortran_literal(".false.", "logical", "")
-    True
-    >>> check_fortran_literal("T", "logical", "")
-    False
-    >>> check_fortran_literal("F", "logical", "")
-    False
-    >>> check_fortran_literal(".TRUE.", "logical", "kind_log")
-    False
-    >>> check_fortran_literal(".TRUE._kind_log", "logical", "kind_log")
-    True
-    >>> check_fortran_literal("(123.,456.)", "complex", "")
-    True
-    >>> check_fortran_literal("(123. , 456.)", "complex", "")
-    True
-    >>> check_fortran_literal("(123.,456", "complex", "")
-    False
-    >>> check_fortran_literal("(123. , 456.)", "complex", "kp")
-    False
-    >>> check_fortran_literal("(123._kp , 456)", "complex", "kp")
-    False
-    >>> check_fortran_literal("(123._kp , 456._kp)", "complex", "kp")
-    True
-    >>> check_fortran_literal("'hi mom'", "character", "")
-    True
-    >>> check_fortran_literal("'hi mom", "character", "")
-    False
-    >>> check_fortran_literal('"hi mom"', "character", "")
-    True
-    >>> check_fortran_literal('"hi""mom"', "character", "")
-    True
-    >>> check_fortran_literal('"hi" "mom"', "character", "")
-    False
-    >>> check_fortran_literal("'hi''there''mom'", "character", "")
-    True
-    >>> check_fortran_literal("'hi mom'", "character", "kc")
-    False
-    >>> check_fortran_literal("kc_'hi mom'", "character", "kc")
-    True
-    >>> check_fortran_literal("123._kp", "float", "kp") #doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ParseInternalError: ERROR: 'float' is not a Fortran intrinsic type
-    """
-    valid = True
-    if FORTRAN_DP_RE.match(typestr.strip()) is not None:
-        vtype = 'real'
-    else:
-        vtype = typestr.lower()
-    # End if
-    # Check complex first
-    if vtype == 'complex':
-        cvals = value.strip().split(',')
-        if len(cvals) == 2:
-            tp = 'integer'
-            if ('.' in cvals[0]) and ('.' in cvals[1]):
-                tp = 'real'
-            elif ('.' in cvals[0]) or ('.' in cvals[1]):
-                valid = False
-            # End if
-            if (cvals[0][0] == '(') and (cvals[1][-1] == ')'):
-                valid = valid and check_fortran_literal(cvals[0][1:], tp, kind)
-                valid = valid and check_fortran_literal(cvals[1][:-1], tp, kind)
-            else:
-                valid = False
-            # End if
-        else:
-            valid = False
-    elif valid:
-        vparts = value.strip().split('_')
-        if vtype == 'character':
-            if len(vparts) > 1:
-                val = vparts[-1]
-                vkind = '_'.join(vparts[0:-1])
-            else:
-                val = vparts[0]
-                vkind = ''
-            # End if
-        else:
-            val = vparts[0]
-            if len(vparts) > 1:
-                vkind = '_'.join(vparts[1:])
-            else:
-                vkind = ''
-            # End if
-        # End if
-        if vkind != kind.lower():
-            valid = False
-        # End if, kind is okay, check value
-        if valid and (vtype == 'integer'):
-            try:
-                vtest = int(val)
-            except ValueError as ve:
-                valid = False
-            # End try
-        elif valid and (vtype == 'real'):
-            if '.' not in val:
-                valid = False
-            else:
-                try:
-                    vtest = float(val)
-                except ValueError as ve:
-                    valid = False
-                # End try
-            # End if
-        elif valid and (vtype == 'logical'):
-            valid = (val.upper() == '.TRUE.') or (val.upper() == '.FALSE.')
-        elif valid and (vtype == 'character'):
-            sep = val[0]
-            cparts = val.split(sep)
-            # We must have balanced delimiters
-            if len(cparts)%2 == 0:
-                valid = False
-            else:
-                for index in range(len(cparts)):
-                    if (index%2 == 0) and (len(cparts[index]) > 0):
-                        valid = False
-                        break
-                    # End if
-                # End for
-            # End if (else okay)
-        elif valid:
-            errmsg = "ERROR: '{}' is not a Fortran intrinsic type"
-            raise ParseInternalError(errmsg.format(typestr))
-        # End if (no else)
-    # End if
-    return valid
-
 
 ########################################################################
 

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -5,39 +5,39 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source import CCPPError
+from .parse_source import CCPPError, ParseInternalError
 
 ########################################################################
 
-def check_dimensions(test_val, max_len=0, error=False):
+def check_dimensions(test_val, prop_dict, error, max_len=0):
     """Return <test_val> if a valid dimensions list, otherwise, None
     If <max_len> > 0, each string in <test_val> must not be longer than
     <max_len>.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_dimensions(["dim1", "dim2name"])
+    >>> check_dimensions(["dim1", "dim2name"], None, False)
     ['dim1', 'dim2name']
-    >>> check_dimensions([":", ":"])
+    >>> check_dimensions([":", ":"], None, False)
     [':', ':']
-    >>> check_dimensions([":", "dim2"])
+    >>> check_dimensions([":", "dim2"], None, False)
     [':', 'dim2']
-    >>> check_dimensions(["dim1", ":"])
+    >>> check_dimensions(["dim1", ":"], None, False)
     ['dim1', ':']
-    >>> check_dimensions(["8", "::"])
+    >>> check_dimensions(["8", "::"], None, False)
     ['8', '::']
-    >>> check_dimensions(['start1:end1', 'start2:end2'])
+    >>> check_dimensions(['start1:end1', 'start2:end2'], None, False)
     ['start1:end1', 'start2:end2']
-    >>> check_dimensions(['start1:', 'start2:end2'])
+    >>> check_dimensions(['start1:', 'start2:end2'], None, False)
     ['start1:', 'start2:end2']
-    >>> check_dimensions(["dim1", "dim2name"], max_len=5)
+    >>> check_dimensions(["dim1", "dim2name"], None, False, max_len=5)
 
-    >>> check_dimensions(["dim1", "dim2name"], error=True, max_len=5)
+    >>> check_dimensions(["dim1", "dim2name"], None, True, max_len=5)
     Traceback (most recent call last):
     CCPPError: 'dim2name' is too long (> 5 chars)
-    >>> check_dimensions("hi_mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_dimensions("hi_mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is invalid; not a list
     """
-    if type(test_val) != list:
+    if not isinstance(test_val, list):
         if error:
             raise CCPPError("'{}' is invalid; not a list".format(test_val))
         else:
@@ -49,7 +49,8 @@ def check_dimensions(test_val, max_len=0, error=False):
             # Check for too many colons
             if (len(isplit) > 3):
                 if error:
-                    raise CCPPError("'{}' is an invalid dimension range".format(item))
+                    errmsg = "'{}' is an invalid dimension range"
+                    raise CCPPError(errmsg.format(item))
                 else:
                     test_val = None
                 # End if
@@ -63,11 +64,13 @@ def check_dimensions(test_val, max_len=0, error=False):
                     valid = isinstance(int(tdim), int)
                 except ValueError as ve:
                     # Not an integer, try a Fortran ID
-                    valid = check_fortran_id(tdim, max_len=max_len, error=error) is not None
+                    valid = check_fortran_id(tdim, None,
+                                             error, max_len=max_len) is not None
                 # End try
                 if not valid:
                     if error:
-                        raise CCPPError("'{}' is an invalid dimension name".format(item))
+                        errmsg = "'{}' is an invalid dimension name"
+                        raise CCPPError(errmsg.format(item))
                     else:
                         test_val = None
                     # End if
@@ -81,30 +84,30 @@ def check_dimensions(test_val, max_len=0, error=False):
 ########################################################################
 
 # CF_ID is a string representing the regular expression for CF Standard Names
-CF_ID = r"[a-z][a-z0-9_]*"
+CF_ID = r"(?i)[a-z][a-z0-9_]*"
 __CFID_RE = re.compile(CF_ID+r"$")
 
-def check_cf_standard_name(test_val, error=False):
+def check_cf_standard_name(test_val, prop_dict, error):
     """Return <test_val> if a valid CF Standard Name, otherwise, None
     http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_cf_standard_name("hi_mom")
+    >>> check_cf_standard_name("hi_mom", None, False)
     'hi_mom'
-    >>> check_cf_standard_name("hi mom")
+    >>> check_cf_standard_name("hi mom", None, False)
 
-    >>> check_cf_standard_name("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_cf_standard_name("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid CF Standard Name
-    >>> check_cf_standard_name("") #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_cf_standard_name("", None, False) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: CCPP Standard Name cannot be blank
-    >>> check_cf_standard_name("_hi_mom")
+    >>> check_cf_standard_name("_hi_mom", None, False)
 
-    >>> check_cf_standard_name("2pac")
+    >>> check_cf_standard_name("2pac", None, False)
 
-    >>> check_cf_standard_name("Agood4tranID")
-
-    >>> check_cf_standard_name("agoodcfid")
+    >>> check_cf_standard_name("Agood4tranID", None, False)
+    'agood4tranid'
+    >>> check_cf_standard_name("agoodcfid", None, False)
     'agoodcfid'
     """
     if len(test_val) == 0:
@@ -114,10 +117,13 @@ def check_cf_standard_name(test_val, error=False):
     # End if
     if match is None:
         if error:
-            raise CCPPError("'{}' is not a valid CCPP Standard Name".format(test_val))
+            errmsg = "'{}' is not a valid CCPP Standard Name"
+            raise CCPPError(errmsg.format(test_val))
         else:
             test_val = None
         # End if
+    else:
+        test_val = test_val.lower()
     # End if
     return test_val
 
@@ -132,9 +138,12 @@ FORTRAN_ID = r"([A-Za-z][A-Za-z0-9_]*)"
 __FID_RE = re.compile(FORTRAN_ID+r"$")
 # Note that the scalar array reference expressions below are not really for
 # scalar references because a colon can be a placeholder, unlike in Fortran code
-FORTRAN_SCALAR_ARREF = r"\(\s*(?:"+FORTRAN_ID+r"|[:])\s*(?:,\s*(?:"+FORTRAN_ID+r"|[:])\s*){0,6}\)"
-FORTRAN_SCALAR_REF = r"(?:"+FORTRAN_ID+r"\s*"+FORTRAN_SCALAR_ARREF+r")"
-_FORTRAN_SCALAR_REF_RE = re.compile(FORTRAN_SCALAR_REF+r"$")
+__FORTRAN_AID = r"(?:[A-Za-z][A-Za-z0-9_]*)"
+__FORT_DIM = r"(?:"+__FORTRAN_AID+r"|[:])"
+__REPEAT_DIM = r"(?:,\s*"+__FORT_DIM+r"\s*)"
+__FORTRAN_SCALAR_ARREF = r"[(]\s*("+__FORT_DIM+r"\s*"+__REPEAT_DIM+r"{0,6})[)]"
+FORTRAN_SCALAR_REF = r"(?:"+FORTRAN_ID+r"\s*"+__FORTRAN_SCALAR_ARREF+r")"
+FORTRAN_SCALAR_REF_RE = re.compile(FORTRAN_SCALAR_REF+r"$")
 FORTRAN_INTRINSIC_TYPES = [ "integer", "real", "logical", "complex",
                             "double precision", "character" ]
 FORTRAN_DP_RE = re.compile(r"(?i)double\s*precision")
@@ -144,29 +153,29 @@ _REGISTERED_FORTRAN_DDT_NAMES = list()
 
 ########################################################################
 
-def check_fortran_id(test_val, max_len=0, error=False):
+def check_fortran_id(test_val, prop_dict, error, max_len=0):
     """Return <test_val> if a valid Fortran identifier, otherwise, None
     If <max_len> > 0, <test_val> must not be longer than <max_len>.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_fortran_id("hi_mom")
+    >>> check_fortran_id("hi_mom", None, False)
     'hi_mom'
-    >>> check_fortran_id("hi_mom", max_len=5)
+    >>> check_fortran_id("hi_mom", None, False, max_len=5)
 
-    >>> check_fortran_id("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_id("hi_mom", None, True, max_len=5) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is too long (> 5 chars)
-    >>> check_fortran_id("hi mom")
+    >>> check_fortran_id("hi mom", None, False)
 
-    >>> check_fortran_id("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_id("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid Fortran identifier
-    >>> check_fortran_id("")
+    >>> check_fortran_id("", None, False)
 
-    >>> check_fortran_id("_hi_mom")
+    >>> check_fortran_id("_hi_mom", None, False)
 
-    >>> check_fortran_id("2pac")
+    >>> check_fortran_id("2pac", None, False)
 
-    >>> check_fortran_id("Agood4tranID")
+    >>> check_fortran_id("Agood4tranID", None, False)
     'Agood4tranID'
     """
     match = __FID_RE.match(test_val)
@@ -187,69 +196,84 @@ def check_fortran_id(test_val, max_len=0, error=False):
 
 ########################################################################
 
-def check_fortran_ref(test_val, max_len=0, error=False):
+def check_fortran_ref(test_val, prop_dict, error, max_len=0):
     """Return <test_val> if a valid simple Fortran variable reference,
     otherwise, None. A simple Fortran variable reference is defined as
     a scalar id or a scalar array reference.
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_fortran_ref("hi_mom")
+    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(1)
+    'foo'
+    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2)
+    'bar, baz '
+    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2).split(',')[0].strip()
+    'bar'
+    >>> FORTRAN_SCALAR_REF_RE.match("foo( :, baz )").group(2).split(',')[0].strip()
+    ':'
+    >>> FORTRAN_SCALAR_REF_RE.match("foo( bar, baz )").group(2).split(',')[1].strip()
+    'baz'
+    >>> check_fortran_ref("hi_mom", None, False)
     'hi_mom'
-    >>> check_fortran_ref("hi_mom", max_len=5)
+    >>> check_fortran_ref("hi_mom", None, False, max_len=5)
 
-    >>> check_fortran_ref("hi_mom", max_len=5, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("hi_mom", None, True, max_len=5) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is too long (> 5 chars)
-    >>> check_fortran_ref("hi mom")
+    >>> check_fortran_ref("hi mom", None, False)
 
-    >>> check_fortran_ref("hi mom", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("hi mom", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'hi_mom' is not a valid Fortran identifier
-    >>> check_fortran_ref("")
+    >>> check_fortran_ref("", None, False)
 
-    >>> check_fortran_ref("_hi_mom")
+    >>> check_fortran_ref("_hi_mom", None, False)
 
-    >>> check_fortran_ref("2pac")
+    >>> check_fortran_ref("2pac", None, False)
 
-    >>> check_fortran_ref("Agood4tranID")
+    >>> check_fortran_ref("Agood4tranID", None, False)
     'Agood4tranID'
-    >>> check_fortran_ref("foo(bar)")
+    >>> check_fortran_ref("foo(bar)", None, False)
     'foo(bar)'
-    >>> check_fortran_ref("foo( bar, baz )")
+    >>> check_fortran_ref("foo( bar, baz )", None, False)
     'foo( bar, baz )'
-    >>> check_fortran_ref("foo( bar, )")
+    >>> check_fortran_ref("foo( :, baz )", None, False)
+    'foo( :, baz )'
+    >>> check_fortran_ref("foo( bar, )", None, False)
 
-    >>> check_fortran_ref("foo( bar, )", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo( bar, )", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo( bar, )' is not a valid Fortran scalar reference
-    >>> check_fortran_ref("foo()", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo()", None, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo()' is not a valid Fortran scalar reference
-    >>> check_fortran_ref("foo(bar, bazz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo(bar, bazz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'bazz' is too long (> 3 chars) in foo(bar, bazz)
-    >>> check_fortran_ref("foo(barr, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("foo(barr, baz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'bazr' is too long (> 3 chars) in foo(barr, baz)
-    >>> check_fortran_ref("fooo(bar, baz)", max_len=3, error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_ref("fooo(bar, baz)", None, True, max_len=3) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'foo' is too long (> 3 chars) in fooo(bar, baz)
     """
-    idval = check_fortran_id(test_val, max_len=max_len, error=False)
+    idval = check_fortran_id(test_val, prop_dict, False, max_len=max_len)
     if idval is None:
-        match = _FORTRAN_SCALAR_REF_RE.match(test_val)
+        match = FORTRAN_SCALAR_REF_RE.match(test_val)
         if match is None:
             if error:
-                raise CCPPError("'{}' is not a valid Fortran scalar reference".format(test_val))
+                emsg = "'{}' is not a valid Fortran scalar reference"
+                raise CCPPError(emsg.format(test_val))
             else:
                 test_val = None
             # End if
         elif max_len > 0:
             tokens = test_val.strip().rstrip(')').split('(')
-            tokens = [tokens[0].strip()] + [x.strip() for x in tokens[1].split(',')]
+            tokens = [tokens[0].strip()] + [x.strip()
+                                            for x in tokens[1].split(',')]
             for token in tokens:
                 if len(token) > max_len:
                     if error:
-                        raise CCPPError("'{}' is too long (> {} chars) in {}".format(token, max_len, test_val))
+                        emsg = "'{}' is too long (> {} chars) in {}"
+                        raise CCPPError(emsg.format(token, max_len, test_val))
                     else:
                         test_val = None
                         break
@@ -262,10 +286,68 @@ def check_fortran_ref(test_val, max_len=0, error=False):
 
 ########################################################################
 
+def check_local_name(test_val, prop_dict, error, max_len=0):
+    """Return <test_val> if a valid simple Fortran variable reference,
+    or Fortran constant, otherwise, None.
+    A simple Fortran variable reference is defined as a scalar id or a
+    scalar array reference.
+    A constant is only valid if <prop_dict> is not None, the 'protected'
+    property is present and True, and the 'type' property matches the
+    type of <test_val>.
+    if <error> is True, raise an Exception if <test_val> is not valid.
+    >>> check_local_name("hi_mom", None, error=False)
+    'hi_mom'
+    >>> check_local_name('122', {'protected':True,'type':'integer'}, error=False)
+    '122'
+    >>> check_local_name('122', None, error=False)
+
+    >>> check_local_name('122', {}, error=False)
+
+    >>> check_local_name('122', {'protected':False,'type':'integer'}, error=False)
+
+    >>> check_local_name('122', {'protected':True,'type':'real'}, error=False)
+
+    >>> check_local_name('-122.e4', {'protected':True,'type':'real'}, error=False)
+    '-122.e4'
+    >>> check_local_name('-122.', {'protected':True,'type':'real','kind':'kp'}, error=False)
+
+    >>> check_local_name('-122._kp', {'protected':True,'type':'real','kind':'kp'}, error=False)
+    '-122._kp'
+    >>> check_local_name('q(:,:,index_of_water_vapor_specific_humidity)', {}, error=False)
+    'q(:,:,index_of_water_vapor_specific_humidity)'
+    """
+    valid_val = None
+    # First check for a constant
+    if (prop_dict is not None) and ('protected' in prop_dict):
+        protected = prop_dict['protected']
+    else:
+        protected = False
+    # End if
+    if (prop_dict is not None) and ('type' in prop_dict):
+        vtype = prop_dict['type']
+    else:
+        vtype = ""
+    # End if
+    if (prop_dict is not None) and ('kind' in prop_dict):
+        kind = prop_dict['kind']
+    else:
+        kind = ""
+    # End if
+    if protected and vtype and check_fortran_literal(test_val, vtype, kind):
+        valid_val = test_val
+    # End if
+    if valid_val is None:
+        valid_val = check_fortran_ref(test_val, prop_dict, error, max_len=max_len)
+    # End if
+    return valid_val
+
+
+########################################################################
+
 def check_fortran_intrinsic(typestr, error=False):
     """Return <test_val> if a valid Fortran intrinsic type, otherwise, None
     if <error> is True, raise an Exception if <test_val> is not valid.
-    >>> check_fortran_intrinsic("real")
+    >>> check_fortran_intrinsic("real", error=False)
     'real'
     >>> check_fortran_intrinsic("complex")
     'complex'
@@ -311,38 +393,38 @@ def check_fortran_intrinsic(typestr, error=False):
 
 ########################################################################
 
-def check_fortran_type(typestr, error=False):
+def check_fortran_type(typestr, prop_dict, error):
     """Return <typestr> if a valid Fortran type, otherwise, None
     if <error> is True, raise an Exception if <typestr> is not valid.
-    >>> check_fortran_type("real")
+    >>> check_fortran_type("real", None, False)
     'real'
-    >>> check_fortran_type("integer")
+    >>> check_fortran_type("integer", None, False)
     'integer'
-    >>> check_fortran_type("InteGer")
+    >>> check_fortran_type("InteGer", None, False)
     'InteGer'
-    >>> check_fortran_type("character")
+    >>> check_fortran_type("character", None, False)
     'character'
-    >>> check_fortran_type("double precision")
+    >>> check_fortran_type("double precision", None, False)
     'double precision'
-    >>> check_fortran_type("double   precision")
+    >>> check_fortran_type("double   precision", None, False)
     'double   precision'
-    >>> check_fortran_type("doubleprecision")
+    >>> check_fortran_type("doubleprecision", None, False)
     'doubleprecision'
-    >>> check_fortran_type("complex")
+    >>> check_fortran_type("complex", None, False)
     'complex'
-    >>> check_fortran_type("char", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_type("char", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'char' is not a valid Fortran type
-    >>> check_fortran_type("int")
+    >>> check_fortran_type("int", None, False)
 
-    >>> check_fortran_type("char", error=False)
+    >>> check_fortran_type("char", {}, False)
 
-    >>> check_fortran_type("type")
+    >>> check_fortran_type("type", None, False)
 
-    >>> check_fortran_type("type", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_fortran_type("type", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    CCPPError: 'char' is not a valid derived Fortran type
-    >>> check_fortran_type("type(hi mom)", error=True) #doctest: +IGNORE_EXCEPTION_DETAIL
+    CCPPError: 'type' is not a valid derived Fortran type
+    >>> check_fortran_type("type(hi mom)", {}, True) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     CCPPError: 'type(hi mom)' is not a valid derived Fortran type
     """
@@ -360,6 +442,181 @@ def check_fortran_type(typestr, error=False):
         # End if
     # End if
     return typestr
+
+########################################################################
+
+def check_fortran_literal(value, typestr, kind):
+    """Return True iff <value> is a valid Fortran literal of type, <typestr>.
+    Note: no attempt is made to handle the older D syntax for real literals.
+    To promote clean coding, real values MUST have a decimal point, however,
+       this check is not available for the complex type so we just require
+       the two components to either both be integers or both be reals.
+    If <kind> is not an empty string, it is required to be present (i.e., if
+    <kind> == 'kind_phys', <value> should be of the form, 123.4_kind_phys)
+    >>> check_fortran_literal("123", "integer", "")
+    True
+    >>> check_fortran_literal("123", "INTEGER", "")
+    True
+    >>> check_fortran_literal("-123", "integer", "")
+    True
+    >>> check_fortran_literal("+123", "integer", "")
+    True
+    >>> check_fortran_literal("+123", "integer", "kind_int")
+    False
+    >>> check_fortran_literal("+123_kind_int", "integer", "kind_int")
+    True
+    >>> check_fortran_literal("+123_int", "integer", "kind_int")
+    False
+    >>> check_fortran_literal("123", "real", "")
+    False
+    >>> check_fortran_literal("123.", "real", "")
+    True
+    >>> check_fortran_literal("123.45", "real", "kind_phys")
+    False
+    >>> check_fortran_literal("123.45_8", "real", "kind_phys")
+    False
+    >>> check_fortran_literal("123.45_kind_phys", "real", "kind_phys")
+    True
+    >>> check_fortran_literal("123", "double precision", "")
+    False
+    >>> check_fortran_literal("123.", "doubleprecision", "")
+    True
+    >>> check_fortran_literal("123.45", "double   precision", "kind_phys")
+    False
+    >>> check_fortran_literal("123.45_8", "doubleprecision", "kind_phys")
+    False
+    >>> check_fortran_literal("123.45_kp", "doubleprecision", "kp")
+    True
+    >>> check_fortran_literal("123", "logical", "")
+    False
+    >>> check_fortran_literal(".true.", "logical", "")
+    True
+    >>> check_fortran_literal(".false.", "logical", "")
+    True
+    >>> check_fortran_literal("T", "logical", "")
+    False
+    >>> check_fortran_literal("F", "logical", "")
+    False
+    >>> check_fortran_literal(".TRUE.", "logical", "kind_log")
+    False
+    >>> check_fortran_literal(".TRUE._kind_log", "logical", "kind_log")
+    True
+    >>> check_fortran_literal("(123.,456.)", "complex", "")
+    True
+    >>> check_fortran_literal("(123. , 456.)", "complex", "")
+    True
+    >>> check_fortran_literal("(123.,456", "complex", "")
+    False
+    >>> check_fortran_literal("(123. , 456.)", "complex", "kp")
+    False
+    >>> check_fortran_literal("(123._kp , 456)", "complex", "kp")
+    False
+    >>> check_fortran_literal("(123._kp , 456._kp)", "complex", "kp")
+    True
+    >>> check_fortran_literal("'hi mom'", "character", "")
+    True
+    >>> check_fortran_literal("'hi mom", "character", "")
+    False
+    >>> check_fortran_literal('"hi mom"', "character", "")
+    True
+    >>> check_fortran_literal('"hi""mom"', "character", "")
+    True
+    >>> check_fortran_literal('"hi" "mom"', "character", "")
+    False
+    >>> check_fortran_literal("'hi''there''mom'", "character", "")
+    True
+    >>> check_fortran_literal("'hi mom'", "character", "kc")
+    False
+    >>> check_fortran_literal("kc_'hi mom'", "character", "kc")
+    True
+    >>> check_fortran_literal("123._kp", "float", "kp") #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseInternalError: ERROR: 'float' is not a Fortran intrinsic type
+    """
+    valid = True
+    if FORTRAN_DP_RE.match(typestr.strip()) is not None:
+        vtype = 'real'
+    else:
+        vtype = typestr.lower()
+    # End if
+    # Check complex first
+    if vtype == 'complex':
+        cvals = value.strip().split(',')
+        if len(cvals) == 2:
+            tp = 'integer'
+            if ('.' in cvals[0]) and ('.' in cvals[1]):
+                tp = 'real'
+            elif ('.' in cvals[0]) or ('.' in cvals[1]):
+                valid = False
+            # End if
+            if (cvals[0][0] == '(') and (cvals[1][-1] == ')'):
+                valid = valid and check_fortran_literal(cvals[0][1:], tp, kind)
+                valid = valid and check_fortran_literal(cvals[1][:-1], tp, kind)
+            else:
+                valid = False
+            # End if
+        else:
+            valid = False
+    elif valid:
+        vparts = value.strip().split('_')
+        if vtype == 'character':
+            if len(vparts) > 1:
+                val = vparts[-1]
+                vkind = '_'.join(vparts[0:-1])
+            else:
+                val = vparts[0]
+                vkind = ''
+            # End if
+        else:
+            val = vparts[0]
+            if len(vparts) > 1:
+                vkind = '_'.join(vparts[1:])
+            else:
+                vkind = ''
+            # End if
+        # End if
+        if vkind != kind.lower():
+            valid = False
+        # End if, kind is okay, check value
+        if valid and (vtype == 'integer'):
+            try:
+                vtest = int(val)
+            except ValueError as ve:
+                valid = False
+            # End try
+        elif valid and (vtype == 'real'):
+            if '.' not in val:
+                valid = False
+            else:
+                try:
+                    vtest = float(val)
+                except ValueError as ve:
+                    valid = False
+                # End try
+            # End if
+        elif valid and (vtype == 'logical'):
+            valid = (val.upper() == '.TRUE.') or (val.upper() == '.FALSE.')
+        elif valid and (vtype == 'character'):
+            sep = val[0]
+            cparts = val.split(sep)
+            # We must have balanced delimiters
+            if len(cparts)%2 == 0:
+                valid = False
+            else:
+                for index in range(len(cparts)):
+                    if (index%2 == 0) and (len(cparts[index]) > 0):
+                        valid = False
+                        break
+                    # End if
+                # End for
+            # End if (else okay)
+        elif valid:
+            errmsg = "ERROR: '{}' is not a Fortran intrinsic type"
+            raise ParseInternalError(errmsg.format(typestr))
+        # End if (no else)
+    # End if
+    return valid
+
 
 ########################################################################
 


### PR DESCRIPTION
Fix parsing of the initial type definition line in Ftype_type_decl.
Note, this is an updated file from the new_metadata_parser branch so other code has changed as well (but I do not think it is used in gmtb/develop).