### PR TITLE
Add dependencies to metadata

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -86,27 +86,21 @@ def import_config(configfile, builddir):
     config['typedefs_cmakefile']        = ccpp_prebuild_config.TYPEDEFS_CMAKEFILE.format(build_dir=builddir)
     config['typedefs_sourcefile']       = ccpp_prebuild_config.TYPEDEFS_SOURCEFILE.format(build_dir=builddir)
     config['scheme_files']              = ccpp_prebuild_config.SCHEME_FILES
-    config['scheme_files_dependencies'] = ccpp_prebuild_config.SCHEME_FILES_DEPENDENCIES
     config['schemes_makefile']          = ccpp_prebuild_config.SCHEMES_MAKEFILE.format(build_dir=builddir)
     config['schemes_cmakefile']         = ccpp_prebuild_config.SCHEMES_CMAKEFILE.format(build_dir=builddir)
     config['schemes_sourcefile']        = ccpp_prebuild_config.SCHEMES_SOURCEFILE.format(build_dir=builddir)
-    config['target_files']              = ccpp_prebuild_config.TARGET_FILES
     config['caps_makefile']             = ccpp_prebuild_config.CAPS_MAKEFILE.format(build_dir=builddir)
     config['caps_cmakefile']            = ccpp_prebuild_config.CAPS_CMAKEFILE.format(build_dir=builddir)
     config['caps_sourcefile']           = ccpp_prebuild_config.CAPS_SOURCEFILE.format(build_dir=builddir)
     config['caps_dir']                  = ccpp_prebuild_config.CAPS_DIR.format(build_dir=builddir)
     config['suites_dir']                = ccpp_prebuild_config.SUITES_DIR
     config['optional_arguments']        = ccpp_prebuild_config.OPTIONAL_ARGUMENTS
-    config['module_include_file']       = ccpp_prebuild_config.MODULE_INCLUDE_FILE
-    config['fields_include_file']       = ccpp_prebuild_config.FIELDS_INCLUDE_FILE
     config['host_model']                = ccpp_prebuild_config.HOST_MODEL_IDENTIFIER
     config['html_vartable_file']        = ccpp_prebuild_config.HTML_VARTABLE_FILE.format(build_dir=builddir)
     config['latex_vartable_file']       = ccpp_prebuild_config.LATEX_VARTABLE_FILE.format(build_dir=builddir)
     # Location of static API file, and shell script to source
     config['static_api_dir']            = ccpp_prebuild_config.STATIC_API_DIR.format(build_dir=builddir)
     config['static_api_srcfile']        = ccpp_prebuild_config.STATIC_API_SRCFILE.format(build_dir=builddir)
-    # Template code in host-model dependent CCPP prebuild config script
-    config['ccpp_data_structure']            = ccpp_prebuild_config.CCPP_DATA_STRUCTURE
 
     # Add model-independent, CCPP-internal variable definition files
     config['variable_definition_files'].append(CCPP_INTERNAL_VARIABLE_DEFINITON_FILE)
@@ -806,13 +800,8 @@ def main():
     if not success:
         raise Exception('Call to generate_typedefs_makefile failed.')
 
