### PR TITLE
dtc/develop: compile only required source files in static mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,29 +6,40 @@ endif (NOT PROJECT)
 
 #------------------------------------------------------------------------------
 # Set the sources
-set(SOURCES_C
-    ccpp_dl.h
-    ccpp_dl.c
-    ccpp_fields_idx.h
-    ccpp_fields_idx.c
-    ccpp_utils.h
-    ccpp_utils.c
-    ccpp_xml.h
-    ccpp_xml.c
-)
-set(SOURCES_F90
-    ccpp.F90
-    ccpp_dl.F90
-    ccpp_errors.F90
-    ccpp_fcall.F90
-    ccpp_fields.F90
-    ccpp_strings.F90
-    ccpp_scheme.F90
-    ccpp_suite.F90
-    ccpp_types.F90
-    ccpp_xml.F90
-    ccpp_api.F90
-)
+if(STATIC)
+  set(SOURCES_C)
+  set(SOURCES_F90
+      ccpp_types.F90
+      ccpp_errors.F90
+      ccpp.F90
+      ccpp_api.F90
+  )
+else(STATIC)
+  set(SOURCES_C
+      ccpp_dl.h
+      ccpp_dl.c
+      ccpp_fields_idx.h
+      ccpp_fields_idx.c
+      ccpp_utils.h
+      ccpp_utils.c
+      ccpp_xml.h
+      ccpp_xml.c
+  )
+  set(SOURCES_F90
+      ccpp.F90
+      ccpp_dl.F90
+      ccpp_errors.F90
+      ccpp_fcall.F90
+      ccpp_fields.F90
+      ccpp_strings.F90
+      ccpp_scheme.F90
+      ccpp_suite.F90
+      ccpp_types.F90
+      ccpp_xml.F90
+      ccpp_api.F90
+  )
+endif(STATIC)
+
 # Generate list of Fortran modules from defined sources
 foreach(source_f90 ${SOURCES_F90})
     string(REGEX REPLACE ".F90" ".mod" module_f90 ${source_f90})
@@ -111,8 +122,10 @@ set(${PACKAGE}_LIB_DIRS
      CACHE FILEPATH "${PACKAGE} library directories")
 
 #------------------------------------------------------------------------------
-# Add the tests
+# Add the tests (designed for DYNAMIC build only)
+if(!STATIC)
 add_subdirectory(tests)
+endif(!STATIC)
 
 #------------------------------------------------------------------------------
 # Define the executable and what to link

--- a/src/ccpp.F90
+++ b/src/ccpp.F90
@@ -17,6 +17,10 @@
 !
 module ccpp
 
+#ifdef STATIC
+    use            :: ccpp_types,                                      &
+                      only: ccpp_t
+#else
     use, intrinsic :: iso_c_binding,                                   &
                       only: c_ptr
     use            :: ccpp_types,                                      &
@@ -25,12 +29,14 @@ module ccpp
                       only: ccpp_suite_init, ccpp_suite_finalize
     use            :: ccpp_fields,                                     &
                       only: ccpp_fields_init, ccpp_fields_finalize
+#endif
     use            :: ccpp_errors,                                     &
                       only: ccpp_error, ccpp_debug
 
     implicit none
 
     private
+
     public :: ccpp_init,                                               &
               ccpp_finalize,                                           &
               ccpp_initialized

--- a/src/ccpp_api.F90
+++ b/src/ccpp_api.F90
@@ -25,11 +25,13 @@ module ccpp_api
     use ccpp,               only: ccpp_init,                           &
                                   ccpp_finalize,                       &
                                   ccpp_initialized
+#ifndef STATIC
     use ccpp_fcall,         only: ccpp_physics_init,                   &
                                   ccpp_physics_run,                    &
                                   ccpp_physics_finalize
     use ccpp_fields,        only: ccpp_field_add,                      &
                                   ccpp_field_get
+#endif
 
     implicit none
 
@@ -38,11 +40,13 @@ module ccpp_api
               ccpp_error,                                              &
               ccpp_debug,                                              &
               ccpp_init,                                               &
-              ccpp_finalize,                                           &
-              ccpp_physics_init,                                       &
+              ccpp_finalize
+#ifndef STATIC
+    public :: ccpp_physics_init,                                       &
               ccpp_physics_run,                                        &
               ccpp_physics_finalize,                                   &
               ccpp_field_add,                                          &
               ccpp_initialized
+#endif
 
 end module ccpp_api


### PR DESCRIPTION
This PR removes code required for the dynamic CCPP option only from the static build.

@DusanJovic-NOAA, for your information, this means that the offending warning messages when compiling ccpp-framework with the GNU compiler are gone.

Associated PRs see below, for regression testing see NCAR/ufs-weather-model#9.