### PR TITLE
Feature/capgen Initial commit of unit testing for capgen parse_scheme_files function

### DIFF
--- a/test/unit_tests/sample_scheme_files/reorder.F90
+++ b/test/unit_tests/sample_scheme_files/reorder.F90
@@ -1,0 +1,68 @@
+MODULE reorder
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: reorder_init
+  PUBLIC :: reorder_run
+  PUBLIC :: reorder_finalize
+
+CONTAINS
+
+  !> \section arg_table_reorder_run  Argument Table
+  !! \htmlinclude arg_table_reorder_run.html
+  !!
+  subroutine reorder_run(foo, timestep, temp_prev, temp_layer, qv, ps,    &
+       errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+    real(kind_phys),    intent(in)    :: timestep
+    real(kind_phys),    intent(inout) :: qv(:)
+    real(kind_phys),    intent(inout) :: ps(:)
+    REAL(kind_phys),    intent(in)    :: temp_prev(:)
+    REAL(kind_phys),    intent(inout) :: temp_layer(foo)
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+    !----------------------------------------------------------------
+
+    integer :: col_index
+
+    errmsg = ''
+    errflg = 0
+
+    do col_index = 1, foo
+       temp_layer(col_index) = temp_layer(col_index) + temp_prev(col_index)
+       qv(col_index) = qv(col_index) + 1.0_kind_phys
+    end do
+
+  END SUBROUTINE reorder_run
+
+  !> \section arg_table_reorder_init  Argument Table
+  !! \htmlinclude arg_table_reorder_init.html
+  !!
+  subroutine reorder_init (errmsg, errflg)
+
+    character(len=512),      intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine reorder_init
+
+  !> \section arg_table_reorder_finalize  Argument Table
+  !! \htmlinclude arg_table_reorder_finalize.html
+  !!
+  subroutine reorder_finalize (errmsg, errflg)
+
+    character(len=512),      intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine reorder_finalize
+
+END MODULE reorder

--- a/test/unit_tests/sample_scheme_files/reorder.meta
+++ b/test/unit_tests/sample_scheme_files/reorder.meta
@@ -1,0 +1,97 @@
+[ccpp-arg-table]
+  name = reorder_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = reorder_run
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ timestep ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ temp_prev ]
+  standard_name = potential_temperature_at_previous_timestep
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[ temp_layer ]
+  standard_name = potential_temperature
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ qv ]
+  standard_name = water_vapor_specific_humidity
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ ps ]
+  standard_name = surface_air_pressure
+  state_variable = true
+  type = real
+  kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  intent = inout
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = reorder_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_scheme_files/temp_adjust.F90
+++ b/test/unit_tests/sample_scheme_files/temp_adjust.F90
@@ -1,0 +1,75 @@
+! Test parameterization with no vertical level
+!
+
+MODULE temp_adjust
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: temp_adjust_init
+  PUBLIC :: temp_adjust_run
+  PUBLIC :: temp_adjust_finalize
+
+CONTAINS
+
+  !> \section arg_table_temp_adjust_run  Argument Table
+  !! \htmlinclude arg_table_temp_adjust_run.html
+  !!
+  subroutine temp_adjust_run(foo, timestep, temp_prev, temp_layer, qv, ps,    &
+       errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+    real(kind_phys),    intent(in)    :: timestep
+    real(kind_phys),    intent(inout) :: qv(:)
+    real(kind_phys),    intent(inout) :: ps(:)
+    REAL(kind_phys),    intent(in)    :: temp_prev(:)
+    REAL(kind_phys),    intent(inout) :: temp_layer(foo)
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+    !----------------------------------------------------------------
+
+    integer :: col_index
+
+    errmsg = ''
+    errflg = 0
+
+    do col_index = 1, foo
+       temp_layer(col_index) = temp_layer(col_index) + temp_prev(col_index)
+       qv(col_index) = qv(col_index) + 1.0_kind_phys
+    end do
+
+  END SUBROUTINE temp_adjust_run
+
+  !> \section arg_table_temp_adjust_init  Argument Table
+  !! \htmlinclude arg_table_temp_adjust_init.html
+  !!
+  subroutine temp_adjust_init (errmsg, errflg)
+
+    character(len=512),      intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine temp_adjust_init
+
+  !> \section arg_table_temp_adjust_finalize  Argument Table
+  !! \htmlinclude arg_table_temp_adjust_finalize.html
+  !!
+  subroutine temp_adjust_finalize (errmsg, errflg)
+
+    character(len=512),      intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine temp_adjust_finalize
+
+END MODULE temp_adjust

--- a/test/unit_tests/sample_scheme_files/temp_adjust.meta
+++ b/test/unit_tests/sample_scheme_files/temp_adjust.meta
@@ -1,0 +1,97 @@
+[ccpp-arg-table]
+  name = temp_adjust_run
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ timestep ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ temp_prev ]
+  standard_name = potential_temperature_at_previous_timestep
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[ temp_layer ]
+  standard_name = potential_temperature
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ qv ]
+  standard_name = water_vapor_specific_humidity
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ ps ]
+  standard_name = surface_air_pressure
+  state_variable = true
+  type = real
+  kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  intent = inout
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_adjust_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = temp_adjust_finalize
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/test_metadata_scheme_file.py
+++ b/test/unit_tests/test_metadata_scheme_file.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python
+
+"""
+-----------------------------------------------------------------------
+ Description:  capgen needs to compare a metadata header against the
+               associated CCPP Fortran interface routine.  This set of
+               tests is testing the parse_scheme_files function in
+               ccpp_capgen.py which performs the operations in the first
+               bullet below. Each test calls this function.
+
+               * This script contains unit tests that do the following:
+                  1) Read a metadata file (to collect the metadata headers)
+                  2) Read the associated CCPP Fortran scheme file (to
+                     collect Fortran interfaces)
+                  3) Compare the metadata header against the Fortran
+
+               * Tests include:
+                  - Correctly identify when the metadata file matches the
+                    Fortran, even if the routines are not in the same order
+                  - Correctly detect a missing metadata header
+                  - Correctly detect a missing Fortran interface
+                  - Correctly detect a mismatch between the metadata and the
+                    Fortran
+                  - Correctly detect invalid Fortran subroutine statements,
+                    invalid dummy argument statements, and invalid Fortran
+                    between the subroutine statement and the end of the
+                    variable declaration block.
+                  - Correctly interpret Fortran with preprocessor logic
+                    which affects the subroutine statement and/or the dummy
+                    argument statements
+                  - Correctly interpret Fortran with preprocessor logic
+                    which affects the subroutine statement and/or the dummy
+                    argument statements resulting in a mismatch between the
+                    metadata header and the Fortran
+                  - Correctly interpret Fortran with preprocessor logic
+                    which affects the subroutine statement and/or the dummy
+                    argument statements resulting in incorrect Fortran
+
+ Assumptions:
+
+ Command line arguments: none
+
+ Usage: python test_metadata_scheme_file.py       # run the unit tests
+-----------------------------------------------------------------------
+"""
+import sys
+import os
+import logging
+import unittest
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = os.path.abspath(os.path.join(_TEST_DIR, os.pardir,
+                                            os.pardir, "scripts"))
+if not os.path.exists(_SCRIPTS_DIR):
+   raise ImportError("Cannot find scripts directory")
+
+sys.path.append(_SCRIPTS_DIR)
+
+# pylint: disable=wrong-import-position
+from ccpp_capgen import parse_scheme_files
+# pylint: enable=wrong-import-position
+
+class MetadataHeaderTestCase(unittest.TestCase):
+
+   def setUp(self):
+      """Setup important directories and logging"""
+      self._sample_files_dir = os.path.join(_TEST_DIR, "sample_scheme_files")
+      self._logger = logging.getLogger(self.__class__.__name__)
+
+   def test_good_scheme_file(self):
+      """Test that good metadata file matches the Fortran, with routines in the same order """
+      #Setup
+      scheme_files = [os.path.join(self._sample_files_dir, "temp_adjust.meta")]
+      preproc_defs={}
+      #Exercise
+      scheme_headers = parse_scheme_files(scheme_files, preproc_defs,
+                                          self._logger)
+      #Verify size of returned list equals number of scheme headers in the test file
+      #       and that header (subroutine) names are 'temp_adjust_[init,run,finalize]'
+      self.assertEqual(len(scheme_headers), 3)
+      #Verify header titles
+      titles = [elem.title for elem in scheme_headers]
+      self.assertTrue('temp_adjust_init' in titles)
+      self.assertTrue('temp_adjust_run' in titles)
+      self.assertTrue('temp_adjust_finalize' in titles)
+
+   def test_reordered_scheme_file(self):
+      """Test that metadata file matches the Fortran when the routines are not in the same order """
+      #Setup
+      scheme_files = [os.path.join(self._sample_files_dir, "reorder.meta")]
+      preproc_defs={}
+      #Exercise
+      scheme_headers = parse_scheme_files(scheme_files, preproc_defs,
+                                          self._logger)
+      #Verify size of returned list equals number of scheme headers in the test file
+      #       and that header (subroutine) names are 'reorder_[init,run,finalize]'
+      self.assertEqual(len(scheme_headers), 3)
+      #Verify header titles
+      titles = [elem.title for elem in scheme_headers]
+      self.assertTrue('reorder_init' in titles)
+      self.assertTrue('reorder_run' in titles)
+      self.assertTrue('reorder_finalize' in titles)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

Two tests are:
- Test that metadata file matches Fortran when routines are in the same order
- Test that metadata file matches Fortran when order of routines differ

All tests pass.