### PR TITLE
Update master from gmtb/develop 2019/10/16

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -3,6 +3,7 @@
 # Standard modules
 import argparse
 import collections
+import importlib
 import itertools
 import logging
 import os
@@ -62,10 +63,10 @@ def import_config(configfile):
 
     # Import the host-model specific CCPP prebuild config;
     # split into path and module name for import
-    configpath = os.path.abspath(os.path.split(configfile)[0])
-    configmodule = os.path.split(configfile)[1].rstrip('.py')
+    configpath = os.path.abspath(os.path.dirname(configfile))
+    configmodule = os.path.splitext(os.path.basename(configfile))[0]
     sys.path.append(configpath)
-    ccpp_prebuild_config = __import__(configmodule)
+    ccpp_prebuild_config = importlib.import_module(configmodule)
 
     # Definitions in host-model dependent CCPP prebuild config script
     config['variable_definition_files'] = ccpp_prebuild_config.VARIABLE_DEFINITION_FILES

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -9,9 +9,9 @@ import os
 import re
 import sys
 
-# Local modules
+# CCPP framework imports
 from common import encode_container, decode_container, decode_container_as_dict, execute
-from common import CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE
+from common import CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE, CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
 from common import split_var_name_and_array_reference
 from metadata_parser import merge_dictionaries, parse_scheme_tables, parse_variable_tables
 from mkcap import Cap, CapsMakefile, CapsCMakefile, SchemesMakefile, SchemesCMakefile
