### PR TITLE
Convert all schemes to new metadata, new unit conversion micrometer<->meter, merge gsd/develop

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -9,6 +9,8 @@ import sys
 CCPP_ERROR_FLAG_VARIABLE = 'ccpp_error_flag'
 CCPP_ERROR_MSG_VARIABLE  = 'ccpp_error_message'
 CCPP_LOOP_COUNTER        = 'ccpp_loop_counter'
+CCPP_BLOCK_NUMBER        = 'ccpp_block_number'
+CCPP_THREAD_NUMBER       = 'ccpp_thread_number'
 
 CCPP_TYPE = 'ccpp_t'
 
@@ -16,6 +18,8 @@ CCPP_INTERNAL_VARIABLES = {
     CCPP_ERROR_FLAG_VARIABLE : 'cdata%errflg',
     CCPP_ERROR_MSG_VARIABLE  : 'cdata%errmsg',
     CCPP_LOOP_COUNTER        : 'cdata%loop_cnt',
+    CCPP_BLOCK_NUMBER        : 'cdata%blk_no',
+    CCPP_THREAD_NUMBER       : 'cdata%thrd_no',
     }
 
 STANDARD_VARIABLE_TYPES = [ 'character', 'integer', 'logical', 'real' ]

--- a/scripts/conversion_tools/unit_conversion.py
+++ b/scripts/conversion_tools/unit_conversion.py
@@ -23,6 +23,14 @@ def m__to__mm():
     """Convert meter to millimeter"""
     return '1.0E+3{kind}*{var}'
 
+def um__to__m():
+    """Convert micrometer to meter"""
+    return '1.0E-6{kind}*{var}'
+
+def m__to__um():
+    """Convert meter to micrometer"""
+    return '1.0E+6{kind}*{var}'
+
 def m__to__km():
     """Convert meter to kilometer"""
     return '1.0E-3{kind}*{var}'

--- a/scripts/convert_metadata_schemes_using_typedef_dims.py
+++ b/scripts/convert_metadata_schemes_using_typedef_dims.py
@@ -45,6 +45,7 @@ def parse_metadata_tables_typedefs(model):
         'ccpp_loop_counter'  : [],
         'ccpp_block_number'  : [],
         'ccpp_thread_number' : [],
+        'ccpp_t'             : [],
         }
     for filename in METADATA_TYPEDEFS[model]:
         metadata_headers = MetadataHeader.parse_metadata_file(filename)
@@ -54,6 +55,21 @@ def parse_metadata_tables_typedefs(model):
                 if standard_name in dimensions.keys():
                     raise ValueError("Duplicate standard name {} in type/variable definition metadata tables".format(standard_name))
                 dimensions[standard_name] = var.get_prop_value('dimensions')
+    #
+    # Add missing variables (not used by FV3)
+    dimensions['lw_heating_rate_spectral'] = [ 'horizontal_dimension', 'adjusted_vertical_layer_dimension_for_radiation', 'number_of_aerosol_bands_for_longwave_radiation' ]
+    dimensions['lw_fluxes'] = ['horizontal_dimension', 'adjusted_vertical_level_dimension_for_radiation']
+    dimensions['cloud_optical_depth'] = [ 'horizontal_dimension', 'adjusted_vertical_layer_dimension_for_radiation' ]
+    #
+    dimensions['sw_heating_rate_spectral'] = [ 'horizontal_dimension', 'adjusted_vertical_layer_dimension_for_radiation', 'number_of_aerosol_bands_for_shortwave_radiation' ]
+    dimensions['sw_fluxes'] = ['horizontal_dimension', 'adjusted_vertical_level_dimension_for_radiation']
+    dimensions['cloud_single_scattering_albedo'] = [ 'horizontal_dimension', 'adjusted_vertical_layer_dimension_for_radiation' ]
+    dimensions['cloud_asymmetry_parameter'] = [ 'horizontal_dimension', 'adjusted_vertical_layer_dimension_for_radiation' ]
+    #
+    dimensions['specified_kinematic_surface_upward_sensible_heat_flux'] = [ 'horizontal_dimension' ]
+    dimensions['specified_kinematic_surface_upward_latent_heat_flux'] = [ 'horizontal_dimension' ]
+    dimensions['vonKarman_constant'] = []
+    #
     return dimensions
 
 ########################################################################

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -368,6 +368,10 @@ def parse_variable_tables(filename):
                     except ValueError:
                         raise Exception('Mandatory column standard_name not found in argument table {0}'.format(table_name))
                     line_counter += 1
