### PR TITLE
dtc/develop: combined PR with bugfixes for ccpp_prebuild.py

### DIFF
--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -158,7 +158,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                       container     = container,
                       kind          = new_var.get_prop_value('kind'),
                       intent        = new_var.get_prop_value('intent'),
-                      optional      = new_var.get_prop_value('optional'),
+                      optional      = 'T' if new_var.get_prop_value('optional') else 'F',
                       )
             # Set rank using integer-setter method
             var.rank = rank

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -185,7 +185,7 @@ class Var(object):
         function_name = '{0}__to__{1}'.format(string_to_python_identifier(self.units), string_to_python_identifier(units))
         try:
             function = getattr(unit_conversion, function_name)
-            logging.info('Automatic unit conversion from {0} to {1} for {2} before entering {3}'.format(self.units, units, self.standard_name, self.container))
+            logging.info('Automatic unit conversion from {0} to {1} for {2} after returning from {3}'.format(self.units, units, self.standard_name, self.container))
         except AttributeError:
             raise Exception('Error, automatic unit conversion from {0} to {1} for {2} in {3} not implemented'.format(self.units, units, self.standard_name, self.container))
         conversion = function()
@@ -196,7 +196,7 @@ class Var(object):
         function_name = '{1}__to__{0}'.format(string_to_python_identifier(self.units), string_to_python_identifier(units))
         try:
             function = getattr(unit_conversion, function_name)
-            logging.info('Automatic unit conversion from {0} to {1} for {2} after returning from {3}'.format(self.units, units, self.standard_name, self.container))
+            logging.info('Automatic unit conversion from {0} to {1} for {2} before entering {3}'.format(self.units, units, self.standard_name, self.container))
         except AttributeError:
             raise Exception('Error, automatic unit conversion from {1} to {0} for {2} in {3} not implemented'.format(self.units, units, self.standard_name, self.container))
         conversion = function()


### PR DESCRIPTION
This PR contains the following PRs:

#252, correct log message for automated unit conversions
#254, bugfix for converting optional attribute from new metadata for ccpp_prebuild.py.

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/260
https://github.com/NCAR/ccpp-physics/pull/394
https://github.com/NCAR/fv3atm/pull/25
https://github.com/NCAR/ufs-weather-model/pull/21

See https://github.com/NCAR/ufs-weather-model/pull/21 for regression testing information.