### PR TITLE
release/public-v4: additional python3 bug fixes

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -55,18 +55,19 @@ def execute(cmd, abort = True):
     status = p.returncode
     if debug:
         message = 'Execution of "{0}" returned with exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        message += '    stdout: "{0}"\n'.format(stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
         logging.debug(message)
     if not status == 0:
         message = 'Execution of command {0} failed, exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        message += '    stdout: "{0}"\n'.format(stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
         if abort:
             raise Exception(message)
         else:
             logging.error(message)
-    return (status, stdout.rstrip('\n'), stderr.rstrip('\n'))
+    return (status, stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'),
+                    stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
 
 def indent(elem, level=0):
     """Subroutine for writing "pretty" XML; copied from


### PR DESCRIPTION
This PR contains additional bugfixes for Python 3 (from master). Without these, using Python 3 users on certain machines (including Stampede) will see an Exception from `ccpp_prebuild.py` and the build is broken.

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/303
https://github.com/NOAA-EMC/fv3atm/pull/130
https://github.com/ufs-community/ufs-weather-model/pull/149

For regression testing information, see below https://github.com/ufs-community/ufs-weather-model/pull/149.