### PR TITLE
master: fix travis build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ string(TIMESTAMP YEAR "%Y")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 #------------------------------------------------------------------------------
+# Static or dynamic CCPP, default is dynamic; standalone build can only be dynamic
+option(STATIC "Build a static CCPP" OFF)
+if (PROJECT STREQUAL "Unknown" AND STATIC)
+    message(FATAL_ERROR "ccpp-framework standalone build can only be dynamic")
+endif(PROJECT STREQUAL "Unknown" AND STATIC)
+
+#------------------------------------------------------------------------------
 # Set OpenMP flags for C/C++/Fortran
 if (OPENMP)
   include(detect_openmp)

--- a/schemes/check/ccpp_prebuild_config.py
+++ b/schemes/check/ccpp_prebuild_config.py
@@ -28,6 +28,10 @@ SCHEME_FILES = {
     '../../../../../schemes/check/check_test.f90' : [ 'test' ],
     }
 
+# Default build dir, relative to current working directory,
+# if not specified as command-line argument
+DEFAULT_BUILD_DIR = '.'
+
 # Auto-generated makefile/cmakefile snippets that contain all schemes
 SCHEMES_MAKEFILE = '/dev/null'
 SCHEMES_CMAKEFILE = '/dev/null'
@@ -84,9 +88,5 @@ LATEX_VARTABLE_FILE = 'CCPP_VARIABLES_FV3.tex'
 # Template code to generate include files                                     #
 ###############################################################################
 
-# Name of the CCPP data structure in the host model cap;
-# in the case of FV3, this is a 2-dimensional array with
-# the number of blocks as the first and the number of
-# OpenMP threads as the second dimension; nb is the loop
-# index for the current block, nt for the current thread
+# Name of the CCPP data structure in the host model cap
 CCPP_DATA_STRUCTURE = 'cdata'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,9 +123,11 @@ set(${PACKAGE}_LIB_DIRS
 
 #------------------------------------------------------------------------------
 # Add the tests (designed for DYNAMIC build only)
-if(!STATIC)
-add_subdirectory(tests)
-endif(!STATIC)
+if(STATIC)
+    message(STATUS "Skipping tests, defined for dynamic build only")
+else(STATIC)
+    add_subdirectory(tests)
+endif(STATIC)
 
 #------------------------------------------------------------------------------
 # Define the executable and what to link


### PR DESCRIPTION
Fix travis build/testing by setting STATIC option correctly for standalone build and adding the missing new configuration option DEFAULT_BUILD_DIR to the standalone build CCPP prebuild config.