-    # Add filenames of schemes and dependencies to makefile/cmakefile/shell script
-    # DH* temporary - for testing and during transition period, still compile all dependencies in ccpp_prebuild_config;
-    # when this is removed, also remove the unnecessary "removal of duplicates" in generate_schemes_makefile and all
-    # occurences of config['scheme_files_dependencies'] in this script.
-    #success = generate_schemes_makefile(schemes_and_dependencies_to_compile,
-    # *DH
-    success = generate_schemes_makefile(schemes_and_dependencies_to_compile + config['scheme_files_dependencies'],
+    # Add filenames of schemes and variable definition files (types) to makefile/cmakefile/shell script
+    success = generate_schemes_makefile(schemes_and_dependencies_to_compile + config['variable_definition_files'],
                                         config['schemes_makefile'], config['schemes_cmakefile'],
                                         config['schemes_sourcefile'])
     if not success:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -7,6 +7,8 @@ import re
 import subprocess
 import sys
 
+CCPP_STAGES = [ 'init', 'run', 'finalize' ]
+
 CCPP_ERROR_FLAG_VARIABLE = 'ccpp_error_flag'
 CCPP_ERROR_MSG_VARIABLE  = 'ccpp_error_message'
 CCPP_LOOP_COUNTER        = 'ccpp_loop_counter'

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -198,8 +198,8 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             elif new_var.get_prop_value('active').lower() == '.false.':
                 active = 'F'
             else:
-                # Replace multiple whitespaces and use lowercase throughout
-                active = ' '.join(new_var.get_prop_value('active').lower().split())
+                # Replace multiple whitespaces, preserve case
+                active = ' '.join(new_var.get_prop_value('active').split())
             var = Var(standard_name = standard_name,
                       long_name     = new_var.get_prop_value('long_name') + legacy_note,
                       units         = new_var.get_prop_value('units'),

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -107,6 +107,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
         NEW_METADATA_SAVE[filename] = new_metadata_headers
 
     # Record dependencies for the metadata table (only applies to schemes)
+    has_scheme_properties = False
     dependencies = []
 
     # Convert new metadata for requested table to old metadata dictionary
@@ -125,6 +126,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             if not new_metadata_header.header_type == 'properties':
                 raise Exception("Unsupported header_type '{}' for scheme-wide metadata")
             dependencies += new_metadata_header.dependencies
+            has_scheme_properties = True
         else:
             if not new_metadata_header.title == table_name:
                 # Skip this table, since it is not requested right now
@@ -181,8 +183,13 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                       )
             # Check for duplicates in same table
             if standard_name in metadata.keys():
-               raise Exception("Error, multiple definitions of standard name {0} in new metadata table {1}".format(standard_name, table_name))
+               raise Exception("Error, multiple definitions of standard name {} in new metadata table {}".format(standard_name, table_name))
             metadata[standard_name] = [var]
+
+    if scheme_name and not has_scheme_properties:
+        raise Exception("Metadata file {} for scheme {} does not have a [ccpp-scheme-properties] section,".format(filename, scheme_name) + \
+                                                                  " or the 'name = ...' attribute in the [ccpp-scheme-properties] is wrong")
+
     return (metadata, dependencies)
 
 def parse_variable_tables(filename):

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -107,7 +107,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
         NEW_METADATA_SAVE[filename] = new_metadata_headers
 
     # Record dependencies for the metadata table (only applies to schemes)
-    has_table_properties = False
+    has_property_table = False
     dependencies = []
 
     # Convert new metadata for requested table to old metadata dictionary
@@ -116,24 +116,24 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
         # Module or DDT tables
         if not scheme_name:
             # Module property tables
-            if new_metadata_header.table_properties and new_metadata_header.title == module_name:
+            if new_metadata_header.property_table and new_metadata_header.title == module_name:
                 # If this is a ccpp-table-properties table for a module, it can only contain dependencies;
                 # ensure that for module tables, the header type is "module"
                 if not new_metadata_header.header_type == 'module':
                     raise Exception("Unsupported header_type '{}' for table properties for modules".format(
                                                                           new_metadata_header.header_type))
                 dependencies += new_metadata_header.dependencies
-                has_table_properties = True
+                has_property_table = True
                 continue
             # DDT property tables
-            elif new_metadata_header.table_properties:
+            elif new_metadata_header.property_table:
                 # If this is a ccpp-table-properties table for a DDT, it can only contain dependencies;
                 # ensure that for DDT tables, the header type is "ddt"
                 if not new_metadata_header.header_type == 'ddt':
                     raise Exception("Unsupported header_type '{}' for table properties for DDTs".format(
                                                                         new_metadata_header.header_type))
                 dependencies += new_metadata_header.dependencies
-                has_table_properties = True
+                has_property_table = True
                 continue
             # Module or DDT argument tables
             else:
@@ -146,15 +146,16 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                 else:
                     container = encode_container(module_name, new_metadata_header.title)
         else:
+            logging.warning("DH DEBUG: new_metadata_header.property_table, new_metadata_header.title, scheme_name: {} {} {}".format(new_metadata_header.property_table, new_metadata_header.title, scheme_name))
             # Scheme property tables
-            if new_metadata_header.table_properties and new_metadata_header.title == scheme_name:
+            if new_metadata_header.property_table and new_metadata_header.title == scheme_name:
                 # If this is a ccpp-table-properties table for a scheme, it can only contain dependencies;
                 # ensure that for scheme tables, the header type is "scheme"
                 if not new_metadata_header.header_type == 'scheme':
                     raise Exception("Unsupported header_type '{}' for table properties for schemes".format(
                                                                           new_metadata_header.header_type))
                 dependencies += new_metadata_header.dependencies
-                has_table_properties = True
+                has_property_table = True
                 continue
             # Scheme argument tables
             else:
@@ -217,7 +218,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             metadata[standard_name] = [var]
 
     # CCPP property tables are mandatory
-    if not has_table_properties:
+    if not has_property_table:
         if scheme_name:
             raise Exception("Metadata file {} for scheme {} does not have a [ccpp-table-properties] section,".format(filename, scheme_name) + \
                                                                       " or the 'name = ...' attribute in the [ccpp-table-properties] is wrong")

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -295,6 +295,11 @@ class MetadataHeader(ParseSource):
             if self.title.split('_')[-1] in CCPP_STAGES:
                 raise ParseSyntaxError("metadata header start, table [ccpp-scheme-properties] has invalid name",
                                        token=self.title, context=self._pobj)
+            # Set mandatory properties to default if not yet set
+            try:
+                self.dependencies
+            except AttributeError:
+                self._dependencies = []
         elif self.header_type == 'scheme':
             # Consistency check for scheme tables: title must end with a valid CCPP stage
             if not self.title.split('_')[-1] in CCPP_STAGES:

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -198,7 +198,7 @@ class MetadataHeader(ParseSource):
 
     def __init__(self, parse_object=None,
                  title=None, type_in=None, module=None, var_dict=None,
-                 logger=None):
+                 property_table=False, logger=None):
         self._pobj = parse_object
         """If <parse_object> is not None, initialize from the current file and
         location in <parse_object>.
@@ -230,7 +230,7 @@ class MetadataHeader(ParseSource):
                 self._variables.add_variable(var)
             # End for
         else:
-            self.__init_from_file__(parse_object, logger)
+            self.__init_from_file__(parse_object, property_table, logger)
         # End if
         # Categorize the variables
         self._var_intents = {'in' : list(), 'out' : list(), 'inout' : list()}
@@ -241,7 +241,7 @@ class MetadataHeader(ParseSource):
             # End if
         # End for
 
-    def __init_from_file__(self, parse_object, logger):
+    def __init_from_file__(self, parse_object, property_table, logger):
         # Read the table preamble, assume the caller already figured out
         #  the first line of the header using the table_start method.
         curr_line, curr_line_num = self._pobj.next_line()
@@ -250,7 +250,7 @@ class MetadataHeader(ParseSource):
         self._module_name = None
         self._dependencies = []
         relative_path_local = ''
-        self._table_properties = False
+        self._property_table = property_table
         while (curr_line is not None) and (not self.variable_start(curr_line)) and (not MetadataHeader.table_start(curr_line)):
             for property in self.parse_config_line(curr_line):
                 # Manually parse name, type, and module properties
@@ -273,7 +273,6 @@ class MetadataHeader(ParseSource):
                         self._module_name = value
                     # End if
                 elif key == 'dependencies':
-                    self._table_properties = True
                     if not(value == "None" or value == ""):
                         # Remove trailing comma, remove white spaces from each list element
                         self._dependencies += [ v.strip() for v in value.rstrip(",").split(",") ]
@@ -516,9 +515,9 @@ class MetadataHeader(ParseSource):
         return self._dependencies
 
     @property
-    def table_properties(self):
+    def property_table(self):
         'Return True iff table is a ccpp-table-properties table'
-        return self._table_properties
+        return self._property_table
 
     @classmethod
     def is_blank(cls, line):
@@ -556,7 +555,10 @@ class MetadataHeader(ParseSource):
         curr_line, curr_line_num = parse_obj.curr_line()
         while curr_line is not None:
             if MetadataHeader.table_start(curr_line):
-                mheaders.append(MetadataHeader(parse_obj))
+                if '[ccpp-table-properties]' in curr_line:
+                    mheaders.append(MetadataHeader(parse_obj, property_table=True))
+                else:
+                    mheaders.append(MetadataHeader(parse_obj))
                 curr_line, curr_line_num = parse_obj.curr_line()
             else:
                 curr_line, curr_line_num = parse_obj.next_line()

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -420,7 +420,7 @@ class Var(object):
         of a Var object with invalid properties.
         In order to prevent silent failures, invalid_ok requires a logger
         in order to take effect."""
