### PR TITLE
Update scripts to Python 3 using 2to3 conversion

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -176,7 +176,7 @@ def parse_suites(suites_dir, sdfs):
 def check_unique_pset_per_scheme(scheme_files):
     """Check that each scheme belongs to one and only one physics set"""
     success = True
-    for scheme_file in scheme_files.keys():
+    for scheme_file in list(scheme_files.keys()):
         if len(scheme_files[scheme_file])>1:
             logging.error("Scheme file {0} belongs to multiple physics sets: {1}".format(scheme_file, ','.join(scheme_files[scheme_file])))
             success = False
@@ -195,16 +195,16 @@ def convert_local_name_from_new_metadata(metadata, standard_name, typedefs_new_m
     container = decode_container_as_dict(var.container)
     # Check if variable is in old or new metadata format
     module_name = container['MODULE']
-    if not module_name in typedefs_new_metadata.keys():
+    if not module_name in list(typedefs_new_metadata.keys()):
         logging.debug('Variable {0} is in old metadata format, no conversion necessary'.format(standard_name))
         return (success, var.local_name, converted_variables)
     # For module variables set type_name to module_name
-    if not 'TYPE' in container.keys():
+    if not 'TYPE' in list(container.keys()):
         type_name = module_name
     else:
         type_name = container['TYPE']
     # Check that this module/type is configured (modules will have empty prefices)
-    if not type_name in typedefs_new_metadata[module_name].keys():
+    if not type_name in list(typedefs_new_metadata[module_name].keys()):
         logging.error("Module {0} uses the new metadata format, but module/type {1} is not configured".format(module_name, type_name))
         success = False
         return (success, None, converted_variables)
@@ -278,7 +278,7 @@ def gather_variable_definitions(variable_definition_files, typedefs_new_metadata
         logging.info('Convert local names from new metadata format into old metadata format ...')
         # Keep track of which variables have already been converted
         converted_variables = []
-        for key in metadata_define.keys():
+        for key in list(metadata_define.keys()):
             # Double-check that variable definitions are unique
             if len(metadata_define[key])>1:
                 logging.error("Multiple definitions of standard_name {0} in type/variable defintions".format(key))
@@ -306,15 +306,15 @@ def collect_physics_subroutines(scheme_files):
     arguments_request = {}
     pset_request = {}
     pset_schemes = {}
-    for scheme_file in scheme_files.keys():
+    for scheme_file in list(scheme_files.keys()):
         (scheme_filepath, scheme_filename) = os.path.split(os.path.abspath(scheme_file))
         # Change to directory where scheme_file lives
         os.chdir(scheme_filepath)
         (metadata, arguments) = parse_scheme_tables(scheme_filename)
         # The different psets for the variables used by schemes in scheme_file
-        pset = { var_name : scheme_files[scheme_file] for var_name in metadata.keys() }
+        pset = { var_name : scheme_files[scheme_file] for var_name in list(metadata.keys()) }
         # The different psets for the schemes in scheme_file
-        for scheme_name in arguments.keys():
+        for scheme_name in list(arguments.keys()):
             pset_schemes[scheme_name] = scheme_files[scheme_file]
         # Merge metadata and pset, append to arguments
         metadata_request = merge_dictionaries(metadata_request, metadata)
@@ -349,7 +349,7 @@ def filter_metadata(metadata, pset, arguments, suites):
             pset_filtered[var_name] = pset[var_name]
         else:
             logging.info("filtering out variable {0}".format(var_name))
-    for scheme in arguments.keys():
+    for scheme in list(arguments.keys()):
         for suite in suites:
             if scheme in suite.all_schemes_called:
                 arguments_filtered[scheme] = arguments[scheme]
@@ -383,8 +383,8 @@ def check_optional_arguments(metadata, arguments, optional_arguments):
                         success = False
                         logging.error('Invalid identifier {0} in container value {1} of requested variable {2}'.format(
                                                                                  subitems[0], var.container, var_name))
-                if not module_name in optional_arguments.keys() or not \
-                        subroutine_name in optional_arguments[module_name].keys():
+                if not module_name in list(optional_arguments.keys()) or not \
+                        subroutine_name in list(optional_arguments[module_name].keys()):
                     success = False
                     logging.error('No entry found in optional_arguments dictionary for optional argument ' + \
                                   '{0} to subroutine {1} in module {2}'.format(var_name, subroutine_name, module_name))
@@ -399,7 +399,7 @@ def check_optional_arguments(metadata, arguments, optional_arguments):
                         metadata[var_name].remove(var)
                         # Remove var_name from list of calling arguments for that subroutine
                         # (unless that module has been filtered out for the static build)
-                        if module_name in arguments.keys():
+                        if module_name in list(arguments.keys()):
                             arguments[module_name][scheme_name][subroutine_name].remove(var_name)
                 elif optional_arguments[module_name][subroutine_name] == 'all':
                     logging.debug('optional argument {0} to subroutine {1} in module {2} is required, keep in list'.format(
@@ -424,7 +424,7 @@ def compare_metadata(metadata_define, metadata_request, pset_request, psets_merg
     metadata = {}
     for var_name in sorted(metadata_request.keys()):
         # Check that variable is provided by the model
-        if not var_name in metadata_define.keys():
+        if not var_name in list(metadata_define.keys()):
             requested_by = ' & '.join(var.container for var in metadata_request[var_name])
             success = False
             logging.error('Variable {0} requested by {1} not provided by the model'.format(var_name, requested_by))
@@ -529,7 +529,7 @@ def create_ccpp_field_add_statements(metadata, pset, ccpp_data_structure):
     # indices for faster retrieval of variables from cdata via ccpp_field_get
     for var_name in sorted(metadata.keys()):
         # Skip CCPP internal variables, these are treated differently
-        if var_name in CCPP_INTERNAL_VARIABLES.keys():
+        if var_name in list(CCPP_INTERNAL_VARIABLES.keys()):
             continue
         # Add variable with var_name = standard_name once
         logging.debug('Generating ccpp_field_add statement for variable {0}'.format(var_name))
@@ -571,9 +571,9 @@ def generate_scheme_caps(metadata_define, metadata_request, arguments, pset_sche
     os.chdir(caps_dir)
     # List of filenames of scheme caps
     scheme_caps = []
-    for module_name in arguments.keys():
-        for scheme_name in arguments[module_name].keys():
-            for subroutine_name in arguments[module_name][scheme_name].keys():
+    for module_name in list(arguments.keys()):
+        for scheme_name in list(arguments[module_name].keys()):
+            for subroutine_name in list(arguments[module_name][scheme_name].keys()):
                 # Skip subroutines without argument table or with empty argument table
                 if not arguments[module_name][scheme_name][subroutine_name]:
                     continue
@@ -583,7 +583,7 @@ def generate_scheme_caps(metadata_define, metadata_request, arguments, pset_sche
             scheme_caps.append(cap.filename)
             # Parse all subroutines and their arguments to generate the cap
             capdata = collections.OrderedDict()
-            for subroutine_name in arguments[module_name][scheme_name].keys():
+            for subroutine_name in list(arguments[module_name][scheme_name].keys()):
                 capdata[subroutine_name] = []
                 for var_name in arguments[module_name][scheme_name][subroutine_name]:
                     container = encode_container(module_name, scheme_name, subroutine_name)
@@ -745,7 +745,7 @@ def main():
         raise Exception('Call to metadata_to_latex failed.')
 
     # Flatten list of list of psets for all variables
-    psets_merged = list(set(itertools.chain(*pset_request.values())))
+    psets_merged = list(set(itertools.chain(*list(pset_request.values()))))
 
     # Check requested against defined arguments to generate metadata (list/dict of variables for CCPP)
     (success, modules, metadata) = compare_metadata(metadata_define, metadata_request, pset_request, psets_merged)
@@ -762,7 +762,7 @@ def main():
                 raise Exception('Call to create_module_use_statements failed.')
 
             # Only process variables that fall into this pset
-            metadata_filtered = { key : value for (key, value) in metadata.items() if pset in pset_request[key] }
+            metadata_filtered = { key : value for (key, value) in list(metadata.items()) if pset in pset_request[key] }
 
             # Create ccpp_fiels_add statements to inject into the host model cap;
             # this returns a ccpp_field_map that contains indices of variables in
@@ -781,7 +781,7 @@ def main():
                 raise Exception('Call to generate_include_files failed.')
 
     # Add filenames of schemes to makefile - add dependencies for schemes
-    success = generate_schemes_makefile(config['scheme_files_dependencies'] + config['scheme_files'].keys(),
+    success = generate_schemes_makefile(config['scheme_files_dependencies'] + list(config['scheme_files'].keys()),
                                         config['schemes_makefile'], config['schemes_cmakefile'],
                                         config['schemes_sourcefile'])
     if not success:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -126,7 +126,7 @@ def decode_container(container):
     items = container.split(' ')
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         items[i] = items[i][:items[i].find('_')] + ' ' + items[i][items[i].find('_')+1:]
     return ' '.join(items)
 
@@ -139,7 +139,7 @@ def decode_container_as_dict(container):
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
     itemsdict = {}
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         key, value = (items[i][:items[i].find('_')], items[i][items[i].find('_')+1:])
         itemsdict[key] = value
     return itemsdict
@@ -157,7 +157,7 @@ def isstring(s):
         return isinstance(s, str)
     # We use Python 2
     elif (sys.version_info.major == 2):
-        return isinstance(s, basestring)
+        return isinstance(s, str)
     else:
         raise Exception('Unknown Python version')
 

--- a/scripts/conversion_tools/__init__.py
+++ b/scripts/conversion_tools/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     'units',
     ]
 
-import unit_conversion
+from . import unit_conversion

--- a/scripts/convert_metadata.py
+++ b/scripts/convert_metadata.py
@@ -60,7 +60,7 @@ class MetadataEntry(OrderedDict):
 
     def write(self, mdfile):
         mdfile.write('[{}]\n'.format(self.local_name))
-        for key in self.keys():
+        for key in list(self.keys()):
             mdfile.write("  {} = {}\n".format(key, self[key]))
         # End for
 
@@ -90,7 +90,7 @@ class MetadataTable(OrderedDict):
     def has(self, varname):
         hasvar = False
         vartest = varname.lower()
-        for name in self.keys():
+        for name in list(self.keys()):
             if vartest == name.lower():
                 hasvar = True
                 break
@@ -101,7 +101,7 @@ class MetadataTable(OrderedDict):
     def get(self, varname):
         var = None
         vartest = varname.lower()
-        for name in self.keys():
+        for name in list(self.keys()):
             if vartest == name.lower():
                 var = self[name]
                 break
@@ -113,7 +113,7 @@ class MetadataTable(OrderedDict):
         mdfile.write('[ccpp-arg-table]\n')
         mdfile.write('  name = {}\n'.format(self._name))
         mdfile.write('  type = {}\n'.format(self._type))
-        for key in self.keys():
+        for key in list(self.keys()):
             self[key].write(mdfile)
 
 ########################################################################
@@ -125,7 +125,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
     if logger:
         logger.info("Converting file {} ...".format(filename_in))
     else:
-        print "Converting file {} ...".format(filename_in)
+        print("Converting file {} ...".format(filename_in))
     current_module = None
     # First, suck in the old file
     do_convert = True
@@ -150,7 +150,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
     # Read all lines of the file at once
     with open(filename_in, 'r') as file:
         fin_lines = file.readlines()
-        for index in xrange(len(fin_lines)):
+        for index in range(len(fin_lines)):
             fin_lines[index] = fin_lines[index].rstrip('\n')
             # First loop through file to build dictionary with local names versus standard names
             # and to record array dimensions from allocate statements
@@ -164,7 +164,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                     if not standard_name:
                         continue
                     # No duplicates allowed
-                    if local_name in standard_names.keys():
+                    if local_name in list(standard_names.keys()):
                         raise Exception("Multiple definitions of local name {}".format(local_name))
                     standard_names[local_name] = standard_name
             elif 'allocate' in fin_lines[index]:
@@ -200,12 +200,12 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                             dims = ['im', 'gfs_control%levs', 'oz_coeff+5']
                         elif var == 'ccpp_interstitial%cappa'.lower():
                             dims = ['isd:ied', 'jsd:jed', '1:npzcappa']
-                        elif var in dimensions.keys() and not dims == dimensions[var]:
+                        elif var in list(dimensions.keys()) and not dims == dimensions[var]:
                             raise Exception("Multiple, conflicting allocations of variable with local name {}: {} vs {}".format(
                                             var, dimensions[var], dims))
                     # End model and file-dependent substitutions
                     else:
-                        if var in dimensions.keys() and not dims == dimensions[var]:
+                        if var in list(dimensions.keys()) and not dims == dimensions[var]:
                             raise Exception("Multiple, conflicting allocations of variable with local name {}: {} vs {}".format(
                                             var, dimensions[var], dims))
                     dimensions[var] = dims
@@ -218,8 +218,8 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
     # Begin model and file-dependent substitutions
     if model == 'FV3':
         # Replace local dimensions in GFS_typedefs.F90, CCPP_typedefs.F90 and CCPP_data.F90 with correct standard names
-        for key in dimensions.keys():
-            for i in xrange(len(dimensions[key])):
+        for key in list(dimensions.keys()):
+            for i in range(len(dimensions[key])):
                 dim = dimensions[key][i]
                 if dim == 'im':
                     dimensions[key][i] = 'horizontal_dimension'
@@ -288,7 +288,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                               'n',
                             ]:
                     dimensions[key][i] = dim + "_XX_SubstituteWithStandardName_XX"
-                elif not dim in standard_names.keys():
+                elif not dim in list(standard_names.keys()):
                     raise Exception("Dimension {} not defined".format(dim))
                 else:
                     dimensions[key][i] = standard_names[dim]
@@ -341,7 +341,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                     file.write('!! \htmlinclude {}.html\n'.format(table_name))
                     #
                     table_header = [x.strip() for x in words[1:-1]]
-                    for ind in xrange(len(table_header)):
+                    for ind in range(len(table_header)):
                         header_locs[table_header[ind]] = ind
                     # End for
                     # Find the local_name index (exception if not found)
@@ -395,7 +395,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                                     if match:
                                         continue
                                     else:
-                                        if index.lower() in standard_names.keys():
+                                        if index.lower() in list(standard_names.keys()):
                                             array_reference = array_reference.replace(index, standard_names[index.lower()])
                                         else:
                                             array_reference = array_reference.replace(index, index + "_XX_SubstituteWithStandardName_XX")
@@ -414,9 +414,9 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                         #
                         if mdtable.type == 'module':
                             ddt_reference = ''
-                        if not current_module in ddt_references.keys():
+                        if not current_module in list(ddt_references.keys()):
                             ddt_references[current_module] = {}
-                        if not table_name in ddt_references[current_module].keys():
+                        if not table_name in list(ddt_references[current_module].keys()):
                             ddt_references[current_module][table_name] = ddt_reference
                         elif not ddt_references[current_module][table_name] == ddt_reference:
                             raise Exception("Conflicting DDT references in table {}: {} vs {}".format(
@@ -425,7 +425,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                         mdobj = MetadataEntry(var_name)
                         mdtable[var_name] = mdobj
                         # Now, create the rest of the entries
-                        for ind in xrange(len(entries)):
+                        for ind in range(len(entries)):
                             attr_name = table_header[ind]
                             entry = entries[ind]
                             if attr_name == 'local_name':
@@ -436,17 +436,17 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
                                 rank = int(entry)
                                 if rank>0:
                                     # Search for key in dimensions dictionary
-                                    if local_name.lower() in dimensions.keys():
+                                    if local_name.lower() in list(dimensions.keys()):
                                         dim_key = local_name.lower()
                                     # Begin model and file-dependent substitutions
                                     elif model == 'FV3':
-                                        if local_name.replace("GFS_Data(cdata%blk_no)%","").lower() in dimensions.keys():
+                                        if local_name.replace("GFS_Data(cdata%blk_no)%","").lower() in list(dimensions.keys()):
                                             dim_key = local_name.replace("GFS_Data(cdata%blk_no)%","").lower()
-                                        elif local_name.replace("GFS_Data(cdata%blk_no)%Intdiag%","Diag%").lower() in dimensions.keys():
+                                        elif local_name.replace("GFS_Data(cdata%blk_no)%Intdiag%","Diag%").lower() in list(dimensions.keys()):
                                             dim_key = local_name.replace("GFS_Data(cdata%blk_no)%Intdiag%","Diag%").lower()
-                                        elif local_name.replace("GFS_Interstitial(cdata%thrd_no)%","Interstitial%").lower() in dimensions.keys():
+                                        elif local_name.replace("GFS_Interstitial(cdata%thrd_no)%","Interstitial%").lower() in list(dimensions.keys()):
                                             dim_key = local_name.replace("GFS_Interstitial(cdata%thrd_no)%","Interstitial%").lower()
-                                        elif local_name.replace("CCPP_Interstitial%","Interstitial%").lower() in dimensions.keys():
+                                        elif local_name.replace("CCPP_Interstitial%","Interstitial%").lower() in list(dimensions.keys()):
                                             dim_key = local_name.replace("CCPP_Interstitial%","Interstitial%").lower()
                                         else:
                                             dim_key = None
@@ -652,7 +652,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
         spacer = ""
         # First pass: write type definitions,
         # second pass: write module table
-        for count in xrange(2):
+        for count in range(2):
             for table in mdconfig:
                 if (count == 0 and not table.type == 'ddt') or \
                    (count == 1 and table.type == 'ddt'):
@@ -670,9 +670,9 @@ def convert_file(filename_in, filename_out, metadata_filename_out, model, logger
         message = """Add the following statement to the CCPP prebuild config (add to existing entry):
 TYPEDEFS_NEW_METADATA = {
 """
-        for module_name in ddt_references.keys():
+        for module_name in list(ddt_references.keys()):
             message += "    '{module_name}' : {{\n".format(module_name=module_name)
-            for table_name in ddt_references[module_name].keys():
+            for table_name in list(ddt_references[module_name].keys()):
                 message += "        '{table_name}' : '{ddt_reference}',\n".format(table_name=table_name,
                                               ddt_reference=ddt_references[module_name][table_name])
             message += "        },\n"
@@ -680,15 +680,15 @@ TYPEDEFS_NEW_METADATA = {
         if logger is not None:
             logger.info(message)
         else:
-            print message
+            print(message)
 
 ########################################################################
 
 def usage(cmd):
     print("Usage:")
-    print("{} <source_file> <target_file> <model>".format(cmd))
+    print(("{} <source_file> <target_file> <model>".format(cmd)))
     print("")
-    print("<model> can be one of '{}'".format(MODELS))
+    print(("<model> can be one of '{}'".format(MODELS)))
     print("")
     print("Translate the metadata in <source_file> into a new file")
     raise Exception

--- a/scripts/convert_metadata_schemes_using_typedef_dims.py
+++ b/scripts/convert_metadata_schemes_using_typedef_dims.py
@@ -52,7 +52,7 @@ def parse_metadata_tables_typedefs(model):
         for metadata_header in metadata_headers:
             for var in metadata_header.variable_list():
                 standard_name = var.get_prop_value('standard_name')
-                if standard_name in dimensions.keys():
+                if standard_name in list(dimensions.keys()):
                     raise ValueError("Duplicate standard name {} in type/variable definition metadata tables".format(standard_name))
                 dimensions[standard_name] = var.get_prop_value('dimensions')
     #
@@ -109,7 +109,7 @@ class MetadataEntry(OrderedDict):
 
     def write(self, mdfile):
         mdfile.write('[{}]\n'.format(self.local_name))
-        for key in self.keys():
+        for key in list(self.keys()):
             mdfile.write("  {} = {}\n".format(key, self[key]))
         # End for
 
@@ -139,7 +139,7 @@ class MetadataTable(OrderedDict):
     def has(self, varname):
         hasvar = False
         vartest = varname.lower()
-        for name in self.keys():
+        for name in list(self.keys()):
             if vartest == name.lower():
                 hasvar = True
                 break
@@ -150,7 +150,7 @@ class MetadataTable(OrderedDict):
     def get(self, varname):
         var = None
         vartest = varname.lower()
-        for name in self.keys():
+        for name in list(self.keys()):
             if vartest == name.lower():
                 var = self[name]
                 break
@@ -162,7 +162,7 @@ class MetadataTable(OrderedDict):
         mdfile.write('[ccpp-arg-table]\n')
         mdfile.write('  name = {}\n'.format(self._name))
         mdfile.write('  type = {}\n'.format(self._type))
-        for key in self.keys():
+        for key in list(self.keys()):
             self[key].write(mdfile)
 
 ########################################################################
@@ -174,7 +174,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
     if logger:
         logger.info("Converting file {} ...".format(filename_in))
     else:
-        print "Converting file {} ...".format(filename_in)
+        print("Converting file {} ...".format(filename_in))
     current_module = None
     # First, suck in the old file
     do_convert = True
@@ -188,7 +188,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
     # Read all lines of the file at once
     with open(filename_in, 'r') as file:
         fin_lines = file.readlines()
-        for index in xrange(len(fin_lines)):
+        for index in range(len(fin_lines)):
             fin_lines[index] = fin_lines[index].rstrip('\n')
         # End for
     # End with
@@ -236,7 +236,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
                     file.write('!! \htmlinclude {}.html\n'.format(table_name))
                     #
                     table_header = [x.strip() for x in words[1:-1]]
-                    for ind in xrange(len(table_header)):
+                    for ind in range(len(table_header)):
                         header_locs[table_header[ind]] = ind
                     # End for
                     # Find the local_name index (exception if not found)
@@ -273,7 +273,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
                         mdobj = MetadataEntry(var_name)
                         mdtable[var_name] = mdobj
                         # Now, create the rest of the entries
-                        for ind in xrange(len(entries)):
+                        for ind in range(len(entries)):
                             attr_name = table_header[ind]
                             entry = entries[ind]
                             if attr_name == 'local_name':
@@ -283,7 +283,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
                                 attr_name = 'dimensions'
                                 rank = int(entry)
                                 # Search for standard_name key in typedef_dimensions dictionary
-                                if not standard_name in typedef_dimensions.keys():
+                                if not standard_name in list(typedef_dimensions.keys()):
                                     raise ValueError("{} does not have an entry in the in typedef_dimensions dictionary".format(standard_name))
                                 if not rank == len(typedef_dimensions[standard_name]):
                                     raise ValueError("Rank of {} in {} does not match with dimension information in typedef_dimensions".format(
@@ -342,7 +342,7 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
         spacer = ""
         # First pass: write type definitions,
         # second pass: write module table
-        for count in xrange(2):
+        for count in range(2):
             for table in mdconfig:
                 if (count == 0 and not table.type == 'ddt') or \
                    (count == 1 and table.type == 'ddt'):
@@ -360,9 +360,9 @@ def convert_file(filename_in, filename_out, metadata_filename_out, typedef_dimen
 
 def usage(cmd):
     print("Usage:")
-    print("{} <source_file> <target_file> <model>".format(cmd))
+    print(("{} <source_file> <target_file> <model>".format(cmd)))
     print("")
-    print("<model> can be one of '{}'".format(METADATA_TYPEDEFS.keys()))
+    print(("<model> can be one of '{}'".format(list(METADATA_TYPEDEFS.keys()))))
     print("")
     print("Translate the metadata in <source_file> into a new file")
     raise Exception
@@ -383,7 +383,7 @@ if __name__ == "__main__":
         #logger = None
         tbase = os.path.basename(sys.argv[2])
         tdir = os.path.dirname(sys.argv[2])
-        if not sys.argv[3] in METADATA_TYPEDEFS.keys():
+        if not sys.argv[3] in list(METADATA_TYPEDEFS.keys()):
             usage(sys.argv[0])
         mdfilename = "{}.meta".format('.'.join(tbase.split('.')[:-1]))
         dest_mdfile = os.path.join(tdir, mdfilename)

--- a/scripts/fortran_tools/__init__.py
+++ b/scripts/fortran_tools/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     'parse_fortran_var_decl'
 ]
 
-from parse_fortran_file import parse_fortran_file
-from parse_fortran      import parse_fortran_var_decl, fortran_type_definition
+from .parse_fortran_file import parse_fortran_file
+from .parse_fortran      import parse_fortran_var_decl, fortran_type_definition

--- a/scripts/fortran_tools/parse_fortran_file.py
+++ b/scripts/fortran_tools/parse_fortran_file.py
@@ -15,7 +15,7 @@ from parse_tools import CCPPError, ParseInternalError, ParseSyntaxError
 from parse_tools import ParseContext, ParseObject, ParseSource, PreprocStack
 from parse_tools import FORTRAN_ID
 from metadata_table import MetadataHeader
-from parse_fortran import parse_fortran_var_decl, fortran_type_definition
+from .parse_fortran import parse_fortran_var_decl, fortran_type_definition
 from metavar import VarDictionary
 
 comment_re = re.compile(r"!.*$")
@@ -342,7 +342,7 @@ def read_file(filename, preproc_defs=None, logger=None):
         # Read all lines of the file at once
         with open(filename, 'r') as file:
             file_lines = file.readlines()
-            for index in xrange(len(file_lines)):
+            for index in range(len(file_lines)):
                 file_lines[index] = file_lines[index].rstrip('\n').rstrip()
             # End for
         # End with
@@ -449,7 +449,7 @@ def parse_use_statement(type_dict, statement, pobj, logger):
     if umatch is None:
         return False
     else:
-        print("use = {}".format(umatch.group(1)))
+        print(("use = {}".format(umatch.group(1))))
         return True
     # End if
 
@@ -813,7 +813,7 @@ if __name__ == "__main__":
         if os.path.exists(fpathname):
             mh = parse_fortran_file(fpathname, preproc_defs={'CCPP':1})
             for h in mh:
-                print('{}: {}'.format(fname, h))
+                print(('{}: {}'.format(fname, h)))
             # End for
         # End if
     # End for

--- a/scripts/metadata2html.py
+++ b/scripts/metadata2html.py
@@ -74,7 +74,7 @@ def import_config(configfile, logger):
 def get_metadata_files_from_config(config, logger):
     """Create a list of metadata filenames for a CCPP prebuild configuration"""
     filenames = []
-    for sourcefile in config['variable_definition_files'] + config['scheme_files'].keys():
+    for sourcefile in config['variable_definition_files'] + list(config['scheme_files'].keys()):
         metafile = os.path.splitext(sourcefile)[0]+'.meta'
         if os.path.isfile(metafile):
             filenames.append(metafile)

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -125,7 +125,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
 
     # Save metadata, because this routine new_metadata
     # is called once for every table in that file
-    if filename in NEW_METADATA_SAVE.keys():
+    if filename in list(NEW_METADATA_SAVE.keys()):
         new_metadata_headers = NEW_METADATA_SAVE[filename]
     else:
         new_metadata_headers = MetadataHeader.parse_metadata_file(filename)
@@ -163,7 +163,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             # Set rank using integer-setter method
             var.rank = rank
             # Check for duplicates in same table
-            if standard_name in metadata.keys():
+            if standard_name in list(metadata.keys()):
                 raise Exception("Error, multiple definitions of standard name {0} in new metadata table {1}".format(standard_name, table_name))
             metadata[standard_name] = [var]
     return metadata
@@ -190,7 +190,7 @@ def parse_variable_tables(filename):
 
     lines = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':
@@ -211,7 +211,7 @@ def parse_variable_tables(filename):
         words = line.split()
         if len(words) > 1 and words[0].lower() in ['module', 'program'] and not words[1].lower() == 'procedure':
             module_name = words[1].strip()
-            if module_name in registry.keys():
+            if module_name in list(registry.keys()):
                 raise Exception('Duplicate module name {0}'.format(module_name))
             registry[module_name] = {}
             module_lines[module_name] = { 'startline' : line_counter }
@@ -227,7 +227,7 @@ def parse_variable_tables(filename):
         line_counter += 1
 
     # Parse each module in the file separately
-    for module_name in registry.keys():
+    for module_name in list(registry.keys()):
         startline = module_lines[module_name]['startline']
         endline = module_lines[module_name]['endline']
         line_counter = 0
@@ -283,7 +283,7 @@ def parse_variable_tables(filename):
                         raise Exception('Nested definitions of derived types not supported')
                     in_type = True
                     type_name = type_declaration[0]
-                    if type_name in registry[module_name].keys():
+                    if type_name in list(registry[module_name].keys()):
                         raise Exception('Duplicate derived type name {0} in module {1}'.format(
                                                                        type_name, module_name))
                     registry[module_name][type_name] = [current_line_number]
@@ -306,7 +306,7 @@ def parse_variable_tables(filename):
                 if in_table:
                     raise Exception('Encountered table start for table {0} while still in table {1}'.format(words[2].replace('arg_table_',''), table_name))
                 table_name = words[2].replace('arg_table_','')
-                if not (table_name == module_name or table_name in registry[module_name].keys()):
+                if not (table_name == module_name or table_name in list(registry[module_name].keys())):
                     raise Exception('Encountered table with name {0} without corresponding module or type name'.format(table_name))
                 in_table = True
                 header_line_number = current_line_number + 1
@@ -326,16 +326,16 @@ def parse_variable_tables(filename):
                             filename_parts = filename.split('.')
                             metadata_filename = '.'.join(filename_parts[0:len(filename_parts)-1]) + '.meta'
                             this_metadata = read_new_metadata(metadata_filename, module_name, table_name)
-                            for var_name in this_metadata.keys():
+                            for var_name in list(this_metadata.keys()):
                                 for var in this_metadata[var_name]:
-                                    if var_name in CCPP_MANDATORY_VARIABLES.keys() and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
+                                    if var_name in list(CCPP_MANDATORY_VARIABLES.keys()) and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
                                         raise Exception('Entry for variable {0}'.format(var_name) + \
                                                         ' in argument table {0}'.format(table_name) +\
                                                         ' is incompatible with mandatory variable:\n' +\
                                                         '    existing: {0}\n'.format(CCPP_MANDATORY_VARIABLES[var_name].print_debug()) +\
                                                         '     vs. new: {0}'.format(var.print_debug()))
                                     # Add variable to metadata dictionary
-                                    if not var_name in metadata.keys():
+                                    if not var_name in list(metadata.keys()):
                                         metadata[var_name] = [var]
                                     else:
                                         for existing_var in metadata[var_name]:
@@ -411,14 +411,14 @@ def parse_variable_tables(filename):
                                 container = encode_container(module_name, table_name)
                             var.container = container
                             # Check for incompatible definitions with CCPP mandatory variables
-                            if var_name in CCPP_MANDATORY_VARIABLES.keys() and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
+                            if var_name in list(CCPP_MANDATORY_VARIABLES.keys()) and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
                                 raise Exception('Entry for variable {0}'.format(var_name) + \
                                                 ' in argument table {0}'.format(table_name) +\
                                                 ' is incompatible with mandatory variable:\n' +\
                                                 '    existing: {0}\n'.format(CCPP_MANDATORY_VARIABLES[var_name].print_debug()) +\
                                                 '     vs. new: {0}'.format(var.print_debug()))
                             # Add variable to metadata dictionary
-                            if not var_name in metadata.keys():
+                            if not var_name in list(metadata.keys()):
                                 metadata[var_name] = [var]
                             else:
                                 for existing_var in metadata[var_name]:
@@ -436,26 +436,26 @@ def parse_variable_tables(filename):
             line_counter += 1
 
         # Informative output to screen
-        if debug and len(metadata.keys()) > 0:
-            for module_name in registry.keys():
+        if debug and len(list(metadata.keys())) > 0:
+            for module_name in list(registry.keys()):
                 logging.debug('Module name: {0}'.format(module_name))
                 container = encode_container(module_name)
                 vars_in_module = []
-                for var_name in metadata.keys():
+                for var_name in list(metadata.keys()):
                     for var in metadata[var_name]:
                         if var.container == container:
                             vars_in_module.append(var_name)
                 logging.debug('Module variables: {0}'.format(', '.join(vars_in_module)))
-                for type_name in registry[module_name].keys():
+                for type_name in list(registry[module_name].keys()):
                     container = encode_container(module_name, type_name)
                     vars_in_type = []
-                    for var_name in metadata.keys():
+                    for var_name in list(metadata.keys()):
                         for var in metadata[var_name]:
                             if var.container == container:
                                 vars_in_type.append(var_name)
                     logging.debug('Variables in derived type {0}: {1}'.format(type_name, ', '.join(vars_in_type)))
 
-        if len(metadata.keys()) > 0:
+        if len(list(metadata.keys())) > 0:
             logging.info('Parsed variable definition tables in module {0}'.format(module_name))
 
     return metadata
@@ -498,7 +498,7 @@ def parse_scheme_tables(filename):
     lines = []
     original_line_numbers = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':
@@ -523,7 +523,7 @@ def parse_scheme_tables(filename):
         words = line.split()
         if len(words) > 1 and words[0].lower() == 'module' and not words[1].lower() == 'procedure':
             module_name = words[1].strip()
-            if module_name in registry.keys():
+            if module_name in list(registry.keys()):
                 raise Exception('Duplicate module name {0}'.format(module_name))
             registry[module_name] = {}
             module_lines[module_name] = { 'startline' : line_counter }
@@ -539,7 +539,7 @@ def parse_scheme_tables(filename):
         line_counter += 1
 
     # Parse each module in the file separately
-    for module_name in registry.keys():
+    for module_name in list(registry.keys()):
         startline = module_lines[module_name]['startline']
         endline = module_lines[module_name]['endline']
         line_counter = 0
@@ -566,9 +566,9 @@ def parse_scheme_tables(filename):
                             if not scheme_name == module_name:
                                 raise Exception('Scheme name differs from module name: module_name="{0}" vs. scheme_name="{1}"'.format(
                                                                                                              module_name, scheme_name))
-                            if not scheme_name in registry[module_name].keys():
+                            if not scheme_name in list(registry[module_name].keys()):
                                 registry[module_name][scheme_name] = {}
-                            if subroutine_name in registry[module_name][scheme_name].keys():
+                            if subroutine_name in list(registry[module_name][scheme_name].keys()):
                                 raise Exception('Duplicate subroutine name {0} in module {1}'.format(
                                                                        subroutine_name, module_name))
                             registry[module_name][scheme_name][subroutine_name] = [current_line_number]
@@ -590,20 +590,20 @@ def parse_scheme_tables(filename):
             line_counter += 1
 
         # Check that for each registered subroutine the start and end lines were found
-        for scheme_name in registry[module_name].keys():
-            for subroutine_name in registry[module_name][scheme_name].keys():
+        for scheme_name in list(registry[module_name].keys()):
+            for subroutine_name in list(registry[module_name][scheme_name].keys()):
                 if not len(registry[module_name][scheme_name][subroutine_name]) == 2:
                     raise Exception('Error parsing start and end lines for subroutine {0} in module {1}'.format(subroutine_name, module_name))
         logging.debug('Parsing file {0} with registry {1}'.format(filename, registry))
 
-        for scheme_name in registry[module_name].keys():
-            for subroutine_name in registry[module_name][scheme_name].keys():
+        for scheme_name in list(registry[module_name].keys()):
+            for subroutine_name in list(registry[module_name][scheme_name].keys()):
                 # Record the order of variables in the call list to each subroutine in a list
-                if not module_name in arguments.keys():
+                if not module_name in list(arguments.keys()):
                     arguments[module_name] = {}
-                if not scheme_name in arguments[module_name].keys():
+                if not scheme_name in list(arguments[module_name].keys()):
                     arguments[module_name][scheme_name] = {}
-                if not subroutine_name in arguments[module_name][scheme_name].keys():
+                if not subroutine_name in list(arguments[module_name][scheme_name].keys()):
                     arguments[module_name][scheme_name][subroutine_name] = []
                 # Find the argument table corresponding to each subroutine by searching
                 # "upward" from the subroutine definition line for the "arg_table_SubroutineName" section
@@ -634,13 +634,13 @@ def parse_scheme_tables(filename):
                             metadata_filename = '.'.join(filename_parts[0:len(filename_parts)-1]) + '.meta'
                             this_metadata = read_new_metadata(metadata_filename, module_name, table_name,
                                                               scheme_name=scheme_name, subroutine_name=subroutine_name)
-                            for var_name in this_metadata.keys():
+                            for var_name in list(this_metadata.keys()):
                                 # Add standard_name to argument list for this subroutine
                                 arguments[module_name][scheme_name][subroutine_name].append(var_name)
                                 # For all instances of this var (can be only one) in this subroutine's metadata,
                                 # add to global metadata and check for compatibility with existing variables
                                 for var in this_metadata[var_name]:
-                                    if not var_name in metadata.keys():
+                                    if not var_name in list(metadata.keys()):
                                         metadata[var_name] = [var]
                                     else:
                                         for existing_var in metadata[var_name]:
@@ -714,7 +714,7 @@ def parse_scheme_tables(filename):
                             arguments[module_name][scheme_name][subroutine_name].append(var_name)
                             var = Var.from_table(table_header,var_items)
                             # Check for incompatible definitions with CCPP mandatory variables
-                            if var_name in CCPP_MANDATORY_VARIABLES.keys() and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
+                            if var_name in list(CCPP_MANDATORY_VARIABLES.keys()) and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
                                 raise Exception('Entry for variable {0}'.format(var_name) + \
                                                 ' in argument table of subroutine {0}'.format(subroutine_name) +\
                                                 ' is incompatible with mandatory variable:\n' +\
@@ -724,7 +724,7 @@ def parse_scheme_tables(filename):
                             container = encode_container(module_name, scheme_name, table_name)
                             var.container = container
                             # Add variable to metadata dictionary
-                            if not var_name in metadata.keys():
+                            if not var_name in list(metadata.keys()):
                                 metadata[var_name] = [var]
                             else:
                                 for existing_var in metadata[var_name]:
@@ -739,52 +739,52 @@ def parse_scheme_tables(filename):
                         line_number += 1
 
                     # After parsing entire metadata table for the subroutine, check that all mandatory CCPP variables are present
-                    for var_name in CCPP_MANDATORY_VARIABLES.keys():
+                    for var_name in list(CCPP_MANDATORY_VARIABLES.keys()):
                         if not var_name in arguments[module_name][scheme_name][subroutine_name]:
                             raise Exception('Mandatory CCPP variable {0} not declared in metadata table of subroutine {1}'.format(
                                                                                                        var_name, subroutine_name))
 
         # For CCPP-compliant files (i.e. files with metadata tables, perform additional checks)
-        if len(metadata.keys()) > 0:
+        if len(list(metadata.keys())) > 0:
             # Check that all subroutine "root" names in the current module are equal to scheme_name
             # and that there are exactly three subroutines for scheme X: X_init, X_run, X_finalize
             message = ''
             abort = False
-            for scheme_name in registry[module_name].keys():
+            for scheme_name in list(registry[module_name].keys()):
                 # Pre-generate error message
                 message += 'Check that all subroutines in module {0} have the same root name:\n'.format(module_name)
                 message += '    i.e. scheme_A_init, scheme_A_run, scheme_A_finalize\n'
                 message += 'Here is a list of the subroutine names for scheme {0}:\n'.format(scheme_name)
                 message += '{0}\n\n'.format(', '.join(sorted(registry[module_name][scheme_name].keys())))
-                if (not len(registry[module_name][scheme_name].keys()) == 3):
+                if (not len(list(registry[module_name][scheme_name].keys())) == 3):
                     logging.exception(message)
                     abort = True
                 else:
                     for suffix in subroutine_suffices:
                         subroutine_name = '{0}_{1}'.format(scheme_name, suffix)
-                        if not subroutine_name in registry[module_name][scheme_name].keys():
+                        if not subroutine_name in list(registry[module_name][scheme_name].keys()):
                             logging.exception(message)
                             abort = True
             if abort:
                 raise Exception(message)
 
         # Debugging output to screen and to XML
-        if debug and len(metadata.keys()) > 0:
+        if debug and len(list(metadata.keys())) > 0:
             # To screen
             logging.debug('Module name: {0}'.format(module_name))
-            for scheme_name in registry[module_name].keys():
+            for scheme_name in list(registry[module_name].keys()):
                 logging.debug('Scheme name: {0}'.format(scheme_name))
-                for subroutine_name in registry[module_name][scheme_name].keys():
+                for subroutine_name in list(registry[module_name][scheme_name].keys()):
                     container = encode_container(module_name, scheme_name, subroutine_name)
                     vars_in_subroutine = []
-                    for var_name in metadata.keys():
+                    for var_name in list(metadata.keys()):
                         for var in metadata[var_name]:
                             if var.container == container:
                                 vars_in_subroutine.append(var_name)
                     logging.debug('Variables in subroutine {0}: {1}'.format(subroutine_name, ', '.join(vars_in_subroutine)))
         # Standard output to screen
-        elif len(metadata.keys()) > 0:
-            for scheme_name in registry[module_name].keys():
+        elif len(list(metadata.keys())) > 0:
+            for scheme_name in list(registry[module_name].keys()):
                 logging.info('Parsed tables in scheme {0}'.format(scheme_name))
 
     # End of loop over all module_names

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -90,7 +90,7 @@ Notes on the input format:
 """
 
 # Python library imports
-from __future__ import print_function
+
 import os
 import re
 # CCPP framework imports
@@ -517,7 +517,7 @@ class MetadataHeader(ParseSource):
         mheaders = list()
         with open(filename, 'r') as file:
             fin_lines = file.readlines()
-            for index in xrange(len(fin_lines)):
+            for index in range(len(fin_lines)):
                 fin_lines[index] = fin_lines[index].rstrip('\n')
             # End for
         # End with

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -4,7 +4,7 @@
 #
 
 # Python library imports
-from __future__ import print_function
+
 import re
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
@@ -473,7 +473,7 @@ class Var(object):
         # End for
         # Make sure all the variable values are valid
         try:
-            for prop in self._prop_dict.keys():
+            for prop in list(self._prop_dict.keys()):
                 check = Var.get_prop(prop).valid_value(self._prop_dict[prop],
                                                        error=True)
             # End for
@@ -703,9 +703,9 @@ class Var(object):
         dimensions    = {dimensions} *
         kind          = {kind} *
 '''
-        if 'intent' in self.__spec_propdict.keys():
+        if 'intent' in list(self.__spec_propdict.keys()):
             str += '        intent        = {intent}\n'
-        if 'optional' in self.__spec_propdict.keys():
+        if 'optional' in list(self.__spec_propdict.keys()):
             str += '        optional      = {optional}\n'
         if self._context is not None:
             str += '        context       = {}'.format(self._context)
@@ -900,12 +900,12 @@ class VarDictionary(OrderedDict):
                 self.add_variable(var)
             # End for
         elif isinstance(variables, VarDictionary):
-            for stdname in variables.keys():
+            for stdname in list(variables.keys()):
                 self[stdname] = variables[stdname]
             # End for
         elif isinstance(variables, dict):
             # variables will not be in 'order', but we accept them anyway
-            for stdname in variables.keys():
+            for stdname in list(variables.keys()):
                 self[stdname] = variables[stdname]
             # End for
         elif variables is not None:
@@ -951,7 +951,7 @@ class VarDictionary(OrderedDict):
         else:
             vlist = list()
         # End if
-        for sn in self.keys():
+        for sn in list(self.keys()):
             var = self[sn]
             if self.include_var_in_list(var, std_vars=std_vars,
                                         loop_vars=loop_vars, consts=consts):
@@ -1017,7 +1017,7 @@ class VarDictionary(OrderedDict):
         std_vars are variables which are neither constants nor loop variables.
         '''
         plist = list()
-        for standard_name in self.keys():
+        for standard_name in list(self.keys()):
             var = self.find_variable(standard_name, any_scope=False, loop_subst=False)
             if self.include_var_in_list(var, std_vars=std_vars, loop_vars=loop_vars, consts=consts):
                 plist.append(self[standard_name].get_prop_value(prop_name))
@@ -1028,7 +1028,7 @@ class VarDictionary(OrderedDict):
     def declare_variables(self, outfile, indent,
                           std_vars=True, loop_vars=True, consts=True):
         "Write out the declarations for this dictionary's variables"
-        for standard_name in self.keys():
+        for standard_name in list(self.keys()):
             var = self.find_variable(standard_name, any_scope=False, loop_subst=False)
             if self.include_var_in_list(var, std_vars=std_vars, loop_vars=loop_vars, consts=consts):
                 self[standard_name].write_def(outfile, indent, self)
@@ -1042,7 +1042,7 @@ class VarDictionary(OrderedDict):
         # End for
 
     def __str__(self):
-        return "VarDictionary({}, {})".format(self.name, self.keys())
+        return "VarDictionary({}, {})".format(self.name, list(self.keys()))
 
     def __repr__(self):
         srepr = super(VarDictionary, self).__repr__()
@@ -1056,7 +1056,7 @@ class VarDictionary(OrderedDict):
 
     def __del__(self):
         try:
-            for key in self.keys():
+            for key in list(self.keys()):
                 del self[key]
             # End for
         except Exception as e:

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -4,7 +4,7 @@
 # from a scheme xml file.
 #
 
-from __future__ import print_function
+
 import copy
 import logging
 import os
@@ -35,7 +35,7 @@ class Var(object):
         self._optional      = None
         self._target        = None
         self._actions       = { 'in' : None, 'out' : None }
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     @property
@@ -154,7 +154,7 @@ class Var(object):
     @actions.setter
     def actions(self, values):
         if type(value)==dict:
-            for key in values.keys():
+            for key in list(values.keys()):
                 if key in ['in', 'out'] and isstring(values[key]):
                     self._actions[key] = values[key]
                 else:
@@ -506,7 +506,7 @@ module {module}_cap
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, module, data, ccpp_field_map, metadata_define):
@@ -518,18 +518,18 @@ module {module}_cap
         else:
             f = sys.stdout
 
-        subs = ','.join(["{0}".format(s) for s in data.keys()])
-        sub_caps = ','.join(["{0}_cap".format(s) for s in data.keys()])
+        subs = ','.join(["{0}".format(s) for s in list(data.keys())])
+        sub_caps = ','.join(["{0}_cap".format(s) for s in list(data.keys())])
 
         # Import variable type definitions for all subroutines (init, run, finalize)
         module_use = []
         local_kind_and_type_vars = []
-        for sub in data.keys():
+        for sub in list(data.keys()):
             for var in data[sub]:
                 if var.type in STANDARD_VARIABLE_TYPES and var.kind and not var.type == STANDARD_CHARACTER_TYPE:
                     kind_var_standard_name = var.kind
                     if not kind_var_standard_name in local_kind_and_type_vars:
-                        if not kind_var_standard_name in metadata_define.keys():
+                        if not kind_var_standard_name in list(metadata_define.keys()):
                             raise Exception("Kind {kind} not defined by host model".format(kind=kind_var_standard_name))
                         kind_var = metadata_define[kind_var_standard_name][0]
                         module_use.append(kind_var.print_module_use())
@@ -537,7 +537,7 @@ module {module}_cap
                 elif not var.type in STANDARD_VARIABLE_TYPES:
                     type_var_standard_name = var.type
                     if not type_var_standard_name in local_kind_and_type_vars:
-                        if not type_var_standard_name in metadata_define.keys():
+                        if not type_var_standard_name in list(metadata_define.keys()):
                             raise Exception("Type {type} not defined by host model".format(type=type_var_standard_name))
                         type_var = metadata_define[type_var_standard_name][0]
                         module_use.append(type_var.print_module_use())
@@ -549,13 +549,13 @@ module {module}_cap
                                   subroutines = subs,
                                   subroutine_caps = sub_caps))
 
-        for sub in data.keys():
+        for sub in list(data.keys()):
             # Treat CCPP internal variables differently: do not retrieve
             # via ccpp_field_get, use them directly via cdata%...
             # (configured in common.py, needs to match what is is ccpp_types.F90)
-            var_defs = "\n".join([" "*8 + x.print_def_pointer() for x in data[sub] if x.standard_name not in CCPP_INTERNAL_VARIABLES.keys()])
+            var_defs = "\n".join([" "*8 + x.print_def_pointer() for x in data[sub] if x.standard_name not in list(CCPP_INTERNAL_VARIABLES.keys())])
             # Use lookup index in cdata from build time for faster retrieval
-            var_gets = "\n".join([x.print_get(ccpp_field_map[x.standard_name]) for x in data[sub]if x.standard_name not in CCPP_INTERNAL_VARIABLES.keys()])
+            var_gets = "\n".join([x.print_get(ccpp_field_map[x.standard_name]) for x in data[sub]if x.standard_name not in list(CCPP_INTERNAL_VARIABLES.keys())])
             # Generate unit conversion statements on input and output. Special handling for
             # unit conversions for intent(in) variables, these don't require defining a
             # temporary variable, instead just pass the conversion function as argument
@@ -585,9 +585,9 @@ module {module}_cap
             args = ''
             length = 0
             for x in data[sub]:
-                if x.standard_name in CCPP_INTERNAL_VARIABLES.keys():
+                if x.standard_name in list(CCPP_INTERNAL_VARIABLES.keys()):
                     arg = "{0}={1},".format(x.local_name, CCPP_INTERNAL_VARIABLES[x.standard_name])
-                elif x.local_name in tmpvars.keys():
+                elif x.local_name in list(tmpvars.keys()):
                     arg = "{0}={1},".format(x.local_name, tmpvars[x.local_name])
                 elif x.actions['in'] and not x.actions['out']:
                     action = x.actions['in'].format(var=x.local_name, kind='_' + x.kind if x.kind else '')
@@ -640,7 +640,7 @@ CAPS_F90 ='''
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, caps):
@@ -681,7 +681,7 @@ set(CAPS
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, schemes):
@@ -722,7 +722,7 @@ export CCPP_CAPS="'''
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, schemes):
@@ -771,7 +771,7 @@ SCHEMES_f90 ='''
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, schemes):
@@ -830,7 +830,7 @@ set(SCHEMES
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, schemes):
@@ -874,7 +874,7 @@ export CCPP_SCHEMES="'''
 
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, schemes):

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -83,7 +83,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
     shading = { 0 : 'darkgray', 1 : 'lightgray' }
     success = True
 
-    var_names = sorted(list(set(metadata_define.keys() + metadata_request.keys())))
+    var_names = sorted(list(set(list(metadata_define.keys()) + list(metadata_request.keys()))))
 
     latex = '''\\documentclass[12pt,letterpaper,oneside,landscape]{{scrbook}}
 
@@ -99,7 +99,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
 \\begin{{longtable}}{{l}}'''.format(model=model)
 
     for var_name in var_names:
-        if var_name in metadata_define.keys():
+        if var_name in list(metadata_define.keys()):
             var = metadata_define[var_name][0]
         else:
             var = metadata_request[var_name][0]
@@ -115,7 +115,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
 '''
 
     for var_name in var_names:
-        if var_name in metadata_define.keys():
+        if var_name in list(metadata_define.keys()):
             var = metadata_define[var_name][0]
             target = escape_tex(decode_container(var.container))
             local_name = escape_tex(var.local_name)
@@ -123,16 +123,16 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
             var = metadata_request[var_name][0]
             target = 'MISSING'
             local_name = 'MISSING'
-        if var_name in metadata_request.keys():
+        if var_name in list(metadata_request.keys()):
             requested_list = [ escape_tex(decode_container(v.container)) for v in metadata_request[var_name] ]
             # for the purpose of the table, just output the name of the subroutine
-            for i in xrange(len(requested_list)):
+            for i in range(len(requested_list)):
                 entry = requested_list[i]
                 requested_list[i] = entry[entry.find('SUBROUTINE')+len('SUBROUTINE')+1:]
             requested = '\\newline '.join(sorted(requested_list))
         else:
             requested = 'NOT REQUESTED'
-        if var_name in pset_request.keys():
+        if var_name in list(pset_request.keys()):
             pset_list = [ escape_tex(c) for c in pset_request[var_name] ]
             pset = '\\newline '.join(sorted(pset_list))
         else:

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -37,7 +37,7 @@ def extract_parents_and_indices_from_local_name(local_name):
     # First, extract all variables/indices in parentheses (used for subsetting)
     indices = []
     while '(' in local_name:
-        for i in xrange(len(local_name)):
+        for i in range(len(local_name)):
             if local_name[i] == '(':
                 last_open = i
             elif local_name[i] == ')':
@@ -106,7 +106,7 @@ def create_arguments_module_use_var_defs(variable_dictionary, metadata_define, t
     module_use = []
     var_defs = []
     local_kind_and_type_vars = []
-    for standard_name in variable_dictionary.keys():
+    for standard_name in list(variable_dictionary.keys()):
         # Add variable local name and variable definitions
         arguments.append(variable_dictionary[standard_name].local_name)
         var_defs.append(variable_dictionary[standard_name].print_def_intent())
@@ -115,7 +115,7 @@ def create_arguments_module_use_var_defs(variable_dictionary, metadata_define, t
                 and not variable_dictionary[standard_name].type == STANDARD_CHARACTER_TYPE:
             kind_var_standard_name = variable_dictionary[standard_name].kind
             if not kind_var_standard_name in local_kind_and_type_vars:
-                if not kind_var_standard_name in metadata_define.keys():
+                if not kind_var_standard_name in list(metadata_define.keys()):
                     raise Exception("Kind {kind} not defined by host model".format(kind=kind_var_standard_name))
                 kind_var = metadata_define[kind_var_standard_name][0]
                 module_use.append(kind_var.print_module_use())
@@ -123,7 +123,7 @@ def create_arguments_module_use_var_defs(variable_dictionary, metadata_define, t
         elif not variable_dictionary[standard_name].type in STANDARD_VARIABLE_TYPES:
             type_var_standard_name = variable_dictionary[standard_name].type
             if not type_var_standard_name in local_kind_and_type_vars:
-                if not type_var_standard_name in metadata_define.keys():
+                if not type_var_standard_name in list(metadata_define.keys()):
                     raise Exception("Type {type} not defined by host model".format(type=type_var_standard_name))
                 type_var = metadata_define[type_var_standard_name][0]
                 module_use.append(type_var.print_module_use())
@@ -203,7 +203,7 @@ end module {module}
         self._subroutines = None
         self._suites      = []
         self._directory   = '.'
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     @property
@@ -257,7 +257,7 @@ end module {module}
         parent_standard_names = []
         for ccpp_stage in CCPP_STAGES:
             for suite in suites:
-                for parent_standard_name in suite.parents[ccpp_stage].keys():
+                for parent_standard_name in list(suite.parents[ccpp_stage].keys()):
                     if not parent_standard_name in parent_standard_names:
                         parent_var = suite.parents[ccpp_stage][parent_standard_name]
                         # Identify which variable is of type CCPP_TYPE (need local name)
@@ -434,7 +434,7 @@ end module {module}
         self._subroutines = None
         self._parents = { ccpp_stage : {} for ccpp_stage in CCPP_STAGES }
         self._arguments = { ccpp_stage : [] for ccpp_stage in CCPP_STAGES }
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     @property
@@ -512,10 +512,10 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the suite.'''
-        print "ALL SUBROUTINES:"
-        print self._all_subroutines_called
-        print "STRUCTURED:"
-        print self._groups
+        print("ALL SUBROUTINES:")
+        print(self._all_subroutines_called)
+        print("STRUCTURED:")
+        print(self._groups)
         for group in self._groups:
             group.print_debug()
 
@@ -584,7 +584,7 @@ end module {module}
             for subroutine in group.subroutines:
                 module_use += '   use {m}, only: {s}\n'.format(m=group.module, s=subroutine)
             for ccpp_stage in CCPP_STAGES:
-                for parent_standard_name in group.parents[ccpp_stage].keys():
+                for parent_standard_name in list(group.parents[ccpp_stage].keys()):
                     if parent_standard_name in self.parents[ccpp_stage]:
                         if self.parents[ccpp_stage][parent_standard_name].intent == 'in' and \
                             not group.parents[ccpp_stage][parent_standard_name].intent == 'in':
@@ -743,13 +743,13 @@ end module {module}
         self._pset = None
         self._parents = { ccpp_stage : {} for ccpp_stage in CCPP_STAGES }
         self._arguments = { ccpp_stage : [] for ccpp_stage in CCPP_STAGES }
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     def write(self, metadata_request, metadata_define, arguments):
         # Create an inverse lookup table of local variable names defined (by the host model) and standard names
         standard_name_by_local_name_define = {}
-        for standard_name in metadata_define.keys():
+        for standard_name in list(metadata_define.keys()):
             standard_name_by_local_name_define[metadata_define[standard_name][0].local_name] = standard_name
 
         # First get target names of standard CCPP variables for subcycling and error handling
@@ -805,8 +805,8 @@ end module {module}
                         for var in metadata_request[var_standard_name]:
                             if container == var.container:
                                 break
-                        if not var_standard_name in local_vars.keys():
-                            if not var_standard_name in metadata_define.keys():
+                        if not var_standard_name in list(local_vars.keys()):
+                            if not var_standard_name in list(metadata_define.keys()):
                                 raise Exception('Variable {standard_name} not defined in host model metadata'.format(
                                                                                     standard_name=var_standard_name))
                             var_local_name_define = metadata_define[var_standard_name][0].local_name
@@ -827,13 +827,13 @@ end module {module}
                             for local_name_define in [parent_local_name_define] + parent_local_names_define_indices:
                                 parent_standard_name = None
                                 parent_var = None
-                                for i in xrange(FORTRAN_ARRAY_MAX_DIMS+1):
+                                for i in range(FORTRAN_ARRAY_MAX_DIMS+1):
                                     if i==0:
                                         dims_string = ''
                                     else:
                                         # (:) for i==1, (:,:) for i==2, ...
-                                        dims_string = '(' + ','.join([':' for j in xrange(i)]) + ')'
-                                    if local_name_define+dims_string in standard_name_by_local_name_define.keys():
+                                        dims_string = '(' + ','.join([':' for j in range(i)]) + ')'
+                                    if local_name_define+dims_string in list(standard_name_by_local_name_define.keys()):
                                         parent_standard_name = standard_name_by_local_name_define[local_name_define+dims_string]
                                         parent_var = metadata_define[parent_standard_name][0]
                                         break
@@ -850,7 +850,7 @@ end module {module}
                                 # Add variable to dictionary of parent variables, if not already there.
                                 # Set or update intent, depending on whether the variable is an index
                                 # in var_local_name_define or the actual parent of that variable.
-                                if not parent_standard_name in self.parents[ccpp_stage].keys():
+                                if not parent_standard_name in list(self.parents[ccpp_stage].keys()):
                                     self.parents[ccpp_stage][parent_standard_name] = copy.deepcopy(parent_var)
                                     # Copy the intent of the actual variable being processed
                                     if local_name_define == parent_local_name_define:
@@ -891,7 +891,7 @@ end module {module}
                         # Add necessary actions before/after while populating the subroutine's argument list
                         kind_string = '_' + local_vars[var_standard_name]['kind'] if local_vars[var_standard_name]['kind'] else ''
                         if var.actions['out']:
-                            if local_vars[var_standard_name]['name'] in tmpvars.keys():
+                            if local_vars[var_standard_name]['name'] in list(tmpvars.keys()):
                                 # If the variable already has a local variable (tmpvar), reuse it
                                 tmpvar = tmpvars[local_vars[var_standard_name]['name']]
                             else:
@@ -964,7 +964,7 @@ end module {module}
 
             # Get list of arguments, module use statement and variable definitions for this subroutine (=stage for the group)
             (self.arguments[ccpp_stage], sub_module_use, sub_var_defs) = create_arguments_module_use_var_defs(
-                                                           self.parents[ccpp_stage], metadata_define, tmpvars.values())
+                                                           self.parents[ccpp_stage], metadata_define, list(tmpvars.values()))
             sub_argument_list = create_argument_list_wrapped(self.arguments[ccpp_stage])
 
             subroutine = self._suite + '_' + self._name + '_' + ccpp_stage + '_cap'
@@ -1028,7 +1028,7 @@ end module {module}
 
     @init.setter
     def init(self, value):
-        if not type(value) == types.BooleanType:
+        if not type(value) == bool:
             raise Exception("Invalid type {0} of argument value, boolean expected".format(type(value)))
         self._init = value
 
@@ -1039,7 +1039,7 @@ end module {module}
 
     @finalize.setter
     def finalize(self, value):
-        if not type(value) == types.BooleanType:
+        if not type(value) == bool:
             raise Exception("Invalid type {0} of argument value, boolean expected".format(type(value)))
         self._finalize = value
 
@@ -1065,7 +1065,7 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the group.'''
-        print self._name
+        print(self._name)
         for subcycle in self._subcycles:
             subcycle.print_debug()
 
@@ -1102,7 +1102,7 @@ class Subcycle(object):
     def __init__(self, **kwargs):
         self._filename = 'sys.stdout'
         self._schemes = None
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(self, "_"+key, value)
 
     @property
@@ -1129,9 +1129,9 @@ class Subcycle(object):
 
     def print_debug(self):
         '''Basic debugging output about the subcycle.'''
-        print self._loop
+        print(self._loop)
         for scheme in self._schemes:
-            print scheme
+            print(scheme)
 
 
 ###############################################################################

--- a/scripts/parse_tools/__init__.py
+++ b/scripts/parse_tools/__init__.py
@@ -28,20 +28,20 @@ __all__ = [
     'setLogToStdout',
 ]
 
-from parse_source   import ParseContext, ParseSource
-from parse_source   import ParseSyntaxError, ParseInternalError
-from parse_source   import CCPPError, context_string
-from parse_object   import ParseObject
-from parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
-from parse_checkers import FORTRAN_DP_RE
-from parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
-from parse_checkers import check_fortran_intrinsic
-from parse_checkers import check_fortran_type, check_balanced_paren
-from parse_checkers import registered_fortran_ddt_name
-from parse_checkers import register_fortran_ddt_name
-from parse_checkers import check_dimensions, check_cf_standard_name
-from parse_log      import init_log, set_log_level
-from parse_log      import set_log_to_stdout, set_log_to_null
-from parse_log      import set_log_to_file
-from preprocess     import PreprocStack
+from .parse_source   import ParseContext, ParseSource
+from .parse_source   import ParseSyntaxError, ParseInternalError
+from .parse_source   import CCPPError, context_string
+from .parse_object   import ParseObject
+from .parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
+from .parse_checkers import FORTRAN_DP_RE
+from .parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
+from .parse_checkers import check_fortran_intrinsic
+from .parse_checkers import check_fortran_type, check_balanced_paren
+from .parse_checkers import registered_fortran_ddt_name
+from .parse_checkers import register_fortran_ddt_name
+from .parse_checkers import check_dimensions, check_cf_standard_name
+from .parse_log      import init_log, set_log_level
+from .parse_log      import set_log_to_stdout, set_log_to_null
+from .parse_log      import set_log_to_file
+from .preprocess     import PreprocStack
 # End if

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -5,7 +5,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source import CCPPError
+from .parse_source import CCPPError
 
 ########################################################################
 

--- a/scripts/parse_tools/parse_object.py
+++ b/scripts/parse_tools/parse_object.py
@@ -4,7 +4,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source    import ParseContext, CCPPError
+from .parse_source    import ParseContext, CCPPError
 
 ########################################################################
 

--- a/scripts/parse_tools/preprocess.py
+++ b/scripts/parse_tools/preprocess.py
@@ -83,7 +83,7 @@ def preproc_item_value(item, preproc_defs):
     elif isinstance(item, ast.Compare):
         left_val = preproc_item_value(item.left, preproc_defs)
         value = True
-        for index in xrange(len(item.ops)):
+        for index in range(len(item.ops)):
             op = item.ops[index]
             rcomp = item.comparators[index]
             right_val = preproc_item_value(rcomp, preproc_defs)


### PR DESCRIPTION
The existing code base ran on Python 2, which is no longer supported as of December 31st 2019. I've converted the code base to use Python 3 using an automatic conversion tool. I've looked over the changes and they all appear sane, and I've been able to use the prebuild tool without issue on Python 3.

This PR would break support for Python 2.