### PR TITLE
dtc/develop: correct log message for automated unit conversions

### DIFF
--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -185,7 +185,7 @@ class Var(object):
         function_name = '{0}__to__{1}'.format(string_to_python_identifier(self.units), string_to_python_identifier(units))
         try:
             function = getattr(unit_conversion, function_name)
-            logging.info('Automatic unit conversion from {0} to {1} for {2} before entering {3}'.format(self.units, units, self.standard_name, self.container))
+            logging.info('Automatic unit conversion from {0} to {1} for {2} after returning from {3}'.format(self.units, units, self.standard_name, self.container))
         except AttributeError:
             raise Exception('Error, automatic unit conversion from {0} to {1} for {2} in {3} not implemented'.format(self.units, units, self.standard_name, self.container))
         conversion = function()
@@ -196,7 +196,7 @@ class Var(object):
         function_name = '{1}__to__{0}'.format(string_to_python_identifier(self.units), string_to_python_identifier(units))
         try:
             function = getattr(unit_conversion, function_name)
-            logging.info('Automatic unit conversion from {0} to {1} for {2} after returning from {3}'.format(self.units, units, self.standard_name, self.container))
+            logging.info('Automatic unit conversion from {0} to {1} for {2} before entering {3}'.format(self.units, units, self.standard_name, self.container))
         except AttributeError:
             raise Exception('Error, automatic unit conversion from {1} to {0} for {2} in {3} not implemented'.format(self.units, units, self.standard_name, self.container))
         conversion = function()


### PR DESCRIPTION
`scripts/mkcap.py`: change the log message to match the logic for automated unit conversions in `ccpp_prebuild.py`.

`ccpp_prebuild.py`:
```
...
            # Register conversion, depending on the intent for this subroutine.
            if var.intent=='inout':
                var.convert_from(metadata_define[var_name][0].units)
                var.convert_to(metadata_define[var_name][0].units)
            elif var.intent=='in':
                var.convert_from(metadata_define[var_name][0].units)
            elif var.intent=='out':
                var.convert_to(metadata_define[var_name][0].units)
...
```
This means that `convert_to` should say "after returning from" and `convert_from` should say "before entering" (and not vice versa).

This can be merged anytime.