-        if source.type is 'SCHEME':
+        if source.type == 'SCHEME':
             required_props = Var.__required_var_props
             master_propdict = Var.__var_propdict
         else:

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -968,7 +968,7 @@ end module {module}
                             conditional = ''
                             # Find all words in the conditional, for each of them look for a matching
                             # standard name in the list of known variables
-                            items = FORTRAN_CONDITIONAL_REGEX.findall(var.active.lower())
+                            items = FORTRAN_CONDITIONAL_REGEX.findall(var.active)
                             for item in items:
                                 if item in FORTRAN_CONDITIONAL_REGEX_WORDS:
                                     conditional += item

--- a/src/ccpp_types.meta
+++ b/src/ccpp_types.meta
@@ -1,3 +1,8 @@
+[ccpp-table-properties]
+  name = ccpp_types
+  type = module
+  dependencies =
+
 [ccpp-arg-table]
   name = ccpp_types
   type = module
@@ -9,6 +14,11 @@
   type = ccpp_t
 
 ########################################################################
+[ccpp-table-properties]
+  name = ccpp_t
+  type = ddt
+  dependencies =
+
 [ccpp-arg-table]
   name = ccpp_t
   type = ddt

--- a/src/ccpp_types.meta
+++ b/src/ccpp_types.meta
@@ -11,7 +11,7 @@
 ########################################################################
 [ccpp-arg-table]
   name = ccpp_t
