### PR TITLE
Bugfix #2 for travis test in schemes/check/ccpp_prebuild_config.py

### DIFF
--- a/schemes/check/ccpp_prebuild_config.py
+++ b/schemes/check/ccpp_prebuild_config.py
@@ -71,6 +71,7 @@ FIELDS_INCLUDE_FILE = 'ccpp_fields_{set}.inc'
 
 # Directory where to write static API to
 STATIC_API_DIR = '.'
+STATIC_API_SRCFILE = './CCPP_STATIC_API.sh'
 
 # HTML document containing the model-defined CCPP variables
 HTML_VARTABLE_FILE = 'CCPP_VARIABLES_FV3.html'


### PR DESCRIPTION
Second bugfix for travis: add missing entry to schemes/check/ccpp_prebuild_config.py following https://github.com/NCAR/ccpp-framework/pull/235 and https://github.com/NCAR/ccpp-framework/pull/230. Merge immediately, no effect on any model.