### PR TITLE
dtc/develop: add unit conversions for Noah LSM, update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,14 @@ if(NOT PROJECT)
 endif (NOT PROJECT)
 
 #------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0)
+
+project(ccpp
+        VERSION 3.0.0
+        LANGUAGES C CXX Fortran)
 
 # Use rpaths on MacOSX
 set(CMAKE_MACOSX_RPATH 1)
-
-if(POLICY CMP0048)
-    cmake_policy(SET CMP0048 NEW)
-    project(ccpp VERSION 3.0.0)
-else(POLICY CMP0048)
-    project(ccpp)
-    set(PROJECT_VERSION 3.0.0)
-    set(PROJECT_VERSION_MAJOR 3)
-    set(PROJECT_VERSION_MINOR 0)
-    set(PROJECT_VERSION_PATCH 0)
-endif(POLICY CMP0048)
-
 if(POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
 endif(POLICY CMP0042)
@@ -31,10 +23,6 @@ endif(POLICY CMP0042)
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif(POLICY CMP0077)
-
-#------------------------------------------------------------------------------
-# Enable Fortran
-enable_language(Fortran)
 
 #------------------------------------------------------------------------------
 # Set package definitions

--- a/scripts/conversion_tools/unit_conversion.py
+++ b/scripts/conversion_tools/unit_conversion.py
@@ -23,6 +23,14 @@ def m__to__mm():
     """Convert meter to millimeter"""
     return '1.0E+3{kind}*{var}'
 
+def cm__to__m():
+    """Convert centimeter to meter"""
+    return '1.0E-2{kind}*{var}'
+
+def m__to__cm():
+    """Convert meter to centimeter"""
+    return '1.0E+2{kind}*{var}'
+
 def um__to__m():
     """Convert micrometer to meter"""
     return '1.0E-6{kind}*{var}'


### PR DESCRIPTION
This PR contains:
- add cm-to-m conversion and reverse for HWRF Noah LSM (from @grantfirl)
- update `CMakeLists.txt`: require CMake 3.0, remove legacy syntax for policy CMP0048

Associated PRs:
https://github.com/NCAR/GFDL_atmos_cubed_sphere/pull/11
https://github.com/NCAR/ccpp-framework/pull/281
https://github.com/NCAR/ccpp-physics/pull/432 (contains https://github.com/NCAR/ccpp-physics/pull/424)
https://github.com/NCAR/fv3atm/pull/40
https://github.com/NCAR/ufs-weather-model/pull/38/files

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/38/files.
