### PR TITLE
CMake Policy 0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ if(POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
 endif(POLICY CMP0042)
 
+#Setting this policy was required when building with the SCM. Without it, the
+#    STATIC cmake variable was getting cleared, making this CMakeLists.txt 
+#    assume a dynamic build.
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif(POLICY CMP0077)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if(POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
 endif(POLICY CMP0042)
 
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif(POLICY CMP0077)
+
 #------------------------------------------------------------------------------
 # Enable Fortran
 enable_language(Fortran)


### PR DESCRIPTION
set a value for cmake policy 0077 in order to not reset the STATIC variable within CMakeLists.txt when building with the SCM

needed for https://github.com/NCAR/gmtb-scm/pull/176