+                    # DH* warn or raise error for old metadata format
+                    logging.warn("Old metadata table found for table {}".format(table_name))
+                    #raise Exception("Old metadata table found for table {}".format(table_name))
+                    # *DH
                     continue
                 elif current_line_number == header_line_number + 1 and not new_metadata:
                     # Skip over separator line
@@ -699,6 +703,10 @@ def parse_scheme_tables(filename):
                         standard_name_index = table_header.index('standard_name')
                     except ValueError:
                         raise Exception('Mandatory column standard_name not found in argument table {0}'.format(table_name))
+                    # DH* warn or raise error for old metadata format
+                    logging.warn("Old metadata table found for table {}".format(table_name))
+                    #raise Exception("Old metadata table found for table {}".format(table_name))
+                    # *DH
                     # Get all of the variable information in table
                     end_of_table = False
                     line_number = header_line_number + 2

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -455,29 +455,7 @@ def parse_variable_tables(filename):
                                 vars_in_type.append(var_name)
                     logging.debug('Variables in derived type {0}: {1}'.format(type_name, ', '.join(vars_in_type)))
 
-        if debug and len(metadata.keys()) > 0:
-            # Write out the XML for debugging purposes
-            top = ET.Element('definition')
-            top.set('module', module_name)
-            container = encode_container(module_name)
-            for var_name in metadata.keys():
-                for var in metadata[var_name]:
-                    if var.container == container:
-                        sub_var = var.to_xml(ET.SubElement(top, 'variable'))
-            for type_name in registry[module_name].keys():
-                container = encode_container(module_name, type_name)
-                sub_type = ET.SubElement(top, 'type')
-                sub_type.set('type_name', type_name)
-                for var_name in metadata.keys():
-                    for var in metadata[var_name]:
-                        if var.container == container:
-                            sub_var = var.to_xml(ET.SubElement(sub_type, 'variable'))
-            indent(top)
-            tree = ET.ElementTree(top)
-            xmlfile = module_name + '.xml'
-            tree.write(xmlfile, xml_declaration=True, encoding='utf-8', method="xml")
-            logging.info('Parsed variable definition tables in module {0}; output => {1}'.format(module_name, xmlfile))
-        elif len(metadata.keys()) > 0:
+        if len(metadata.keys()) > 0:
             logging.info('Parsed variable definition tables in module {0}'.format(module_name))
 
     return metadata
@@ -804,24 +782,6 @@ def parse_scheme_tables(filename):
                             if var.container == container:
                                 vars_in_subroutine.append(var_name)
                     logging.debug('Variables in subroutine {0}: {1}'.format(subroutine_name, ', '.join(vars_in_subroutine)))
-            # To XML
-            for scheme_name in registry[module_name].keys():
-                top = ET.Element('scheme')
-                top.set('module', scheme_name)
-                for subroutine_name in registry[module_name][scheme_name].keys():
-                    sub_sub = ET.SubElement(top, 'subroutine')
-                    sub_sub.set('name', subroutine_name)
-                    container = encode_container(module_name, scheme_name, subroutine_name)
-                    # Variable output in order of calling arguments
-                    for var_name in arguments[module_name][scheme_name][subroutine_name]:
-                        for var in metadata[var_name]:
-                            if var.container == container:
-                                sub_var = var.to_xml(ET.SubElement(sub_sub, 'variable'))
-                indent(top)
-                tree = ET.ElementTree(top)
-                xmlfile = scheme_name + '.xml'
-                tree.write(xmlfile, xml_declaration=True, encoding='utf-8', method="xml")
-                logging.info('Parsed tables in scheme {0}; output => {1}'.format(scheme_name, xmlfile))
         # Standard output to screen
         elif len(metadata.keys()) > 0:
             for scheme_name in registry[module_name].keys():

