### PR TITLE
release/public-v4: Python 3 compatibility for CCPP prebuild scripts

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -781,7 +781,7 @@ def main():
                 raise Exception('Call to generate_include_files failed.')
 
     # Add filenames of schemes to makefile - add dependencies for schemes
-    success = generate_schemes_makefile(config['scheme_files_dependencies'] + config['scheme_files'].keys(),
+    success = generate_schemes_makefile(config['scheme_files_dependencies'] + list(config['scheme_files'].keys()),
                                         config['schemes_makefile'], config['schemes_cmakefile'],
                                         config['schemes_sourcefile'])
     if not success:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -126,7 +126,7 @@ def decode_container(container):
     items = container.split(' ')
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         items[i] = items[i][:items[i].find('_')] + ' ' + items[i][items[i].find('_')+1:]
     return ' '.join(items)
 
@@ -139,7 +139,7 @@ def decode_container_as_dict(container):
     if not len(items) in [1, 2, 3]:
         raise Exception("decode_container not implemented for {0} items".format(len(items)))
     itemsdict = {}
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         key, value = (items[i][:items[i].find('_')], items[i][items[i].find('_')+1:])
         itemsdict[key] = value
     return itemsdict

--- a/scripts/conversion_tools/__init__.py
+++ b/scripts/conversion_tools/__init__.py
@@ -2,7 +2,49 @@
 """
 
 __all__ = [
-    'units',
+    'mm__to__m',
+    'm__to__mm',
+    'um__to__m',
+    'm__to__um',
+    'm__to__km',
+    'km__to__m',
+    'mm__to__km',
+    'km__to__mm',
+    's__to__min',
+    'min__to__s',
+    's__to__h',
+    'h__to__s',
+    'h__to__d',
+    'd__to__h',
+    's__to__d',
+    'd__to__s',
+    'Pa__to__hPa',
+    'hPa__to__Pa',
+    'm_s_minus_1__to__km_h_minus_1',
+    'km_h_minus_1__to__m_s_minus_1',
+    'W_m_minus_2__to__erg_cm_minus_2_s_minus_1',
+    'erg_cm_minus_2_s_minus_1__to__W_m_minus_2',
     ]
 
-import unit_conversion
+from .unit_conversion import mm__to__m
+from .unit_conversion import m__to__mm
+from .unit_conversion import um__to__m
+from .unit_conversion import m__to__um
+from .unit_conversion import m__to__km
+from .unit_conversion import km__to__m
+from .unit_conversion import mm__to__km
+from .unit_conversion import km__to__mm
+from .unit_conversion import s__to__min
+from .unit_conversion import min__to__s
+from .unit_conversion import s__to__h
+from .unit_conversion import h__to__s
+from .unit_conversion import h__to__d
+from .unit_conversion import d__to__h
+from .unit_conversion import s__to__d
+from .unit_conversion import d__to__s
+from .unit_conversion import Pa__to__hPa
+from .unit_conversion import hPa__to__Pa
+from .unit_conversion import m_s_minus_1__to__km_h_minus_1
+from .unit_conversion import km_h_minus_1__to__m_s_minus_1
+from .unit_conversion import W_m_minus_2__to__erg_cm_minus_2_s_minus_1
+from .unit_conversion import erg_cm_minus_2_s_minus_1__to__W_m_minus_2

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -190,7 +190,7 @@ def parse_variable_tables(filename):
 
     lines = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':
@@ -498,7 +498,7 @@ def parse_scheme_tables(filename):
     lines = []
     original_line_numbers = []
     buffer = ''
-    for i in xrange(len(file_lines)):
+    for i in range(len(file_lines)):
         line = file_lines[i].rstrip('\n').strip()
         # Skip empty lines
         if line == '' or line == '&':

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -517,7 +517,7 @@ class MetadataHeader(ParseSource):
         mheaders = list()
         with open(filename, 'r') as file:
             fin_lines = file.readlines()
-            for index in xrange(len(fin_lines)):
+            for index in range(len(fin_lines)):
                 fin_lines[index] = fin_lines[index].rstrip('\n')
             # End for
         # End with

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -83,7 +83,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
     shading = { 0 : 'darkgray', 1 : 'lightgray' }
     success = True
 
-    var_names = sorted(list(set(metadata_define.keys() + metadata_request.keys())))
+    var_names = sorted(list(set(list(metadata_define.keys()) + list(metadata_request.keys()))))
 
     latex = '''\\documentclass[12pt,letterpaper,oneside,landscape]{{scrbook}}
 
@@ -126,7 +126,7 @@ def metadata_to_latex(metadata_define, metadata_request, pset_request, model, fi
         if var_name in metadata_request.keys():
             requested_list = [ escape_tex(decode_container(v.container)) for v in metadata_request[var_name] ]
             # for the purpose of the table, just output the name of the subroutine
-            for i in xrange(len(requested_list)):
+            for i in range(len(requested_list)):
                 entry = requested_list[i]
                 requested_list[i] = entry[entry.find('SUBROUTINE')+len('SUBROUTINE')+1:]
             requested = '\\newline '.join(sorted(requested_list))

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -37,7 +37,7 @@ def extract_parents_and_indices_from_local_name(local_name):
     # First, extract all variables/indices in parentheses (used for subsetting)
     indices = []
     while '(' in local_name:
-        for i in xrange(len(local_name)):
+        for i in range(len(local_name)):
             if local_name[i] == '(':
                 last_open = i
             elif local_name[i] == ')':
@@ -512,10 +512,10 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the suite.'''
-        print "ALL SUBROUTINES:"
-        print self._all_subroutines_called
-        print "STRUCTURED:"
-        print self._groups
+        print("ALL SUBROUTINES:")
+        print(self._all_subroutines_called)
+        print("STRUCTURED:")
+        print(self._groups)
         for group in self._groups:
             group.print_debug()
 
@@ -827,12 +827,12 @@ end module {module}
                             for local_name_define in [parent_local_name_define] + parent_local_names_define_indices:
                                 parent_standard_name = None
                                 parent_var = None
-                                for i in xrange(FORTRAN_ARRAY_MAX_DIMS+1):
+                                for i in range(FORTRAN_ARRAY_MAX_DIMS+1):
                                     if i==0:
                                         dims_string = ''
                                     else:
                                         # (:) for i==1, (:,:) for i==2, ...
-                                        dims_string = '(' + ','.join([':' for j in xrange(i)]) + ')'
+                                        dims_string = '(' + ','.join([':' for j in range(i)]) + ')'
                                     if local_name_define+dims_string in standard_name_by_local_name_define.keys():
                                         parent_standard_name = standard_name_by_local_name_define[local_name_define+dims_string]
                                         parent_var = metadata_define[parent_standard_name][0]
@@ -1065,7 +1065,7 @@ end module {module}
 
     def print_debug(self):
         '''Basic debugging output about the group.'''
-        print self._name
+        print(self._name)
         for subcycle in self._subcycles:
             subcycle.print_debug()
 
@@ -1129,9 +1129,9 @@ class Subcycle(object):
 
     def print_debug(self):
         '''Basic debugging output about the subcycle.'''
-        print self._loop
+        print(self._loop)
         for scheme in self._schemes:
-            print scheme
+            print(scheme)
 
 
 ###############################################################################

--- a/scripts/parse_tools/__init__.py
+++ b/scripts/parse_tools/__init__.py
@@ -28,20 +28,20 @@ __all__ = [
     'setLogToStdout',
 ]
 
-from parse_source   import ParseContext, ParseSource
-from parse_source   import ParseSyntaxError, ParseInternalError
-from parse_source   import CCPPError, context_string
-from parse_object   import ParseObject
-from parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
-from parse_checkers import FORTRAN_DP_RE
-from parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
-from parse_checkers import check_fortran_intrinsic
-from parse_checkers import check_fortran_type, check_balanced_paren
-from parse_checkers import registered_fortran_ddt_name
-from parse_checkers import register_fortran_ddt_name
-from parse_checkers import check_dimensions, check_cf_standard_name
-from parse_log      import init_log, set_log_level
-from parse_log      import set_log_to_stdout, set_log_to_null
-from parse_log      import set_log_to_file
-from preprocess     import PreprocStack
+from .parse_source   import ParseContext, ParseSource
+from .parse_source   import ParseSyntaxError, ParseInternalError
+from .parse_source   import CCPPError, context_string
+from .parse_object   import ParseObject
+from .parse_checkers import check_fortran_id, LITERAL_INT, FORTRAN_ID
+from .parse_checkers import FORTRAN_DP_RE
+from .parse_checkers import check_fortran_ref, FORTRAN_SCALAR_REF
+from .parse_checkers import check_fortran_intrinsic
+from .parse_checkers import check_fortran_type, check_balanced_paren
+from .parse_checkers import registered_fortran_ddt_name
+from .parse_checkers import register_fortran_ddt_name
+from .parse_checkers import check_dimensions, check_cf_standard_name
+from .parse_log      import init_log, set_log_level
+from .parse_log      import set_log_to_stdout, set_log_to_null
+from .parse_log      import set_log_to_file
+from .preprocess     import PreprocStack
 # End if

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -5,7 +5,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source import CCPPError
+from .parse_source import CCPPError
 
 ########################################################################
 

--- a/scripts/parse_tools/parse_object.py
+++ b/scripts/parse_tools/parse_object.py
@@ -4,7 +4,7 @@
 # Python library imports
 import re
 # CCPP framework imports
-from parse_source    import ParseContext, CCPPError
+from .parse_source import ParseContext, CCPPError
 
 ########################################################################
 


### PR DESCRIPTION
This PR updates the CCPP prebuild scripts (`ccpp_prebuild.py` and dependencies) so that they are compatible with both Python 2.7 and Python 3 (tested with Python 3.7).

Credits for this PR go to Nick Weber (@njweber2) for sending these changes in an email.

`ccpp_prebuild.py` tested manually (in addition to the regression testing):
```
# Dynamic CCPP
./FV3/ccpp/framework/scripts/ccpp_prebuild.py --config=FV3/ccpp/config/ccpp_prebuild_config.py

# Dynamic CCPP, debug
./FV3/ccpp/framework/scripts/ccpp_prebuild.py --config=FV3/ccpp/config/ccpp_prebuild_config.py --debug

# Static CCPP
./FV3/ccpp/framework/scripts/ccpp_prebuild.py --config=FV3/ccpp/config/ccpp_prebuild_config.py --static --suites=FV3_GFS_v16beta,FV3_GFS_v15p2_no_nsst

# Static CCPP, debug
./FV3/ccpp/framework/scripts/ccpp_prebuild.py --config=FV3/ccpp/config/ccpp_prebuild_config.py --static --suites=FV3_GFS_v16beta,FV3_GFS_v15p2_no_nsst --debug
```

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/271/files
https://github.com/NOAA-EMC/fv3atm/pull/88
https://github.com/ufs-community/ufs-weather-model/pull/92

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/92