### PR TITLE
RRTMGP in CCPP (updates to ccpp_prebuild.py)

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -839,7 +839,7 @@ def main():
         raise Exception('Call to generate_typedefs_makefile failed.')
 
     # Add filenames of schemes to makefile/cmakefile/shell script - add dependencies for schemes
-    success = generate_schemes_makefile(config['scheme_files_dependencies'] + config['scheme_files'].keys(),
+    success = generate_schemes_makefile(config['scheme_files_dependencies'] + list(config['scheme_files'].keys()),
                                         config['schemes_makefile'], config['schemes_cmakefile'],
                                         config['schemes_sourcefile'])
     if not success:

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -13,10 +13,12 @@ import sys
 # CCPP framework imports
 from common import encode_container, decode_container, decode_container_as_dict, execute
 from common import CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE, CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
+from common import STANDARD_VARIABLE_TYPES, STANDARD_INTEGER_TYPE, CCPP_TYPE
 from common import split_var_name_and_array_reference
 from metadata_parser import merge_dictionaries, parse_scheme_tables, parse_variable_tables
 from mkcap import Cap, CapsMakefile, CapsCMakefile, CapsSourcefile, \
-                  SchemesMakefile, SchemesCMakefile, SchemesSourcefile
+                  SchemesMakefile, SchemesCMakefile, SchemesSourcefile, \
+                  TypedefsMakefile, TypedefsCMakefile, TypedefsSourcefile
 from mkdoc import metadata_to_html, metadata_to_latex
 from mkstatic import API, Suite, Group
 
@@ -80,6 +82,9 @@ def import_config(configfile, builddir):
 
     # Definitions in host-model dependent CCPP prebuild config script
     config['variable_definition_files'] = ccpp_prebuild_config.VARIABLE_DEFINITION_FILES
+    config['typedefs_makefile']         = ccpp_prebuild_config.TYPEDEFS_MAKEFILE.format(build_dir=builddir)
+    config['typedefs_cmakefile']        = ccpp_prebuild_config.TYPEDEFS_CMAKEFILE.format(build_dir=builddir)
+    config['typedefs_sourcefile']       = ccpp_prebuild_config.TYPEDEFS_SOURCEFILE.format(build_dir=builddir)
     config['scheme_files']              = ccpp_prebuild_config.SCHEME_FILES
     config['scheme_files_dependencies'] = ccpp_prebuild_config.SCHEME_FILES_DEPENDENCIES
     config['schemes_makefile']          = ccpp_prebuild_config.SCHEMES_MAKEFILE.format(build_dir=builddir)
@@ -629,6 +634,63 @@ def generate_static_api(suites, static_api_dir):
     os.chdir(BASEDIR)
     return (success, api)
 
+def generate_typedefs_makefile(metadata_define, typedefs_makefile, typedefs_cmakefile, typedefs_sourcefile):
+    """Generate list of Fortran modules containing CCPP type/kind definitions,
+       and create makefile/cmakefile snippets for host model build system"""
+    logging.info('Generating list of Fortran modules containing CCPP type definitions ...')
+    success = True
+    #
+    typedefs = []
+    # (1) Search for type definitions in the metadata, defined by:
+    #    (a) the type not being a standard type, and
+    #    (b) the type not being the CCPP framework internal type
+    #    (c) the standard_name being identical to the type name
+    # (2) Search for kind definitions in the metadata, defined by:
+    #    (a) the standard_name starting with "kind_"
+    #    (b) the type being integer and the units being none
+    for key in metadata_define.keys():
+        # derived data types
+        if not metadata_define[key][0].type in STANDARD_VARIABLE_TYPES and \
+                not metadata_define[key][0].type == CCPP_TYPE and \
+                metadata_define[key][0].type == metadata_define[key][0].standard_name:
+            container = decode_container_as_dict(metadata_define[key][0].container)
+            if not 'MODULE' in container.keys():
+                logging.error("Invalid type definition for type {}: {}".format(metadata_define[key][0].type, metadata_define[key][0].print_debug()))
+                success = False
+                continue
+            # Fortran modules are lowercase and have the ending ".mod"
+            typedef_fortran_module = "{}.mod".format(container['MODULE']).lower()
+            if not typedef_fortran_module in typedefs:
+                typedefs.append(typedef_fortran_module)
+        # kind definitions
+        elif metadata_define[key][0].standard_name.startswith("kind_") and \
+                metadata_define[key][0].type == STANDARD_INTEGER_TYPE and \
+                metadata_define[key][0].units == 'none':
+            container = decode_container_as_dict(metadata_define[key][0].container)
+            if not 'MODULE' in container.keys():
+                logging.error("Invalid kind definition for kind {}: {}".format(metadata_define[key][0].type, metadata_define[key][0].print_debug()))
+                success = False
+                continue
+            # Fortran modules are lowercase and have the ending ".mod"
+            typedef_fortran_module = "{}.mod".format(container['MODULE']).lower()
+            if not typedef_fortran_module in typedefs:
+                typedefs.append(typedef_fortran_module)
+
+    logging.info('Generating typedefs makefile/cmakefile snippet ...')
+    # Write the Fortran modules without path - the build system knows where they are
+    makefile = TypedefsMakefile()
+    makefile.filename = typedefs_makefile
+    cmakefile = TypedefsCMakefile()
+    cmakefile.filename = typedefs_cmakefile
+    sourcefile = TypedefsSourcefile()
+    sourcefile.filename = typedefs_sourcefile
+    makefile.write(typedefs)
+    cmakefile.write(typedefs)
+    sourcefile.write(typedefs)
+    logging.info('Added {0} typedefs to {1}, {2}, {3}'.format(
+           len(typedefs), makefile.filename, cmakefile.filename, sourcefile.filename))
+    return success
+
 def generate_schemes_makefile(schemes, schemes_makefile, schemes_cmakefile, schemes_sourcefile):
     """Generate makefile/cmakefile snippets for all schemes."""
     logging.info('Generating schemes makefile/cmakefile snippet ...')
@@ -639,20 +701,13 @@ def generate_schemes_makefile(schemes, schemes_makefile, schemes_cmakefile, sche
     cmakefile.filename = schemes_cmakefile
     sourcefile = SchemesSourcefile()
     sourcefile.filename = schemes_sourcefile
-    # Adjust relative file path to schemes from caps makefile
-    schemes_with_path = []
-    schemes_with_abspath = []
-    schemes_makefile_dir = os.path.split(os.path.abspath(schemes_makefile))[0]
-    for scheme in schemes:
-        (scheme_filepath, scheme_filename) = os.path.split(os.path.abspath(scheme))
-        relative_path = './{0}'.format(os.path.relpath(scheme_filepath, schemes_makefile_dir))
-        schemes_with_path.append(os.path.join(relative_path, scheme_filename))
-        schemes_with_abspath.append(os.path.abspath(scheme))
+    # Generate list of schemes with absolute path
+    schemes_with_abspath = [ os.path.abspath(scheme) for scheme in schemes ]
     makefile.write(schemes_with_abspath)
     cmakefile.write(schemes_with_abspath)
     sourcefile.write(schemes_with_abspath)
     logging.info('Added {0} schemes to {1}, {2}, {3}'.format(
-           len(schemes_with_path), makefile.filename, cmakefile.filename, sourcefile.filename))
+           len(schemes_with_abspath), makefile.filename, cmakefile.filename, sourcefile.filename))
     return success
 
 def generate_caps_makefile(caps, caps_makefile, caps_cmakefile, caps_sourcefile, caps_dir):
