### PR TITLE
First version of metadata2html converter

### DIFF
--- a/scripts/convert_metadata.py
+++ b/scripts/convert_metadata.py
@@ -328,8 +328,6 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
 #                logger.info('Found old metadata table, {}, on line {}'.format(table_name, lindex+1))
                 # The header line is not modified
                 file.write(line+"\n")
-                # Write an include line for the metadata table
-                file.write('!! \htmlinclude {}.html\n'.format(table_name))
                 # Create the table start section
                 mdtable = MetadataTable(table_name, current_module)
                 mdconfig.append(mdtable)
@@ -339,6 +337,9 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                 dim_names = [__not_found__]*15
                 # Do not work on a blank table
                 if len(words) > 1:
+                    # Write an include line for the metadata table
+                    file.write('!! \htmlinclude {}.html\n'.format(table_name))
+                    #
                     table_header = [x.strip() for x in words[1:-1]]
                     for ind in xrange(len(table_header)):
                         header_locs[table_header[ind]] = ind

--- a/scripts/convert_metadata_schemes_using_typedef_dims.py
+++ b/scripts/convert_metadata_schemes_using_typedef_dims.py
@@ -207,8 +207,6 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
 #                logger.info('Found old metadata table, {}, on line {}'.format(table_name, lindex+1))
                 # The header line is not modified
                 file.write(line+"\n")
-                # Write an include line for the metadata table
-                file.write('!! \htmlinclude {}.html\n'.format(table_name))
                 # Create the table start section
                 mdtable = MetadataTable(table_name, current_module)
                 mdconfig.append(mdtable)
@@ -218,6 +216,9 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
                 dim_names = [__not_found__]*15
                 # Do not work on a blank table
                 if len(words) > 1:
+                    # Write an include line for the metadata table
+                    file.write('!! \htmlinclude {}.html\n'.format(table_name))
+                    #
                     table_header = [x.strip() for x in words[1:-1]]
                     for ind in xrange(len(table_header)):
                         header_locs[table_header[ind]] = ind

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -13,6 +13,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--metafile', '-m', action='store',
                     help='name of metadata file to convert',
                     required=True)
+parser.add_argument('--outputdir', '-o', action='store',
+                    help='directory where to write the html files',
+                    required=True)
 
 attributes = [ 'standard_name', 'long_name', 'units', 'local_name',
                'type', 'dimensions', 'kind', 'intent', 'optional' ]
@@ -21,16 +24,17 @@ def parse_arguments():
     """Parse command line arguments."""
     args = parser.parse_args()
     filename = args.metafile
-    return filename
+    outdir = args.outputdir
+    return (filename, outdir)
 
-def convert_to_html(filename_in, logger):
+def convert_to_html(filename_in, outdir, logger):
     """Convert a metadata file into html (one html file for each table)"""
     if not os.path.isfile(filename_in):
         raise Exception("Metadata file {} not found".format(filename_in))
     logger.info("Converting file {} to HTML".format(filename_in))
     metadata_headers = MetadataHeader.parse_metadata_file(filename_in)
     for metadata_header in metadata_headers:
-        filename_out = metadata_header.to_html(attributes)
+        filename_out = metadata_header.to_html(outdir, attributes)
         if filename_out:
             logger.info("  ... wrote {}".format(filename_out))
 
@@ -39,8 +43,8 @@ def main():
     logger = init_log('metadata2html')
     set_log_level(logger, logging.INFO)
     # Convert metadata file
