### PR TITLE
Add 4 more pre-processor directive unit tests to test_metadata_scheme…

### DIFF
--- a/test/unit_tests/sample_scheme_files/preproc_defs_test3.F90
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test3.F90
@@ -1,0 +1,38 @@
+! Test parameterization with no vertical level
+!
+
+MODULE preproc_defs_test3
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: preproc_defs_test3_run
+
+CONTAINS
+
+  !> \section arg_table_preproc_defs_test3_run  Argument Table
+  !! \htmlinclude arg_table_preproc_defs_test3_run.html
+  !!
+  subroutine preproc_defs_test3_run (foo, &
+#ifdef CCPP
+                                     bar, &
+#endif
+                                     errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+#ifdef CCPP
+    real(kind_phys),    intent(in)    :: bar
+#endif
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine preproc_defs_test3_run
+
+END MODULE preproc_defs_test3

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test3.meta
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test3.meta
@@ -1,0 +1,32 @@
+[ccpp-arg-table]
+  name = preproc_defs_test3_run
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ bar ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test4.F90
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test4.F90
@@ -1,0 +1,38 @@
+! Test parameterization with no vertical level
+!
+
+MODULE preproc_defs_test4
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: preproc_defs_test4_init
+
+CONTAINS
+
+  !> \section arg_table_preproc_defs_test4_init  Argument Table
+  !! \htmlinclude arg_table_preproc_defs_test4_init.html
+  !!
+  subroutine preproc_defs_test4_init (foo, &
+#if CCPP > 1
+                                     bar, &
+#endif
+                                     errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+#if CCPP > 1
+    real(kind_phys),    intent(in)    :: bar
+#endif
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine preproc_defs_test4_init
+
+END MODULE preproc_defs_test4

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test4.meta
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test4.meta
@@ -1,0 +1,32 @@
+[ccpp-arg-table]
+  name = preproc_defs_test4_init
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ bar ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test5.F90
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test5.F90
@@ -1,0 +1,38 @@
+! Test parameterization with no vertical level
+!
+
+MODULE preproc_defs_test5
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: preproc_defs_test5_finalize
+
+CONTAINS
+
+  !> \section arg_table_preproc_defs_test5_finalize  Argument Table
+  !! \htmlinclude arg_table_preproc_defs_test5_finalize.html
+  !!
+  subroutine preproc_defs_test5_finalize (foo, &
+#ifdef CCPP
+                                     bar, &
+#endif
+                                     errmsg, errflg)
+
+    integer,            intent(in)    :: foo
+#ifdef CCPP
+    real(kind_phys),    intent(in)    :: bar
+#endif
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine preproc_defs_test5_finalize
+
+END MODULE preproc_defs_test5

--- a/test/unit_tests/sample_scheme_files/preproc_defs_test5.meta
+++ b/test/unit_tests/sample_scheme_files/preproc_defs_test5.meta
@@ -1,0 +1,24 @@
+[ccpp-arg-table]
+  name = preproc_defs_test5_finalize
+  type = scheme
+[ foo ]
+  standard_name = horizontal_loop_extent
+  type = integer
+  units = count
+  dimensions = ()
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_flag
+  long_name = Error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/test_metadata_scheme_file.py
+++ b/test/unit_tests/test_metadata_scheme_file.py
@@ -196,5 +196,68 @@ class MetadataHeaderTestCase(unittest.TestCase):
         self.assertTrue('Out of order argument, errmsg in preproc_defs_test2_run' in str(context.exception))
         self.assertTrue('3 errors found comparing' in str(context.exception))
 
+    def test_preproc_defs_test3(self):
+        """Test positive case of a variable that IS PRESENT the subroutine argument list
+           (due to a pre-processor directive: #ifdef CCPP), and IS PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test3.meta")]
+        preproc_defs = {'CCPP':1}  # Set CCPP directive
+        #Exercise
+        scheme_headers = parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify size of returned list equals number of scheme headers in the test file (1)
+        #       and that header (subroutine) name is 'preproc_defs_test3_run'
+        self.assertEqual(len(scheme_headers), 1)
+        #Verify header titles
+        titles = [elem.title for elem in scheme_headers]
+        self.assertTrue('preproc_defs_test3_run' in titles)
+
+    def test_preproc_defs_test4(self):
+        """Test positive case of a variable that IS PRESENT the subroutine argument list
+           (due to a pre-processor directive: #if CCPP > 1), and IS PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test4.meta")]
+        preproc_defs = {'CCPP':2}  # Set CCPP directive to > 1
+        #Exercise
+        scheme_headers = parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify size of returned list equals number of scheme headers in the test file (1)
+        #       and that header (subroutine) name is 'preproc_defs_test4_init'
+        self.assertEqual(len(scheme_headers), 1)
+        #Verify header titles
+        titles = [elem.title for elem in scheme_headers]
+        self.assertTrue('preproc_defs_test4_init' in titles)
+
+    def test_preproc_defs_test4a(self):
+        """Test correct detection of a variable that IS NOT PRESENT the subroutine argument list
+           (due to a pre-processor directive: #if CCPP > 1), but IS PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test4.meta")]
+        preproc_defs = {'CCPP':1}  # Set CCPP directive to 1
+        #Exercise
+        with self.assertRaises(Exception) as context:
+            parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify 3 correct error messages returned
+        self.assertTrue('Variable mismatch in preproc_defs_test4_init, variables missing from Fortran scheme.'
+                        in str(context.exception))
+        self.assertTrue('Variable mismatch in preproc_defs_test4_init, no Fortran variable bar.'
+                        in str(context.exception))
+        self.assertTrue('Out of order argument, errmsg in preproc_defs_test4_init' in str(context.exception))
+        self.assertTrue('3 errors found comparing' in str(context.exception))
+
+    def test_preproc_defs_test5(self):
+        """Test correct detection of a variable that IS PRESENT the subroutine argument list
+           (due to a pre-processor directive: #ifdef CCPP), and IS NOT PRESENT in meta file"""
+        #Setup
+        scheme_files = [os.path.join(self._sample_files_dir, "preproc_defs_test5.meta")]
+        preproc_defs = {'CCPP':1}  # Set CCPP directive
+        #Exercise
+        with self.assertRaises(Exception) as context:
+            parse_scheme_files(scheme_files, preproc_defs, self._logger)
+        #Verify 3 correct error messages returned
+        self.assertTrue('Variable mismatch in preproc_defs_test5_finalize, variables missing from metadata header.'
+                         in str(context.exception))
+        self.assertTrue('Out of order argument, errmsg in preproc_defs_test5_finalize' in str(context.exception))
+        self.assertTrue('Out of order argument, errflg in preproc_defs_test5_finalize' in str(context.exception))
+        self.assertTrue('3 errors found comparing' in str(context.exception))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…_file.py

and the corresponding fortran and meta sample files:

- Test positive case of a variable that IS PRESENT the subroutine argument list
  (due to a pre-processor directive: #ifdef CCPP), and IS ALSO PRESENT in meta file

- Test positive case of a variable that IS PRESENT the subroutine argument list
  (due to a pre-processor directive: #if CCPP > 1), and IS PRESENT in meta file

- Test correct detection of a variable that IS NOT PRESENT the subroutine argument list
  (due to a pre-processor directive: #if CCPP > 1), but IS PRESENT in meta file

- Test correct detection of a variable that IS PRESENT the subroutine argument list
  (due to a pre-processor directive: #ifdef CCPP), and IS NOT PRESENT in meta file

I'm still a perfect 10.00/10.  You're so kind pylint.
All tests pass.