@@ -665,16 +720,13 @@ def generate_caps_makefile(caps, caps_makefile, caps_cmakefile, caps_sourcefile,
     cmakefile.filename = caps_cmakefile
     sourcefile = CapsSourcefile()
     sourcefile.filename = caps_sourcefile
-    # Adjust relative file path to schemes from caps makefile
-    caps_makefile_dir = os.path.split(os.path.abspath(caps_makefile))[0]
-    relative_path = './{0}'.format(os.path.relpath(caps_dir, caps_makefile_dir))
-    caps_with_path = [ os.path.join(relative_path, cap) for cap in caps]
-    caps_with_abspath = [ os.path.abspath(os.path.join(caps_dir, cap)) for cap in caps]
+    # Generate list of caps with absolute path
+    caps_with_abspath = [ os.path.abspath(os.path.join(caps_dir, cap)) for cap in caps ]
     makefile.write(caps_with_abspath)
     cmakefile.write(caps_with_abspath)
     sourcefile.write(caps_with_abspath)
-    logging.info('Added {0} auto-generated caps to {1} and {2}'.format(
-                          len(caps_with_path), makefile.filename, cmakefile.filename))
+    logging.info('Added {0} auto-generated caps to {1} and {2}, {3}'.format(
+           len(caps_with_abspath), makefile.filename, cmakefile.filename, sourcefile.filename))
     return success
 
 def main():
@@ -780,7 +832,13 @@ def main():
             if not success:
                 raise Exception('Call to generate_include_files failed.')
 
-    # Add filenames of schemes to makefile - add dependencies for schemes
+    # Add Fortran module files of typedefs to makefile/cmakefile/shell script
+    success = generate_typedefs_makefile(metadata_define, config['typedefs_makefile'],
+                                         config['typedefs_cmakefile'], config['typedefs_sourcefile'])
+    if not success:
+        raise Exception('Call to generate_typedefs_makefile failed.')
+
+    # Add filenames of schemes to makefile/cmakefile/shell script - add dependencies for schemes
     success = generate_schemes_makefile(config['scheme_files_dependencies'] + config['scheme_files'].keys(),
                                         config['schemes_makefile'], config['schemes_cmakefile'],
                                         config['schemes_sourcefile'])
@@ -808,7 +866,7 @@ def main():
         if not success:
             raise Exception('Call to generate_scheme_caps failed.')
 
-    # Add filenames of caps to makefile
+    # Add filenames of caps to makefile/cmakefile/shell script
     if static:
         all_caps = suite_and_group_caps
     else:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -33,8 +33,9 @@ CCPP_INTERNAL_VARIABLES = {
     CCPP_THREAD_NUMBER       : 'cdata%thrd_no',
     }
 
-STANDARD_VARIABLE_TYPES = [ 'character', 'integer', 'logical', 'real' ]
 STANDARD_CHARACTER_TYPE = 'character'
+STANDARD_INTEGER_TYPE = 'integer'
+STANDARD_VARIABLE_TYPES = [ STANDARD_CHARACTER_TYPE, STANDARD_INTEGER_TYPE, 'logical', 'real' ]
 
 # For static build
 CCPP_STATIC_API_MODULE = 'ccpp_static_api'

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -127,7 +127,7 @@ def decode_container(container):
     items = container.split(' ')
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         items[i] = items[i][:items[i].find('_')] + ' ' + items[i][items[i].find('_')+1:]
     return ' '.join(items)
 
@@ -140,7 +140,7 @@ def decode_container_as_dict(container):
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
     itemsdict = {}
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         key, value = (items[i][:items[i].find('_')], items[i][items[i].find('_')+1:])
         itemsdict[key] = value
     return itemsdict

--- a/scripts/conversion_tools/__init__.py
+++ b/scripts/conversion_tools/__init__.py
@@ -2,7 +2,49 @@
 """
 
 __all__ = [
-    'units',
+    'mm__to__m',
+    'm__to__mm',
+    'um__to__m',
+    'm__to__um',
+    'm__to__km',
+    'km__to__m',
+    'mm__to__km',
+    'km__to__mm',
+    's__to__min',
+    'min__to__s',
+    's__to__h',
+    'h__to__s',
+    'h__to__d',
+    'd__to__h',
+    's__to__d',
+    'd__to__s',
+    'Pa__to__hPa',
+    'hPa__to__Pa',
+    'm_s_minus_1__to__km_h_minus_1',
+    'km_h_minus_1__to__m_s_minus_1',
+    'W_m_minus_2__to__erg_cm_minus_2_s_minus_1',
+    'erg_cm_minus_2_s_minus_1__to__W_m_minus_2',
     ]
 
-import unit_conversion
+from .unit_conversion import mm__to__m
+from .unit_conversion import m__to__mm
+from .unit_conversion import um__to__m
+from .unit_conversion import m__to__um
+from .unit_conversion import m__to__km
+from .unit_conversion import km__to__m
+from .unit_conversion import mm__to__km
+from .unit_conversion import km__to__mm
+from .unit_conversion import s__to__min
+from .unit_conversion import min__to__s
+from .unit_conversion import s__to__h
+from .unit_conversion import h__to__s
+from .unit_conversion import h__to__d
+from .unit_conversion import d__to__h
+from .unit_conversion import s__to__d
+from .unit_conversion import d__to__s
+from .unit_conversion import Pa__to__hPa
+from .unit_conversion import hPa__to__Pa
+from .unit_conversion import m_s_minus_1__to__km_h_minus_1
+from .unit_conversion import km_h_minus_1__to__m_s_minus_1
+from .unit_conversion import W_m_minus_2__to__erg_cm_minus_2_s_minus_1
+from .unit_conversion import erg_cm_minus_2_s_minus_1__to__W_m_minus_2

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -190,7 +190,7 @@ def parse_variable_tables(filename):
 
     lines = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':
@@ -498,7 +498,7 @@ def parse_scheme_tables(filename):
     lines = []
     original_line_numbers = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -517,7 +517,7 @@ class MetadataHeader(ParseSource):
         mheaders = list()
         with open(filename, 'r') as file:
             fin_lines = file.readlines()
-            for index in xrange(len(fin_lines)):
+            for index in range(len(fin_lines)):
                 fin_lines[index] = fin_lines[index].rstrip('\n')
             # End for
         # End with

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -684,15 +684,15 @@ set(CAPS
         for key, value in kwargs.items():
             setattr(self, "_"+key, value)
 
-    def write(self, schemes):
+    def write(self, caps):
         if (self.filename is not sys.stdout):
             f = open(self.filename, 'w')
         else:
             f = sys.stdout
 
         contents = self.header
-        for scheme in schemes:
-            contents += '      {0}\n'.format(scheme)
+        for cap in caps:
+            contents += '      {0}\n'.format(cap)
         contents += self.footer
         f.write(contents)
 
@@ -711,7 +711,7 @@ set(CAPS
 class CapsSourcefile(object):
 
     header='''
-# All CCPP schemes are defined here.
+# All CCPP caps are defined here.
 #
 # This file is auto-generated using ccpp_prebuild.py
 # at compile time, do not edit manually.
@@ -725,7 +725,7 @@ export CCPP_CAPS="'''
         for key, value in kwargs.items():
             setattr(self, "_"+key, value)
 
-    def write(self, schemes):
+    def write(self, caps):
         if (self.filename is not sys.stdout):
             filepath = os.path.split(self.filename)[0]
             if not os.path.isdir(filepath):
@@ -735,8 +735,8 @@ export CCPP_CAPS="'''
             f = sys.stdout
 
         contents = self.header
-        for scheme in schemes:
-            contents += '{0};'.format(scheme)
+        for cap in caps:
+            contents += '{0};'.format(cap)
         contents = contents.rstrip(';')
         contents += self.footer
         f.write(contents)
@@ -889,6 +889,131 @@ export CCPP_SCHEMES="'''
         contents = self.header
         for scheme in schemes:
             contents += '{0};'.format(scheme)
+        contents = contents.rstrip(';')
+        contents += self.footer
+        f.write(contents)
+
+        if (f is not sys.stdout):
+            f.close()
+
+    @property
+    def filename(self):
+        '''Get the filename of write the output to.'''
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+class TypedefsMakefile(object):
+
+    header='''
+# All CCPP types are defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+TYPEDEFS ='''
+
+    def __init__(self, **kwargs):
+        self._filename = 'sys.stdout'
+        for key, value in kwargs.items():
+            setattr(self, "_"+key, value)
+
+    def write(self, typedefs):
+        if (self.filename is not sys.stdout):
+            f = open(self.filename, 'w')
+        else:
+            f = sys.stdout
+
+        contents = self.header
+        for typedef in typedefs:
+            contents += ' \\\n\t   {0}'.format(typedef)
+        f.write(contents)
+
+        if (f is not sys.stdout):
+            f.close()
+
+    @property
+    def filename(self):
+        '''Get the filename of write the output to.'''
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+class TypedefsCMakefile(object):
+
+    header='''
+# All CCPP types are defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+set(TYPEDEFS
+'''
+    footer=''')
+'''
+
+    def __init__(self, **kwargs):
+        self._filename = 'sys.stdout'
+        for key, value in kwargs.items():
+            setattr(self, "_"+key, value)
+
+    def write(self, typedefs):
+        if (self.filename is not sys.stdout):
+            f = open(self.filename, 'w')
+        else:
+            f = sys.stdout
+
+        contents = self.header
+        for typedef in typedefs:
+            contents += '      {0}\n'.format(typedef)
+        contents += self.footer
+        f.write(contents)
+
+        if (f is not sys.stdout):
+            f.close()
+
+    @property
+    def filename(self):
+        '''Get the filename of write the output to.'''
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+class TypedefsSourcefile(object):
+
+    header='''
+# All CCPP types are defined here.
+#
+# This file is auto-generated using ccpp_prebuild.py
+# at compile time, do not edit manually.
+#
+export CCPP_TYPEDEFS="'''
+    footer='''"
+'''
+
+    def __init__(self, **kwargs):
+        self._filename = 'sys.stdout'
+        for key, value in kwargs.items():
+            setattr(self, "_"+key, value)
+
+    def write(self, typedefs):
+        if (self.filename is not sys.stdout):
+            filepath = os.path.split(self.filename)[0]
+            if not os.path.isdir(filepath):
+                os.makedirs(filepath)
+            f = open(self.filename, 'w')
+        else:
+            f = sys.stdout
+
+        contents = self.header
+        for typedef in typedefs:
+            contents += '{0};'.format(typedef)
         contents = contents.rstrip(';')
         contents += self.footer
         f.write(contents)

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -83,7 +83,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
     shading = { 0 : 'darkgray', 1 : 'lightgray' }
     success = True
 
-    var_names = sorted(list(set(metadata_define.keys() + metadata_request.keys())))
+    var_names = sorted(list(set(list(metadata_define.keys()) + list(metadata_request.keys()))))
 
     latex = '''\\documentclass[12pt,letterpaper,oneside,landscape]{{scrbook}}
 
@@ -126,7 +126,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
         if var_name in metadata_request.keys():
             requested_list = [ escape_tex(decode_container(v.container)) for v in metadata_request[var_name] ]
             # for the purpose of the table, just output the name of the subroutine
-            for i in xrange(len(requested_list)):
+            for i in range(len(requested_list)):
                 entry = requested_list[i]
                 requested_list[i] = entry[entry.find('SUBROUTINE')+len('SUBROUTINE')+1:]
             requested = '\\newline '.join(sorted(requested_list))

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -37,7 +37,7 @@ def extract_parents_and_indices_from_local_name(local_name):
     # First, extract all variables/indices in parentheses (used for subsetting)
     indices = []
     while '(' in local_name:
-        for i in xrange(len(local_name)):
+        for i in range(len(local_name)):
             if local_name[i] == '(':
                 last_open = i
             elif local_name[i] == ')':
@@ -512,10 +512,10 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the suite.'''
-        print "ALL SUBROUTINES:"
-        print self._all_subroutines_called
-        print "STRUCTURED:"
-        print self._groups
+        print("ALL SUBROUTINES:")
+        print(self._all_subroutines_called)
+        print("STRUCTURED:")
+        print(self._groups)
         for group in self._groups:
             group.print_debug()
 
@@ -827,12 +827,12 @@ end module {module}
                             for local_name_define in [parent_local_name_define] + parent_local_names_define_indices:
                                 parent_standard_name = None
                                 parent_var = None
-                                for i in xrange(FORTRAN_ARRAY_MAX_DIMS+1):
+                                for i in range(FORTRAN_ARRAY_MAX_DIMS+1):
                                     if i==0:
                                         dims_string = ''
                                     else:
                                         # (:) for i==1, (:,:) for i==2, ...
-                                        dims_string = '(' + ','.join([':' for j in xrange(i)]) + ')'
+                                        dims_string = '(' + ','.join([':' for j in range(i)]) + ')'
                                     if local_name_define+dims_string in standard_name_by_local_name_define.keys():
                                         parent_standard_name = standard_name_by_local_name_define[local_name_define+dims_string]
                                         parent_var = metadata_define[parent_standard_name][0]
@@ -1065,7 +1065,7 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the group.'''
-        print self._name
+        print(self._name)
         for subcycle in self._subcycles:
             subcycle.print_debug()
 
@@ -1129,9 +1129,9 @@ class Subcycle(object):
 
     def print_debug(self):
         '''Basic debugging output about the subcycle.'''
-        print self._loop
+        print(self._loop)
         for scheme in self._schemes:
-            print scheme
+            print(scheme)
 
 
 ###############################################################################

--- a/scripts/parse_tools/__init__.py
+++ b/scripts/parse_tools/__init__.py
@@ -28,20 +28,20 @@ __all__ = [
     'setLogToStdout',
 ]
 
-from parse_source   import ParseContext, ParseSource
-from parse_source   import ParseSyntaxError, ParseInternalError
-from parse_source   import CCPPError, context_string
-from parse_object   import ParseObject
-from parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
-from parse_checkers import FORTRAN_DP_RE
-from parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
-from parse_checkers import check_fortran_intrinsic
-from parse_checkers import check_fortran_type, check_balanced_paren
-from parse_checkers import registered_fortran_ddt_name
-from parse_checkers import register_fortran_ddt_name
-from parse_checkers import check_dimensions, check_cf_standard_name
-from parse_log      import init_log, set_log_level
-from parse_log      import set_log_to_stdout, set_log_to_null
-from parse_log      import set_log_to_file
-from preprocess     import PreprocStack
+from .parse_source   import ParseContext, ParseSource
+from .parse_source   import ParseSyntaxError, ParseInternalError
+from .parse_source   import CCPPError, context_string
+from .parse_object   import ParseObject
+from .parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
+from .parse_checkers import FORTRAN_DP_RE
+from .parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
+from .parse_checkers import check_fortran_intrinsic
+from .parse_checkers import check_fortran_type, check_balanced_paren
+from .parse_checkers import registered_fortran_ddt_name
+from .parse_checkers import register_fortran_ddt_name
+from .parse_checkers import check_dimensions, check_cf_standard_name
+from .parse_log      import init_log, set_log_level
+from .parse_log      import set_log_to_stdout, set_log_to_null
+from .parse_log      import set_log_to_file
+from .preprocess     import PreprocStack
 # End if

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -5,7 +5,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source import CCPPError
+from .parse_source import CCPPError
 
 ########################################################################
 

--- a/scripts/parse_tools/parse_object.py
+++ b/scripts/parse_tools/parse_object.py
@@ -4,7 +4,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source    import ParseContext, CCPPError
+from .parse_source import ParseContext, CCPPError
 
 ########################################################################
 


### PR DESCRIPTION
This PR is required for merging RRTMGP into CCPP. It updates/extends the CCPP prebuild script to provide information on CCPP kind and type definitions to the host model.

This is required so that the host model build system (calling/using the ccpp-physics cmake build system) can install and find the Fortran modules containing the definitions of the RRTMGP-internal DDTs, and also the already existing DDTs such as those in `GFS_typedefs.F90`. This is an important cleanup, because it means we do not have to manually list and compile the type definitions on the host model side (in addition to being compiled and installed by CCPP).

The PR also includes an update of the NCAR dtc/develop branch from the NCAR master branch, as well as an update of the CCPP prebuild scripts to work with Python 3 as described in https://github.com/NCAR/ccpp-framework/pull/271 (this PR was pulled into the current PR and any merge conflicts arising from #271 being based on the release/public-v4 branch were resolved).

Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/270
https://github.com/NCAR/ccpp-physics/pull/411 (includes https://github.com/NCAR/ccpp-physics/pull/413; the latter supersedes https://github.com/NCAR/ccpp-physics/pull/400)
https://github.com/NCAR/fv3atm/pull/32 (includes https://github.com/NCAR/fv3atm/pull/26)
https://github.com/NCAR/ufs-weather-model/pull/29

For detailed information on the RRTMGP code to be committed, see https://github.com/NCAR/ccpp-physics/pull/400.

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/29.