-    filename = parse_arguments()
-    convert_to_html(filename, logger)
+    (filename, outdir) = parse_arguments()
+    convert_to_html(filename, outdir, logger)
 
 if __name__ == '__main__':
     main()

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+
+from metadata_table import MetadataHeader
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--metafile', '-m', action='store', help='name of metadata file to convert', required=True)
+
+attributes = [ 'standard_name', 'long_name', 'units', 'local_name', 'type', 'dimensions', 'kind', 'intent', 'optional' ]
+
+def parse_arguments():
+    """Parse command line arguments."""
+    args = parser.parse_args()
+    filename = args.metafile
+    return filename
+
+def convert_to_html(filename_in):
+    """Convert a metadata file into html (one html file for each table)"""
+    if not os.path.isfile(filename_in):
+        raise Exception("Metadata file {} not found".format(filename_in))
+    filename_out = filename_in.replace(".meta", ".html")
+    metadata_headers = MetadataHeader.parse_metadata_file(filename_in)
+    
+    for metadata_header in metadata_headers:
+        print metadata_header
+        metadata_header.to_html(filename_out, attributes)
+
+def main():
+    filename = parse_arguments()
+    print filename
+    convert_to_html(filename)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 
 import argparse
+import logging
 import os
 import sys
 
+# CCPP framework imports
+from parse_tools import init_log, set_log_level
 from metadata_table import MetadataHeader
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--metafile', '-m', action='store', help='name of metadata file to convert', required=True)
+parser.add_argument('--metafile', '-m', action='store',
+                    help='name of metadata file to convert',
+                    required=True)
 
-attributes = [ 'standard_name', 'long_name', 'units', 'local_name', 'type', 'dimensions', 'kind', 'intent', 'optional' ]
+attributes = [ 'standard_name', 'long_name', 'units', 'local_name',
+               'type', 'dimensions', 'kind', 'intent', 'optional' ]
 
 def parse_arguments():
     """Parse command line arguments."""
@@ -17,21 +23,24 @@ def parse_arguments():
     filename = args.metafile
     return filename
 
-def convert_to_html(filename_in):
+def convert_to_html(filename_in, logger):
     """Convert a metadata file into html (one html file for each table)"""
     if not os.path.isfile(filename_in):
         raise Exception("Metadata file {} not found".format(filename_in))
-    filename_out = filename_in.replace(".meta", ".html")
+    logger.info("Converting file {} to HTML".format(filename_in))
     metadata_headers = MetadataHeader.parse_metadata_file(filename_in)
-    
     for metadata_header in metadata_headers:
-        print metadata_header
-        metadata_header.to_html(filename_out, attributes)
+        filename_out = metadata_header.to_html(attributes)
+        if filename_out:
+            logger.info("  ... wrote {}".format(filename_out))
 
 def main():
+    # Initialize logging
+    logger = init_log('metadata2html')
+    set_log_level(logger, logging.INFO)
+    # Convert metadata file
     filename = parse_arguments()
