### PR TITLE
gmtb/develop: remove TRANSITION mode

### DIFF
--- a/doc/CCPPtechnical/source/BuildingRunningHostModels.rst
+++ b/doc/CCPPtechnical/source/BuildingRunningHostModels.rst
@@ -305,7 +305,6 @@ The ``MAKEOPTS`` string, enclosed in single or double quotes, allows to specify 
 * **32BIT=Y** - compiles FV3 dynamical core in single precision; note that physics are always compiled in double precision; this option is only available on *Theia, Cheyenne*, and *Jet* (default is ``N``)
 * **REPRO=Y** - compiles code in :term:`REPRO` mode, i.e. removes certain compiler optimization flags used in the default :term:`PROD` mode to obtain bit-for-bit (b4b) identical results between CCPP and non-CCPP code (default is ``N``)
 * **DEBUG=Y** - compiles code in DEBUG mode, i.e. removes all optimization of :term:`PROD` mode and add bound checks; mutually exclusive with ``REPRO=Y`` (default is ``N``)
-* **TRANSITION=Y** - applies selective lowering of optimization for selected files to obtain b4b with non-CCPP code in PROD mode (only when using Intel 15 on *Theia*)
 
 Examples:
 


### PR DESCRIPTION
Remove documentation for TRANSITION mode from tech doc.

This change is tested together with https://github.com/NCAR/NEMSfv3gfs/pull/251 and other PRs listed below.