### PR TITLE
Add two unit tests for metadata scheme to test preprocessor directives

### DIFF
--- a/test/unit_tests/sample_scheme_files/preproc_defs_test1.F90
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test1.F90
@@ -1,0 +1,38 @@
+! Test parameterization with no vertical level
+!
+
+MODULE preproc_defs_test1
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: preproc_defs_test1_run
+
+CONTAINS
+
+  !> \section arg_table_preproc_defs_test1_run  Argument Table
+  !! \htmlinclude arg_table_preproc_defs_test1_run.html
+  !!
+  subroutine preproc_defs_test1_run (foo, &
+#ifndef CCPP
+                                     bar, &
+#endif
+                                     errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+#ifndef CCPP
+    real(kind_phys),    intent(in)    :: bar
+#endif
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine preproc_defs_test1_run
+
+END MODULE preproc_defs_test1

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test1.meta
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test1.meta
@@ -1,0 +1,24 @@
+[ccpp-arg-table]
+  name = preproc_defs_test1_run
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test2.F90
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test2.F90
@@ -1,0 +1,38 @@
+! Test parameterization with no vertical level
+!
+
+MODULE preproc_defs_test2
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: preproc_defs_test2_run
+
+CONTAINS
+
+  !> \section arg_table_preproc_defs_test2_run  Argument Table
+  !! \htmlinclude arg_table_preproc_defs_test2_run.html
+  !!
+  subroutine preproc_defs_test2_run (foo, &
+#ifndef CCPP
+                                     bar, &
+#endif
+                                     errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+#ifndef CCPP
+    real(kind_phys),    intent(in)    :: bar
+#endif
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine preproc_defs_test2_run
+
+END MODULE preproc_defs_test2

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test2.meta
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test2.meta
@@ -1,0 +1,32 @@
+[ccpp-arg-table]
+  name = preproc_defs_test2_run
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ bar ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/test_metadata_scheme_file.py
+++ b/test/unit_tests/test_metadata_scheme_file.py
@@ -163,5 +163,38 @@ class MetadataHeaderTestCase(unittest.TestCase):
         #Verify correct error message returned
         self.assertTrue("Invalid dummy argument, 'woohoo', at" in str(context.exception))
 
+    def test_preproc_defs_test1(self):
+        """Test for correct detection of a variable that REMAINS in the subroutine argument list
+           (due to an undefined pre-processor directive: #ifndef CCPP), BUT IS NOT PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test1.meta")]
+        preproc_defs = {}          # CCPP directive is not set
+        #Exercise
+        with self.assertRaises(Exception) as context:
+            parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify 3 correct error messages returned
+        self.assertTrue('Variable mismatch in preproc_defs_test1_run, variables missing from metadata header.'
+                         in str(context.exception))
+        self.assertTrue('Out of order argument, errmsg in preproc_defs_test1_run' in str(context.exception))
+        self.assertTrue('Out of order argument, errflg in preproc_defs_test1_run' in str(context.exception))
+        self.assertTrue('3 errors found comparing' in str(context.exception))
+
+    def test_preproc_defs_test2(self):
+        """Test for correct detection of a variable that IS REMOVED the subroutine argument list
+           (due to a pre-processor directive: #ifndef CCPP), but IS PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test2.meta")]
+        preproc_defs = {'CCPP':1}  # Set CCPP directive
+        #Exercise
+        with self.assertRaises(Exception) as context:
+            parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify 3 correct error messages returned
+        self.assertTrue('Variable mismatch in preproc_defs_test2_run, variables missing from Fortran scheme.'
+                        in str(context.exception))
+        self.assertTrue('Variable mismatch in preproc_defs_test2_run, no Fortran variable bar.'
+                        in str(context.exception))
+        self.assertTrue('Out of order argument, errmsg in preproc_defs_test2_run' in str(context.exception))
+        self.assertTrue('3 errors found comparing' in str(context.exception))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add test for correct detection of a variable that remains in the subroutine argument
  list due to an undefined pre-processor directive, but IS NOT present in the meta file
- Add test for correct detection of a variable that is removed from the subroutine
  argugment list due to a pre-processor directive, but IS present in the meta file
- Add corresponding fortran and metadata files for tests

Your code has been rated at 10.00/10
All tests pass.