-  type = scheme
+  type = ddt
 [errflg]
   standard_name = ccpp_error_flag
   long_name = error flag for error handling in CCPP


### PR DESCRIPTION
This PR fixes https://github.com/NCAR/ccpp-framework/issues/308 for `ccpp_prebuild.py`.

Changes:
- add capability to parse new, required sections starting with `[ccpp-table-properties]`
    - the names in the `name = ...` attributes for these sections cannot end with one of the predefined CCPP stages (e.g. `_init`)
    - the type for these sections must be the same table as the corresponding `[ccpp-arg-table]` sections
- remove unnecessary duplication of information in `ccpp_prebuild.py`'s `argument` dictionary: instead of `arguments[module_name][scheme_name][subroutine_name]`, use `arguments[scheme_name][subroutine_name]`; this is sufficient, because per requirement `module_name = scheme_name`
- fix a bug in `src/ccpp_types.meta`
- fix a warning in `scripts/metavar.py` by changing `is` to `==`:
```
FV3/ccpp/framework/scripts/metavar.py:423: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if source.type is 'SCHEME':
```

Associated PRs:
https://github.com/earth-system-radiation/rte-rrtmgp/pull/85
https://github.com/NCAR/ccpp-framework/pull/317
https://github.com/NCAR/ccpp-physics/pull/483
https://github.com/NOAA-EMC/fv3atm/pull/153
https://github.com/ufs-community/ufs-weather-model/pull/180

See https://github.com/ufs-community/ufs-weather-model/pull/180 for regression testing.