@@ -31,15 +31,6 @@ parser.add_argument('--suites',     action='store', help='suite definition files
 
 # BASEDIR is the current directory where this script is executed
 BASEDIR = os.getcwd()
-
-# SCRIPTDIR is the directory where the ccpp_prebuild.py and its Python modules are located
-SCRIPTDIR = os.path.abspath(os.path.split(__file__)[0])
-
-# SRCDIR is the directory where the CCPP framework source code (C, Fortran) is located
-SRCDIR = os.path.abspath(os.path.join(SCRIPTDIR, '..', 'src'))
-
-# Definition of variables (metadata tables) that are provided by CCPP
-CCPP_INTERNAL_VARIABLE_DEFINITON_FILE = os.path.join(SRCDIR, 'ccpp_types.F90')
 
 ###############################################################################
 # Functions and subroutines                                                   #
@@ -99,7 +90,7 @@ def import_config(configfile):
     # Template code in host-model dependent CCPP prebuild config script
     config['ccpp_data_structure']            = ccpp_prebuild_config.CCPP_DATA_STRUCTURE
 
-    # Add model-intependent, CCPP-internal variable definition files
+    # Add model-independent, CCPP-internal variable definition files
     config['variable_definition_files'].append(CCPP_INTERNAL_VARIABLE_DEFINITON_FILE)
 
     # To handle new metadata: import DDT references (if exist)

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -641,8 +641,8 @@ def generate_schemes_makefile(schemes, schemes_makefile, schemes_cmakefile, sche
         relative_path = './{0}'.format(os.path.relpath(scheme_filepath, schemes_makefile_dir))
         schemes_with_path.append(os.path.join(relative_path, scheme_filename))
         schemes_with_abspath.append(os.path.abspath(scheme))
-    makefile.write(schemes_with_path)
-    cmakefile.write(schemes_with_path)
+    makefile.write(schemes_with_abspath)
+    cmakefile.write(schemes_with_abspath)
     sourcefile.write(schemes_with_abspath)
     logging.info('Added {0} schemes to {1}, {2}, {3}'.format(
            len(schemes_with_path), makefile.filename, cmakefile.filename, sourcefile.filename))
@@ -663,8 +663,8 @@ def generate_caps_makefile(caps, caps_makefile, caps_cmakefile, caps_sourcefile,
     relative_path = './{0}'.format(os.path.relpath(caps_dir, caps_makefile_dir))
     caps_with_path = [ os.path.join(relative_path, cap) for cap in caps]
     caps_with_abspath = [ os.path.abspath(os.path.join(caps_dir, cap)) for cap in caps]
-    makefile.write(caps_with_path)
-    cmakefile.write(caps_with_path)
+    makefile.write(caps_with_abspath)
+    cmakefile.write(caps_with_abspath)
     sourcefile.write(caps_with_abspath)
     logging.info('Added {0} auto-generated caps to {1} and {2}'.format(
                           len(caps_with_path), makefile.filename, cmakefile.filename))

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -2,6 +2,7 @@
 
 import keyword
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -14,6 +15,16 @@ CCPP_THREAD_NUMBER       = 'ccpp_thread_number'
 
 CCPP_TYPE = 'ccpp_t'
 
+# SCRIPTDIR is the directory where ccpp_prebuild.py and its Python modules are located
+SCRIPTDIR = os.path.abspath(os.path.split(__file__)[0])
+
+# SRCDIR is the directory where the CCPP framework source code (C, Fortran) is located
+SRCDIR = os.path.abspath(os.path.join(SCRIPTDIR, '..', 'src'))
+
+# Definition of variables (metadata tables) that are provided by CCPP
+CCPP_INTERNAL_VARIABLE_DEFINITON_FILE = os.path.join(SRCDIR, 'ccpp_types.F90')
+
+# List of internal variables provided by the CCPP
 CCPP_INTERNAL_VARIABLES = {
     CCPP_ERROR_FLAG_VARIABLE : 'cdata%errflg',
     CCPP_ERROR_MSG_VARIABLE  : 'cdata%errmsg',

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -16,10 +16,10 @@ CCPP_THREAD_NUMBER       = 'ccpp_thread_number'
 CCPP_TYPE = 'ccpp_t'
 
 # SCRIPTDIR is the directory where ccpp_prebuild.py and its Python modules are located
-SCRIPTDIR = os.path.abspath(os.path.split(__file__)[0])
+SCRIPTDIR = os.path.abspath(os.path.dirname(__file__))
 
 # SRCDIR is the directory where the CCPP framework source code (C, Fortran) is located
-SRCDIR = os.path.abspath(os.path.join(SCRIPTDIR, '..', 'src'))
+SRCDIR = os.path.abspath(os.path.join(SCRIPTDIR, os.pardir, 'src'))
 
 # Definition of variables (metadata tables) that are provided by CCPP
 CCPP_INTERNAL_VARIABLE_DEFINITON_FILE = os.path.join(SRCDIR, 'ccpp_types.F90')

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import importlib
 import os
 import sys
 
@@ -48,10 +49,10 @@ def import_config(configfile, logger):
 
     # Import the host-model specific CCPP prebuild config;
     # split into path and module name for import
-    configpath = os.path.abspath(os.path.split(configfile)[0])
-    configmodule = os.path.split(configfile)[1].rstrip('.py')
+    configpath = os.path.abspath(os.path.dirname(configfile))
+    configmodule = os.path.splitext(os.path.basename(configfile))[0]
     sys.path.append(configpath)
-    ccpp_prebuild_config = __import__(configmodule)
+    ccpp_prebuild_config = importlib.import_module(configmodule)
 
     config = {}
     # Definitions in host-model dependent CCPP prebuild config script

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -6,26 +6,84 @@ import os
 import sys
 
 # CCPP framework imports
+from common import CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
 from parse_tools import init_log, set_log_level
 from metadata_table import MetadataHeader
 
+###############################################################################
+# Set up the command line argument parser and other global variables          #
+###############################################################################
+
 parser = argparse.ArgumentParser()
-parser.add_argument('--metafile', '-m', action='store',
-                    help='name of metadata file to convert',
-                    required=True)
+method = parser.add_mutually_exclusive_group(required=True)
+method.add_argument('--config', '-c', action='store',
+                    help='path to CCPP prebuild configuration file')
+method.add_argument('--metafile', '-m', action='store',
+                    help='name of metadata file to convert (requires -o)')
 parser.add_argument('--outputdir', '-o', action='store',
                     help='directory where to write the html files',
-                    required=True)
+                    required='--metafile' in sys.argv or '-m' in sys.argv)
 
-attributes = [ 'local_name', 'standard_name', 'long_name', 'units',
+# List and order of variable attributes to output to HTML
+ATTRIBUTES = [ 'local_name', 'standard_name', 'long_name', 'units',
                'type', 'dimensions', 'kind', 'intent', 'optional' ]
+
+###############################################################################
+# Functions and subroutines                                                   #
+###############################################################################
 
 def parse_arguments():
     """Parse command line arguments."""
     args = parser.parse_args()
+    config = args.config
     filename = args.metafile
     outdir = args.outputdir
-    return (filename, outdir)
+    return (config, filename, outdir)
+
+def import_config(configfile, logger):
+    """Import the configuration from a given configuration file"""
+
+    if not os.path.isfile(configfile):
+        raise Exception("Configuration file {0} not found".format(configfile))
+
+    # Import the host-model specific CCPP prebuild config;
+    # split into path and module name for import
+    configpath = os.path.abspath(os.path.split(configfile)[0])
+    configmodule = os.path.split(configfile)[1].rstrip('.py')
+    sys.path.append(configpath)
+    ccpp_prebuild_config = __import__(configmodule)
+
+    config = {}
+    # Definitions in host-model dependent CCPP prebuild config script
+    config['variable_definition_files'] = ccpp_prebuild_config.VARIABLE_DEFINITION_FILES
+    config['scheme_files']              = ccpp_prebuild_config.SCHEME_FILES
+    # Add model-independent, CCPP-internal variable definition files
+    config['variable_definition_files'].append(CCPP_INTERNAL_VARIABLE_DEFINITON_FILE)
+    # Output directory for converted metadata tables
+    config['metadata_html_output_dir'] = ccpp_prebuild_config.METADATA_HTML_OUTPUT_DIR
+
+    return config
+
+def get_metadata_files_from_config(config, logger):
+    """Create a list of metadata filenames for a CCPP prebuild configuration"""
+    filenames = []
+    for sourcefile in config['variable_definition_files'] + config['scheme_files'].keys():
+        metafile = os.path.splitext(sourcefile)[0]+'.meta'
+        if os.path.isfile(metafile):
+            filenames.append(metafile)
+        else:
+            # DH* Warn for now, raise exception later when
+            # old metadata format is no longer supported
+            logger.warn("Metadata file {} for source file {} not found, assuming old metadata format".format(
+                                                                                       metafile, sourcefile))
+    return filenames
+
+def get_output_directory_from_config(config, logger):
+    """Return the html output directory for a CCPP prebuild configuration"""
+    outdir = config['metadata_html_output_dir']
+    if not os.path.isdir(outdir):
+        raise Exception("Output directory {} for converted metadata tables does not exist".format(outdir))
+    return outdir
 
 def convert_to_html(filename_in, outdir, logger):
     """Convert a metadata file into html (one html file for each table)"""
@@ -34,7 +92,7 @@ def convert_to_html(filename_in, outdir, logger):
     logger.info("Converting file {} to HTML".format(filename_in))
     metadata_headers = MetadataHeader.parse_metadata_file(filename_in)
     for metadata_header in metadata_headers:
-        filename_out = metadata_header.to_html(outdir, attributes)
+        filename_out = metadata_header.to_html(outdir, ATTRIBUTES)
         if filename_out:
             logger.info("  ... wrote {}".format(filename_out))
 
@@ -43,8 +101,15 @@ def main():
     logger = init_log('metadata2html')
     set_log_level(logger, logging.INFO)
     # Convert metadata file
-    (filename, outdir) = parse_arguments()
-    convert_to_html(filename, outdir, logger)
+    (configfile, filename, outdir) = parse_arguments()
+    if configfile:
+        config = import_config(configfile, logger)
+        filenames = get_metadata_files_from_config(config, logger)
+        outdir = get_output_directory_from_config(config, logger)
+        for filename in filenames:
+            convert_to_html(filename, outdir, logger)
+    else:
+        convert_to_html(filename, outdir, logger)
 
 if __name__ == '__main__':
     main()

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -369,12 +369,7 @@ class Var(object):
                     VariableProperty('dimensions', list,
                                      check_fn_in=check_dimensions),
                     VariableProperty('type', str,
-                                     # DH* Avoid checking of DDTs being registered or not,
-                                     # this only works if all DDTs required in one metadata
-                                     # are defined in that file and/or parsed beforehand.
-                                     #check_fn_in=check_fortran_type),
-                                     # *DH
-                                     ),
+                                     check_fn_in=check_fortran_type),
                     VariableProperty('kind', str,
                                      optional_in=True,
                                      default_fn_in=default_kind_val),

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -508,6 +508,9 @@ module {module}_cap
 
     def write(self, module, data, ccpp_field_map, metadata_define):
         if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if filepath and not os.path.isdir(filepath):
+                os.makedirs(filepath)
             f = open(self.filename, 'w')
         else:
             f = sys.stdout
@@ -702,6 +705,51 @@ set(CAPS
     def filename(self, value):
         self._filename = value
 
+class CapsSourcefile(object):
+
+    header='''
+# All CCPP schemes are defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+export CCPP_CAPS="'''
+    footer='''"
+'''
+
+    def __init__(self, **kwargs):
+        self._filename = 'sys.stdout'
+        for key, value in kwargs.items():
+            setattr(self, "_"+key, value)
+
+    def write(self, schemes):
+        if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if not os.path.isdir(filepath):
+                os.makedirs(filepath)
+            f = open(self.filename, 'w')
+        else:
+            f = sys.stdout
+
+        contents = self.header
+        for scheme in schemes:
+            contents += '{0};'.format(scheme)
+        contents = contents.rstrip(';')
+        contents += self.footer
+        f.write(contents)
+
+        if (f is not sys.stdout):
+            f.close()
+
+    @property
+    def filename(self):
+        '''Get the filename of write the output to.'''
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
 class SchemesMakefile(object):
 
     header='''
@@ -725,6 +773,9 @@ SCHEMES_f90 ='''
 
     def write(self, schemes):
         if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if filepath and not os.path.isdir(filepath):
+                os.makedirs(filepath)
             f = open(self.filename, 'w')
         else:
             f = sys.stdout
@@ -781,6 +832,9 @@ set(SCHEMES
 
     def write(self, schemes):
         if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if not os.path.isdir(filepath):
+                os.makedirs(filepath)
             f = open(self.filename, 'w')
         else:
             f = sys.stdout
@@ -788,6 +842,51 @@ set(SCHEMES
         contents = self.header
         for scheme in schemes:
             contents += '      {0}\n'.format(scheme)
+        contents += self.footer
+        f.write(contents)
+
+        if (f is not sys.stdout):
+            f.close()
+
+    @property
+    def filename(self):
+        '''Get the filename of write the output to.'''
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+class SchemesSourcefile(object):
+
+    header='''
+# All CCPP schemes are defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+export CCPP_SCHEMES="'''
+    footer='''"
+'''
+
+    def __init__(self, **kwargs):
+        self._filename = 'sys.stdout'
+        for key, value in kwargs.items():
+            setattr(self, "_"+key, value)
+
+    def write(self, schemes):
+        if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if not os.path.isdir(filepath):
+                os.makedirs(filepath)
+            f = open(self.filename, 'w')
+        else:
+            f = sys.stdout
+
+        contents = self.header
+        for scheme in schemes:
+            contents += '{0};'.format(scheme)
+        contents = contents.rstrip(';')
         contents += self.footer
         f.write(contents)
 

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -8,6 +8,7 @@
 # and use this for ccpp_prebuild.py; create to_html and to_latex routines for it
 
 import logging
+import os
 
 from common import decode_container, escape_tex
 
@@ -65,6 +66,9 @@ def metadata_to_html(metadata, model, filename):
 </html>
 '''
 
+    filepath = os.path.split(os.path.abspath(filename))[0]
+    if not os.path.isdir(filepath):
+        os.makedirs(filepath)
     with open(filename, 'w') as f:
         f.write(html)
 
@@ -167,6 +171,9 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
 \\end{document}
 '''
 
+    filepath = os.path.split(os.path.abspath(filename))[0]
+    if not os.path.isdir(filepath):
+        os.makedirs(filepath)
     with open(filename, 'w') as f:
         f.write(latex)
 

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -202,6 +202,7 @@ end module {module}
         self._module      = CCPP_STATIC_API_MODULE
         self._subroutines = None
         self._suites      = []
+        self._directory   = '.'
         for key, value in kwargs.items():
             setattr(self, "_"+key, value)
 
@@ -213,6 +214,15 @@ end module {module}
     @filename.setter
     def filename(self, value):
         self._filename = value
+
+    @property
+    def directory(self):
+        '''Get the directory to write API to.'''
+        return self._directory
+
+    @directory.setter
+    def directory(self, value):
+        self._directory = value
 
     @property
     def module(self):
@@ -328,8 +338,11 @@ end module {module}
                                    suite_switch=suite_switch)
 
         # Write output to stdout or file
-        if (self._filename is not sys.stdout):
-            f = open(self._filename, 'w')
+        if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if filepath and not os.path.isdir(filepath):
+                os.makedirs(filepath)
+            f = open(self.filename, 'w')
         else:
             f = sys.stdout
         f.write(API.header.format(module=self._module,
@@ -341,6 +354,22 @@ end module {module}
             f.close()
         return
 
+    def write_sourcefile(self, source_filename):
+        success = True
+        filepath = os.path.split(source_filename)[0]
+        if filepath and not os.path.isdir(filepath):
+            os.makedirs(filepath)
+        f = open(source_filename, 'w')
+        contents = """# The CCPP static API is defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+export CCPP_STATIC_API=\"{filename}\"
+""".format(filename=os.path.abspath(os.path.join(self.directory,self.filename)))
+        f.write(contents)
+        f.close()
+        return success
 
 class Suite(object):
 

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -354,13 +354,15 @@ def check_fortran_type(typestr, error=False):
         match = registered_fortran_ddt_name(typestr)
         dt = " derived"
     # End if
-    if match is None:
-        if error:
-            raise CCPPError("'{}' is not a valid{} Fortran type".format(typestr, dt))
-        else:
-            typestr = None
-        # End if
-    # End if
+    # DH* 20190913 - skip checking if a DDT is registered at this time
+    #if match is None:
+    #    if error:
+    #        raise CCPPError("'{}' is not a valid{} Fortran type".format(typestr, dt))
+    #    else:
+    #        typestr = None
+    #    # End if
+    ## End if
+    # *DH 20190913
     return typestr
 
 ########################################################################


### PR DESCRIPTION
Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/230
https://github.com/NCAR/ccpp-physics/pull/340
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/5
https://github.com/NOAA-EMC/fv3atm/pull/1
https://github.com/ufs-community/ufs-weather-model/pull/1
https://github.com/NOAA-EMC/NEMS/pull/11 (merged)
https://github.com/NOAA-EMC/NEMS/pull/12

See https://github.com/ufs-community/ufs-weather-model/pull/1 for a description and regression testing information.

This PR for ccpp-framework merges the previously approved changes made for the gmtb/develop branch into the master branch.

Changes specific to ccpp-framework:
- cleanup of prebuild scripts (move common code into common.py module, ...)
- add capability to create html pages from metadata files for all schemes in a CCPP configuration file (required for generating scientific documentation)
- add out-of-source build capability to CCPP prebuild scripts (optional argument --builddir for ccpp_prebuild.py, write out list of schemes and caps to a shell script that can be sourced and sets environment variables)