--- a/src/ccpp_types.F90
+++ b/src/ccpp_types.F90
@@ -20,9 +20,7 @@
 module ccpp_types
 
 !! \section arg_table_ccpp_types
-!! | local_name                        | standard_name             | long_name                                             | units   | rank | type      |   kind   | intent | optional |
-!! |-----------------------------------|-------------------------- |-------------------------------------------------------|---------|------|-----------|----------|--------|----------|
-!! | ccpp_t                            | ccpp_t                    | definition of type ccpp_t                             | DDT     |    0 | ccpp_t    |          | none   | F        |
+!! \htmlinclude ccpp_types.html
 !!
 
     use, intrinsic :: iso_c_binding,                                   &
@@ -151,13 +149,7 @@ module ccpp_types
 
 #if 0
 !! \section arg_table_ccpp_t
-!! | local_name                        | standard_name             | long_name                                             | units   | rank | type      |   kind   | intent | optional |
-!! |-----------------------------------|-------------------------- |-------------------------------------------------------|---------|------|-----------|----------|--------|----------|
-!! | cdata%errflg                      | ccpp_error_flag           | error flag for error handling in CCPP                 | flag    |    0 | integer   |          | none   | F        |
-!! | cdata%errmsg                      | ccpp_error_message        | error message for error handling in CCPP              | none    |    0 | character | len=512  | none   | F        |
-!! | cdata%loop_cnt                    | ccpp_loop_counter         | loop counter for subcycling loops in CCPP             | index   |    0 | integer   |          | none   | F        |
-!! | cdata%blk_no                      | ccpp_block_number         | number of block for explicit data blocking in CCPP    | index   |    0 | integer   |          | none   | F        |
-!! | cdata%thrd_no                     | ccpp_thread_number        | number of thread for threading in CCPP                | index   |    0 | integer   |          | none   | F        |
+!! \htmlinclude ccpp_t.html
 !!
 #endif
     !>

--- a/src/ccpp_types.meta
+++ b/src/ccpp_types.meta
@@ -1,0 +1,45 @@
+[ccpp-arg-table]
+  name = ccpp_types
+  type = module
+[ccpp_t]
+  standard_name = ccpp_t
+  long_name = definition of type ccpp_t
+  units = DDT
+  dimensions = ()
+  type = ccpp_t
+
+########################################################################
+[ccpp-arg-table]
+  name = ccpp_t
+  type = scheme
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+[loop_cnt]
+  standard_name = ccpp_loop_counter
+  long_name = loop counter for subcycling loops in CCPP
+  units = index
+  dimensions = ()
+  type = integer
+[blk_no]
+  standard_name = ccpp_block_number
+  long_name = number of block for explicit data blocking in CCPP
+  units = index
+  dimensions = ()
+  type = integer
+[thrd_no]
+  standard_name = ccpp_thread_number
+  long_name = number of thread for threading in CCPP
+  units = index
+  dimensions = ()
+  type = integer


### PR DESCRIPTION
- convert `src/ccpp_types.F90` to new metadata format (`scripts/common.py`: register missing CCPP internal variables)
- `scripts/conversion_tools/unit_conversion.py`: register unit conversion from micrometer to meter and vice versa
- `scripts/convert_metadata_schemes_using_typedef_dims.py`: add missing variables to GFS_typedefs-based dimensions dictionary that are not used by FV3
- `scripts/metadata_parser.py`: warn or raise exception (currently warn) if old metadata is found