-    print filename
-    convert_to_html(filename)
+    convert_to_html(filename, logger)
 
 if __name__ == '__main__':
     main()

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -179,7 +179,7 @@ class MetadataHeader(ParseSource):
     __html_template__ = """
 <html>
 <head>
-<title>My First HTML</title>
+<title>{title}</title>
 <meta charset="UTF-8">
 </head>
 <body>
@@ -412,7 +412,8 @@ class MetadataHeader(ParseSource):
             contents += row
         filename = os.path.join(outdir, self.title + '.html')
         with open(filename,"w") as f:
-            f.writelines(self.__html_template__.format(header=header, contents=contents))
+            f.writelines(self.__html_template__.format(title=self.title + ' argument table',
+                                                       header=header, contents=contents))
         return filename
 
     def get_var(self, standard_name=None, intent=None):

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -91,6 +91,7 @@ Notes on the input format:
 
 # Python library imports
 from __future__ import print_function
+import os
 import re
 # CCPP framework imports
 from metavar     import Var, VarDictionary
@@ -385,7 +386,7 @@ class MetadataHeader(ParseSource):
         "Return an ordered list of the header's variables"
         return self._variables.variable_list()
 
-    def to_html(self, props):
+    def to_html(self, outdir, props):
         """Write html file for metadata table and return filename.
         Skip metadata headers without variables"""
         if not self._variables.variable_list():
@@ -403,13 +404,13 @@ class MetadataHeader(ParseSource):
                 value = var.get_prop_value(prop)
                 # Pretty-print for dimensions
                 if prop == 'dimensions':
-                    value = '(' + ','.join(value) + ')'
+                    value = '(' + ', '.join(value) + ')'
                 elif value is None:
                     value = "n/a"
                 row += "<td>{}</td>".format(value)
             row += "</tr>\n"
             contents += row
-        filename = self.title + '.html'
+        filename = os.path.join(outdir, self.title + '.html')
         with open(filename,"w") as f:
             f.writelines(self.__html_template__.format(header=header, contents=contents))
         return filename

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -372,6 +372,42 @@ class MetadataHeader(ParseSource):
         "Return an ordered list of the header's variables"
         return self._variables.variable_list()
 
+# DH*
+    def to_html(self, filename, props):
+        HTML = """
+<html>
+<head>
+<title>My First HTML</title>
+<meta charset="UTF-8">
+</head>
+<body>
+<table>
+{header}{contents}</table>
+</body>
+</html>
+"""
+        # Write table header
+        header = "<tr>"
+        for prop in props:
+            header += "<th>{}</th>".format(prop)
+        header += "</tr>\n"
+        # Write table contents, one row per variable
+        contents = ""
+        for var in self._variables.variable_list():
+            row = "<tr>"
+            for prop in props:
+                value = var.get_prop_value(prop)
+                if value is None:
+                    value = "n/a"
+                row += "<td>{}</td>".format(value)
+            row += "</tr>\n"
+            contents += row
+        with open(filename,"w") as f:
+            f.writelines(HTML.format(header=header, contents=contents))
+        print(filename)
+        raise Exception
+# *DH
+
     def get_var(self, standard_name=None, intent=None):
         if standard_name is not None:
             var = self._variables.find_variable(standard_name)

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -381,8 +381,6 @@ class Var(object):
                                      default_fn_in=default_kind_val),
                     VariableProperty('state_variable', bool,
                                      optional_in=True, default_in=False),
-                    VariableProperty('optional', bool,
-                                     optional_in=True, default_in=False),
                     VariableProperty('constant', bool,
                                      optional_in=True, default_in=False),
                     VariableProperty('allocatable', bool,
@@ -392,7 +390,9 @@ class Var(object):
                                      default_in='timestep')]
 
     # __var_props contains properties which are not in __spec_props
-    __var_props = [VariableProperty('intent', str,
+    __var_props = [VariableProperty('optional', bool,
+                                     optional_in=True, default_in=False),
+                   VariableProperty('intent', str,
                                     valid_values_in=['in', 'out', 'inout'])]
 
 
@@ -708,11 +708,13 @@ class Var(object):
         type          = {type} *
         dimensions    = {dimensions} *
         kind          = {kind} *
-        intent        = {intent}
-        optional      = {optional}
-        '''
+'''
+        if 'intent' in self.__spec_propdict.keys():
+            str += '        intent        = {intent}\n'
+        if 'optional' in self.__spec_propdict.keys():
+            str += '        optional      = {optional}\n'
         if self._context is not None:
-            str = str + '\n        context       = {}'.format(self._context)
+            str += '        context       = {}'.format(self._context)
         # End if
         return str.format(**self._prop_dict)
 


### PR DESCRIPTION
Associated PRs:

https://github.com/NCAR/NEMSfv3gfs/pull/212
https://github.com/NCAR/ccpp-physics/pull/293
https://github.com/NCAR/FV3/pull/184
https://github.com/NCAR/ccpp-framework/pull/208
https://github.com/NCAR/NEMS/pull/1

For regression testing, see https://github.com/NCAR/NEMSfv3gfs/pull/212.

Changes in ccpp-framework:

- first version of metadata to html converter, making use of the existing `metadata_header` class and extending it with a `to_html` class function
- `scripts/convert_metadata*.py`: skip adding `\htmlinclude` statements for blank metadata tables