### PR TITLE
Fix/report Python3 decoding errors, parse all suites if --suites=... argument not present

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -41,6 +41,9 @@ STANDARD_VARIABLE_TYPES = [ STANDARD_CHARACTER_TYPE, STANDARD_INTEGER_TYPE, 'log
 CCPP_STATIC_API_MODULE = 'ccpp_static_api'
 CCPP_STATIC_SUBROUTINE_NAME = 'ccpp_physics_{stage}'
 
+# Filename pattern for suite definition files
+SUITE_DEFINITION_FILENAME_PATTERN = re.compile('^suite_(.*)\.xml$')
+
 def execute(cmd, abort = True):
     """Runs a local command in a shell. Waits for completion and
     returns status, stdout and stderr. If abort = True, abort in
@@ -56,18 +59,18 @@ def execute(cmd, abort = True):
     status = p.returncode
     if debug:
         message = 'Execution of "{0}" returned with exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        message += '    stdout: "{0}"\n'.format(stdout.decode('ascii').rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.decode('ascii').rstrip('\n'))
         logging.debug(message)
     if not status == 0:
         message = 'Execution of command {0} failed, exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        message += '    stdout: "{0}"\n'.format(stdout.decode('ascii').rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.decode('ascii').rstrip('\n'))
         if abort:
             raise Exception(message)
         else:
             logging.error(message)
-    return (status, stdout.rstrip('\n'), stderr.rstrip('\n'))
+    return (status, stdout.decode('ascii').rstrip('\n'), stderr.decode('ascii').rstrip('\n'))
 
 def split_var_name_and_array_reference(var_name):
     """Split an expression like foo(:,a,1:ddt%ngas)

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -157,7 +157,10 @@ def parse_variable_tables(filename):
 
     # Read all lines of the file at once
     with (open(filename, 'r')) as file:
-        file_lines = file.readlines()
+        try:
+            file_lines = file.readlines()
+        except UnicodeDecodeError:
+            raise Exception("Decoding error while trying to read file {}, check that the file only contains ASCII characters".format(filename))
 
     lines = []
     buffer = ''
@@ -464,7 +467,10 @@ def parse_scheme_tables(filename):
 
     # Read all lines of the file at once
     with (open(filename, 'r')) as file:
-        file_lines = file.readlines()
+        try:
+            file_lines = file.readlines()
+        except UnicodeDecodeError:
+            raise Exception("Decoding error while trying to read file {}, check that the file only contains ASCII characters".format(filename))
 
     lines = []
     original_line_numbers = []


### PR DESCRIPTION
This PR:
- fix Python 3 decoding error in `scripts/common.py`
- raise proper exceptions when decoding non-ascii files in `scripts/metadata_parser.py`
- parse all suite definition files if suites argument is not present when calling `ccpp_prebuild.py`; this addresses issue https://github.com/NCAR/ccpp-framework/issues/293

Associated PRs:
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/20
https://github.com/NCAR/ccpp-framework/pull/292
https://github.com/NCAR/ccpp-physics/pull/451
https://github.com/NOAA-EMC/fv3atm/pull/115
https://github.com/NOAA-EMC/NEMS/pull/62
https://github.com/ufs-community/ufs-weather-model/pull/126

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/126.