### PR TITLE
Feature/capgen Add unit test for capgen parse_metadata_file

### DIFF
--- a/test/unit_tests/README.md
+++ b/test/unit_tests/README.md
@@ -1,0 +1,32 @@
+# How to build the test/capgen_test (on hera)
+
+## Quick start:
+```
+cd test/capgen_test
+mkdir build
+cd build
+cmake ..
+make
+./test_host
+```
+
+The command to run ccpp_capgen.py is:
+
+`/scratch1/BMC/gmtb/Julie.Schramm/NEMSfv3gfs/ccpp/framework/scripts/ccpp_capgen.py \
+   --host-files test_host_data.meta,test_host_mod.meta,test_host.meta \
+   --scheme-files temp_scheme_files.txt,ddt_suite_files.txt \
+   --suites ddt_suite.xml,temp_suite.xml\
+   --output-root /scratch1/BMC/gmtb/Julie.Schramm/NEMSfv3gfs/ccpp/framework/test/capgen_test/build/ccpp\
+   --generate-host-cap`
+
+Modify a *meta* file in `capgen_test` and write a test that passes when fixed.
+
+To run the unit tests:
+```
+cd /scratch1/BMC/gmtb/Julie.Schramm/ccpp-framework-fork/test/unit_tests
+python  test_metadata_table.py
+```
+For more verbose output:
+```
+python  test_metadata_table.py -v 
+```

--- a/test/unit_tests/README.md
+++ b/test/unit_tests/README.md
@@ -30,3 +30,8 @@ For more verbose output:
 ```
 python  test_metadata_table.py -v 
 ```
+If you have `coverage` installed, to get test coverage:
+```
+coverage run test_metadata_table.py
+coverage report -m
+```

--- a/test/unit_tests/README.md
+++ b/test/unit_tests/README.md
@@ -12,18 +12,20 @@ make
 
 The command to run ccpp_capgen.py is:
 
-`/scratch1/BMC/gmtb/Julie.Schramm/NEMSfv3gfs/ccpp/framework/scripts/ccpp_capgen.py \
+`<root>/scripts/ccpp_capgen.py \
    --host-files test_host_data.meta,test_host_mod.meta,test_host.meta \
    --scheme-files temp_scheme_files.txt,ddt_suite_files.txt \
    --suites ddt_suite.xml,temp_suite.xml\
-   --output-root /scratch1/BMC/gmtb/Julie.Schramm/NEMSfv3gfs/ccpp/framework/test/capgen_test/build/ccpp\
+   --output-root <root>/test/capgen_test/build/ccpp\
    --generate-host-cap`
+
+where `<root>` is the path to your ccpp/framework directory.
 
 Modify a *meta* file in `capgen_test` and write a test that passes when fixed.
 
 To run the unit tests:
 ```
