### PR TITLE
Bug fixes and more reports

### DIFF
--- a/scripts/ccpp_fortran_to_metadata.py
+++ b/scripts/ccpp_fortran_to_metadata.py
@@ -112,7 +112,7 @@ def parse_fortran_files(filenames, preproc_defs, output_dir, sep, logger):
                     lname_dict[lname] = prop
                     prop = var.get_prop_value('units')
                     if not prop:
-                        prop = 'enter units'
+                        prop = 'enter_units'
                     # End if
                     outfile.write('  units = {}\n'.format(prop))
                     tprop = var.get_prop_value('type')

--- a/scripts/host_model.py
+++ b/scripts/host_model.py
@@ -88,7 +88,8 @@ class HostModel(VarDictionary):
                     # End if
                 # End for
             else:
-                errmsg = "Invalid host model metadata header, {} ({}){}"
+                errmsg = "Invalid host model metadata header type, {} ({}){}"
+                errmsg += "\nType must be 'module' or 'host'"
                 ctx = context_string(header.context)
                 raise CCPPError(errmsg.format(header.title,
                                               header.header_type, ctx))


### PR DESCRIPTION
- Fix issue with how capgen handles the `intent` of CCPP suite CAP entry points
- Improve error message for bad host model table type.
- Create tests for post-capgen database reports
- Create and improve tests for run time inspection routines

fixes #279 

Test with unit tests (python test/unit_tests/test_metadata_table.py) and capgen test (capgen_test/run_test)