### PR TITLE
dtc/develop: update logic around builddir (ccpp_prebuild.py) / basedir (metadata2html.py)

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -30,7 +30,7 @@ parser.add_argument('--clean',      action='store_true', help='remove files crea
 parser.add_argument('--debug',      action='store_true', help='enable debugging output', default=False)
 parser.add_argument('--static',     action='store_true', help='enable a static build for a given suite definition file', default=False)
 parser.add_argument('--suites',     action='store', help='suite definition files to use (comma-separated, for static build only, without path)', default='')
-parser.add_argument('--builddir',   action='store', help='relative path to CCPP build directory', required=False, default='.')
+parser.add_argument('--builddir',   action='store', help='relative path to CCPP build directory', required=False, default=None)
 
 # BASEDIR is the current directory where this script is executed
 BASEDIR = os.getcwd()
@@ -70,6 +70,13 @@ def import_config(configfile, builddir):
     configmodule = os.path.splitext(os.path.basename(configfile))[0]
     sys.path.append(configpath)
     ccpp_prebuild_config = importlib.import_module(configmodule)
+
+    # If the build directory for running ccpp_prebuild.py is not
+    # specified as command line argument, use value from config
+    if not builddir:
+        builddir = os.path.join(BASEDIR, ccpp_prebuild_config.DEFAULT_BUILD_DIR)
+        logging.info('Build directory not specified on command line, ' + \
+                     'use "{}" from CCPP prebuild config'.format(ccpp_prebuild_config.DEFAULT_BUILD_DIR))
 
     # Definitions in host-model dependent CCPP prebuild config script
     config['variable_definition_files'] = ccpp_prebuild_config.VARIABLE_DEFINITION_FILES


### PR DESCRIPTION
This PR updates the logic around the current command line arguments `--builddir` (for `ccpp_prebuild.py`) and `--basedir` (for `metadata2html.py`).

- for `ccpp_prebuild.py`: use default value from the CCPP prebuild config (newly added) if not provided on the command line; this means that the default build is in-source, but by specifying `--builddir` an out-of-source build can be requested; this is also backward compatible with the current settings in UFS and SCM
- for `metadata2html.py`: since it does not make sense to create the html tables from the CCPP metadata outside of the source directories (all accompanying doxygen files are in-source), always use the default value from the CCPP prebuild config, remove the command line argument entirely

With this change, it is possible to run `metadata2html.py` from the top-level `ufs-weather-model` directory as follows (for bulk conversions):
```
./FV3/ccpp/framework/scripts/metadata2html.py --config=FV3/ccpp/config/ccpp_prebuild_config.py
```