-cd /scratch1/BMC/gmtb/Julie.Schramm/ccpp-framework-fork/test/unit_tests
+cd <root>/test/unit_tests
 python  test_metadata_table.py
 ```
 For more verbose output:

--- a/test/unit_tests/sample_files/double_header.meta
+++ b/test/unit_tests/sample_files/double_header.meta
@@ -1,0 +1,31 @@
+[ccpp-arg-table]
+  name = test_host
+  type = host
+[ccpp-arg-table]
+  name = test_host
+  type = host
+[ col_start ]
+  standard_name = horizontal_loop_begin
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ col_end ]
+  standard_name = horizontal_loop_end
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer

--- a/test/unit_tests/sample_files/test_bad_dimension.meta
+++ b/test/unit_tests/sample_files/test_bad_dimension.meta
@@ -1,0 +1,28 @@
+[ccpp-arg-table]
+  name = test_host
+  type = host
+[ col_start ]
+  standard_name = horizontal_loop_begin
+  type = integer
+  units = count
+  dimensions = banana
+  protected = True
+[ col_end ]
+  standard_name = horizontal_loop_end
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer

--- a/test/unit_tests/sample_files/test_bad_type_name.meta
+++ b/test/unit_tests/sample_files/test_bad_type_name.meta
@@ -1,0 +1,28 @@
+[ccpp-arg-table]
+  name = test_host
+  type = banana
+[ col_start ]
+  standard_name = horizontal_loop_begin
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ col_end ]
+  standard_name = horizontal_loop_end
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer

--- a/test/unit_tests/sample_files/test_duplicate_variable.meta
+++ b/test/unit_tests/sample_files/test_duplicate_variable.meta
@@ -1,0 +1,87 @@
+[ccpp-arg-table]
+  name = temp_calc_adjust_run
+  type = scheme
+[ nbox ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ timestep ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ temp_calc ]
+  standard_name = potential_temperature_at_previous_timestep
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[ temp ]
+  standard_name = index_of_water_vapor_specific_humidity
+  units = index
+  type = integer
+  intent = in
+  dimensions = ()
+[ temp ]
+  standard_name = index_of_water_vapor_specific_humidity
+  units = index
+  type = integer
+  intent = in
+  dimensions = ()
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_files/test_host.meta
+++ b/test/unit_tests/sample_files/test_host.meta
@@ -1,0 +1,28 @@
+[ccpp-arg-table]
+  name = test_host
+  type = host
+[ col_start ]
+  standard_name = horizontal_loop_begin
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ col_end ]
+  standard_name = horizontal_loop_end
+  type = integer
+  units = count
+  dimensions = ()
+  protected = True
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer

--- a/test/unit_tests/sample_files/test_invalid_intent.meta
+++ b/test/unit_tests/sample_files/test_invalid_intent.meta
@@ -1,0 +1,81 @@
+[ccpp-arg-table]
+  name = temp_calc_adjust_run
+  type = scheme
+[ nbox ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ timestep ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = banana
+[ temp_calc ]
+  standard_name = potential_temperature_at_previous_timestep
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[ temp ]
+  standard_name = index_of_water_vapor_specific_humidity
+  units = index
+  type = integer
+  intent = in
+  dimensions = ()
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_files/test_missing_intent.meta
+++ b/test/unit_tests/sample_files/test_missing_intent.meta
@@ -1,0 +1,80 @@
+[ccpp-arg-table]
+  name = temp_calc_adjust_run
+  type = scheme
+[ nbox ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ timestep ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[ temp_calc ]
+  standard_name = potential_temperature_at_previous_timestep
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[ temp ]
+  standard_name = index_of_water_vapor_specific_humidity
+  units = index
+  type = integer
+  intent = in
+  dimensions = ()
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_calc_adjust_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_files/test_multi_ccpp_arg_tables.meta
+++ b/test/unit_tests/sample_files/test_multi_ccpp_arg_tables.meta
@@ -1,0 +1,104 @@
+[ccpp-arg-table]
+  name = vmr_type
+  type = ddt
+[ nvmr ]
+  standard_name = number_of_chemical_species
+  units = count
+  dimensions = ()
+  type = integer
+[ vmr_array ]
+  standard_name = array_of_volume_mixing_ratios
+  units = ppmv
+  dimensions = (horizontal_loop_extent, number_of_chemical_species)
+  type = real
+  kind = kind_phys
+[ccpp-arg-table]
+  name = make_ddt_run
+  type = scheme
+[ nbox ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ O3 ]
+  standard_name = ozone
+  units = ppmv
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[ HNO3 ]
+  standard_name = nitric_acid
+  units = ppmv
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[ vmr ]
+  standard_name = volume_mixing_ratio_ddt
+  dimensions = ()
+  ddt_type = vmr_type
+  intent = inout
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = make_ddt_init
+  type = scheme
+[ nbox ]
+  standard_name = horizontal_dimension
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ vmr ]
+  standard_name = volume_mixing_ratio_ddt
+  dimensions = ()
+  ddt_type = vmr_type
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = make_ddt_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -14,9 +14,9 @@ import os
 import logging
 import unittest
 
-root_dir = os.path.dirname(os.path.abspath(__file__))
-scripts_dir = os.path.join(root_dir, "../../scripts")
-sample_files_dir = os.path.join(root_dir, "sample_files")
+test_dir = os.path.dirname(os.path.abspath(__file__))
+scripts_dir = os.path.abspath(os.path.join(test_dir, os.pardir, os.pardir, "scripts"))
+sample_files_dir = os.path.join(test_dir, "sample_files")
 
 if not os.path.exists(scripts_dir):
     raise ImportError("Cannot find scripts directory")

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -16,7 +16,8 @@ import unittest
 
 unit_test_dir = os.path.dirname(os.path.abspath(__file__))
 scripts_dir = os.path.join(unit_test_dir, "../../scripts")
-print("scripts_dir: " + scripts_dir)
+sample_files_dir =  os.path.join(unit_test_dir, "sample_files")
+
 if not os.path.exists(scripts_dir):
     raise ImportError("Cannot find scripts directory")
 
@@ -27,21 +28,37 @@ from metadata_table import MetadataTable
 '''Test parse_metadata_file in metadata_table.py'''
 
 class MetadataTableTestCase(unittest.TestCase):
+
    """Tests for `parse_metadata_file`."""
 
-   def test_bad_file(self):
-       """I dont know what im doing"""
+   def test_good_host_file(self):
+       """Test that good host file test_host.meta returns one header named test_host"""
        #Setup
-       #known_ddts = None
-       #logger = None
        known_ddts = list()
        logger = None
-       filename="/scratch1/BMC/gmtb/Julie.Schramm/ccpp-framework-fork/test/capgen_test/test_host.meta"
+       filename= sample_files_dir + "/test_host.meta"
        #Exercise
        result = MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+       #Verify that size of returned list equals number of headers in the test file
+       #       and that header name is 'test_host'
+       self.assertEqual(len(result), 1)
+       listToStr = " ".join([str(elem) for elem in result])
+       self.assertIn('test_host', listToStr, msg="Header name is not expected 'test_host'")
+
+   def test_bad_type_name(self):
+       """Test that `type = banana` returns expected error"""
+       #Setup
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/test_bad_type_name.meta"
+
+       #Exercise
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
        #Verify
-       for x in result: 
-           print x 
+       #print("The exception is", context.exception)
+       self.assertTrue('Invalid metadata table type, \'banana' in str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -14,9 +14,9 @@ import os
 import logging
 import unittest
 
-unit_test_dir = os.path.dirname(os.path.abspath(__file__))
-scripts_dir = os.path.join(unit_test_dir, "../../scripts")
-sample_files_dir =  os.path.join(unit_test_dir, "sample_files")
+root_dir = os.path.dirname(os.path.abspath(__file__))
+scripts_dir = os.path.join(root_dir, "../../scripts")
+sample_files_dir = os.path.join(root_dir, "sample_files")
 
 if not os.path.exists(scripts_dir):
     raise ImportError("Cannot find scripts directory")
@@ -36,38 +36,38 @@ class MetadataTableTestCase(unittest.TestCase):
        #Setup
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_host.meta"
+       filename = os.path.join(sample_files_dir, "test_host.meta")
        #Exercise
        result = MetadataTable.parse_metadata_file(filename, known_ddts, logger)
        #Verify that size of returned list equals number of headers in the test file
        #       and that header name is 'test_host'
        self.assertEqual(len(result), 1)
-       listToStr = " ".join([str(elem) for elem in result])
-       self.assertIn('test_host', listToStr, msg="Header name is not expected 'test_host'")
+       listToStr = " ".join([elem.title for elem in result])
+       self.assertIn('test_host', listToStr, msg="Header name 'test_host' is expected but not found")
 
    def test_good_multi_ccpp_arg_table(self):
        """Test that good file with 4 ccpp-arg-table returns 4 headers"""
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_multi_ccpp_arg_tables.meta"
+       filename = os.path.join(sample_files_dir, "test_multi_ccpp_arg_tables.meta")
 
        result = MetadataTable.parse_metadata_file(filename, known_ddts, logger)
 
        #Verify that size of returned list equals number of headers in the test file
        self.assertEqual(len(result), 4)
-       listToStr = " ".join([str(elem) for elem in result])
+       listToStr = " ".join([elem.title for elem in result])
        #print(listToStr)
-       self.assertIn('vmr_type', listToStr, msg="Header name is not expected 'vmr_type'")
-       self.assertIn('make_ddt_run', listToStr, msg="Header name is not expected 'make_ddt_run'")
-       self.assertIn('make_ddt_init', listToStr, msg="Header name is not expected 'make_ddt_init'")
-       self.assertIn('make_ddt_finalize', listToStr, msg="Header name is not expected 'make_ddt_finalize'")
+       self.assertIn('vmr_type', listToStr, msg="Header name 'vmr_type' is expected but not found")
+       self.assertIn('make_ddt_run', listToStr, msg="Header name 'make_ddt_run' is expected but not found")
+       self.assertIn('make_ddt_init', listToStr, msg="Header name 'make_ddt_init' is expected but not found")
+       self.assertIn('make_ddt_finalize', listToStr, msg="Header name 'make_ddt_finalize' is expected but not found")
 
    def test_bad_type_name(self):
        """Test that `type = banana` returns expected error"""
        #Setup
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_bad_type_name.meta"
+       filename = os.path.join(sample_files_dir, "test_bad_type_name.meta")
 
        #Exercise
        with self.assertRaises(Exception) as context:
@@ -81,7 +81,7 @@ class MetadataTableTestCase(unittest.TestCase):
        """Test that a duplicate header returns expected error"""
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/double_header.meta"
+       filename = os.path.join(sample_files_dir, "double_header.meta")
 
        with self.assertRaises(Exception) as context:
            MetadataTable.parse_metadata_file(filename, known_ddts, logger)
@@ -93,7 +93,7 @@ class MetadataTableTestCase(unittest.TestCase):
        """Test that `dimension = banana` returns expected error"""
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_bad_dimension.meta"
+       filename = os.path.join(sample_files_dir, "test_bad_dimension.meta")
 
        with self.assertRaises(Exception) as context:
            MetadataTable.parse_metadata_file(filename, known_ddts, logger)
@@ -105,7 +105,7 @@ class MetadataTableTestCase(unittest.TestCase):
        """Test that a duplicate variable returns expected error"""
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_duplicate_variable.meta"
+       filename = os.path.join(sample_files_dir, "test_duplicate_variable.meta")
 
        with self.assertRaises(Exception) as context:
            MetadataTable.parse_metadata_file(filename, known_ddts, logger)
@@ -117,7 +117,7 @@ class MetadataTableTestCase(unittest.TestCase):
        """Test that an invalid intent returns expected error"""
        known_ddts = list()
        logger = None
-       filename= sample_files_dir + "/test_invalid_intent.meta"
+       filename = os.path.join(sample_files_dir, "test_invalid_intent.meta")
 
        with self.assertRaises(Exception) as context:
            MetadataTable.parse_metadata_file(filename, known_ddts, logger)

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -125,5 +125,17 @@ class MetadataTableTestCase(unittest.TestCase):
        #print("The exception is", context.exception)
        self.assertTrue('Invalid \'intent\' property value, \'banana\', at ' in str(context.exception))
 
+   def test_missing_intent(self):
+       """Test that a missing intent returns expected error"""
+       known_ddts = list()
+       logger = None
+       filename = os.path.join(sample_files_dir, "test_missing_intent.meta")
+
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       print("The exception is", context.exception)
+       #self.assertTrue('Missing \'intent\' for variable \'timestep\', at ' in str(context.exception))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -42,8 +42,8 @@ class MetadataTableTestCase(unittest.TestCase):
        #Verify that size of returned list equals number of headers in the test file
        #       and that header name is 'test_host'
        self.assertEqual(len(result), 1)
-       listToStr = " ".join([elem.title for elem in result])
-       self.assertIn('test_host', listToStr, msg="Header name 'test_host' is expected but not found")
+       titles = [elem.title for elem in result]
+       self.assertIn('test_host', titles, msg="Header name 'test_host' is expected but not found")
 
    def test_good_multi_ccpp_arg_table(self):
        """Test that good file with 4 ccpp-arg-table returns 4 headers"""
@@ -55,12 +55,12 @@ class MetadataTableTestCase(unittest.TestCase):
 
        #Verify that size of returned list equals number of headers in the test file
        self.assertEqual(len(result), 4)
-       listToStr = " ".join([elem.title for elem in result])
-       #print(listToStr)
-       self.assertIn('vmr_type', listToStr, msg="Header name 'vmr_type' is expected but not found")
-       self.assertIn('make_ddt_run', listToStr, msg="Header name 'make_ddt_run' is expected but not found")
-       self.assertIn('make_ddt_init', listToStr, msg="Header name 'make_ddt_init' is expected but not found")
-       self.assertIn('make_ddt_finalize', listToStr, msg="Header name 'make_ddt_finalize' is expected but not found")
+       titles = [elem.title for elem in result]
+       #print(titles)
+       self.assertIn('vmr_type', titles, msg="Header name 'vmr_type' is expected but not found")
+       self.assertIn('make_ddt_run', titles, msg="Header name 'make_ddt_run' is expected but not found")
+       self.assertIn('make_ddt_init', titles, msg="Header name 'make_ddt_init' is expected but not found")
+       self.assertIn('make_ddt_finalize', titles, msg="Header name 'make_ddt_finalize' is expected but not found")
 
    def test_bad_type_name(self):
        """Test that `type = banana` returns expected error"""
@@ -134,8 +134,8 @@ class MetadataTableTestCase(unittest.TestCase):
        with self.assertRaises(Exception) as context:
            MetadataTable.parse_metadata_file(filename, known_ddts, logger)
 
-       print("The exception is", context.exception)
-       #self.assertTrue('Missing \'intent\' for variable \'timestep\', at ' in str(context.exception))
+       #print("The exception is", context.exception)
+       self.assertTrue('Missing \'intent\' for variable \'timestep\', at ' in str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+#-----------------------------------------------------------------------
+# Description:  Contains unit tests for parse_metadata_file in the class
+#               MetadataTable in scripts file metadata_table.py
+#
+# Assumptions:  
+#
+# Command line arguments: none
+#
+# Usage: python test_metadata_table.py         # run the unit tests
+#-----------------------------------------------------------------------
+import sys
+import os
+import logging
+import unittest
+
+unit_test_dir = os.path.dirname(os.path.abspath(__file__))
+scripts_dir = os.path.join(unit_test_dir, "../../scripts")
+print("scripts_dir: " + scripts_dir)
+if not os.path.exists(scripts_dir):
+    raise ImportError("Cannot find scripts directory")
+
+sys.path.append(scripts_dir)
+
+from metadata_table import MetadataTable
+
+'''Test parse_metadata_file in metadata_table.py'''
+
+class MetadataTableTestCase(unittest.TestCase):
+   """Tests for `parse_metadata_file`."""
+
+   def test_bad_file(self):
+       """I dont know what im doing"""
+       #Setup
+       #known_ddts = None
+       #logger = None
+       known_ddts = list()
+       logger = None
+       filename="/scratch1/BMC/gmtb/Julie.Schramm/ccpp-framework-fork/test/capgen_test/test_host.meta"
+       #Exercise
+       result = MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+       #Verify
+       for x in result: 
+           print x 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -45,6 +45,23 @@ class MetadataTableTestCase(unittest.TestCase):
        listToStr = " ".join([str(elem) for elem in result])
        self.assertIn('test_host', listToStr, msg="Header name is not expected 'test_host'")
 
+   def test_good_multi_ccpp_arg_table(self):
+       """Test that good file with 4 ccpp-arg-table returns 4 headers"""
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/test_multi_ccpp_arg_tables.meta"
+
+       result = MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       #Verify that size of returned list equals number of headers in the test file
+       self.assertEqual(len(result), 4)
+       listToStr = " ".join([str(elem) for elem in result])
+       #print(listToStr)
+       self.assertIn('vmr_type', listToStr, msg="Header name is not expected 'vmr_type'")
+       self.assertIn('make_ddt_run', listToStr, msg="Header name is not expected 'make_ddt_run'")
+       self.assertIn('make_ddt_init', listToStr, msg="Header name is not expected 'make_ddt_init'")
+       self.assertIn('make_ddt_finalize', listToStr, msg="Header name is not expected 'make_ddt_finalize'")
+
    def test_bad_type_name(self):
        """Test that `type = banana` returns expected error"""
        #Setup
@@ -59,6 +76,54 @@ class MetadataTableTestCase(unittest.TestCase):
        #Verify
        #print("The exception is", context.exception)
        self.assertTrue('Invalid metadata table type, \'banana' in str(context.exception))
+
+   def test_double_header(self):
+       """Test that a duplicate header returns expected error"""
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/double_header.meta"
+
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       #print("The exception is", context.exception)
+       self.assertTrue('Duplicate metadata header, test_host' in str(context.exception))
+
+   def test_bad_dimension(self):
+       """Test that `dimension = banana` returns expected error"""
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/test_bad_dimension.meta"
+
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       #print("The exception is", context.exception)
+       self.assertTrue('Invalid \'dimensions\' property value, \'' in str(context.exception))
+
+   def test_duplicate_variable(self):
+       """Test that a duplicate variable returns expected error"""
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/test_duplicate_variable.meta"
+
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       #print("The exception is", context.exception)
+       self.assertTrue('Invalid (duplicate) standard name in temp_calc_adjust_run, defined at ' in str(context.exception))
+
+   def test_invalid_intent(self):
+       """Test that an invalid intent returns expected error"""
+       known_ddts = list()
+       logger = None
+       filename= sample_files_dir + "/test_invalid_intent.meta"
+
+       with self.assertRaises(Exception) as context:
+           MetadataTable.parse_metadata_file(filename, known_ddts, logger)
+
+       #print("The exception is", context.exception)
+       self.assertTrue('Invalid \'intent\' property value, \'banana\', at ' in str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the first commit of unit testing for capgen.  There are 8 tests so far:

1) a good host file
2) a bad dimension
3) a bad type name
4) duplicate header in meta file
5) duplicate variable
6) a good host file with 4 occurrences of ccpp-arg-table
7) a bad intent
8) a missing intent

Tests 1-7 pass, test 8 fails.  An issue has been submitted.