### PR TITLE
scripts/ccpp_prebuild.py: bugfix for Python 3

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -375,9 +375,9 @@ def generate_list_of_schemes_and_dependencies_to_compile(schemes_in_files, depen
     success = True
     # schemes_in_files is a dictionary with key scheme_name and value scheme_file
     # dependencies is a dictionary with key scheme_name and value "list of dependencies"
-    schemes_and_dependencies_to_compile = schemes_in_files.values() + \
-            [dependency for dependency_list in dependencies1.values() for dependency in dependency_list] + \
-            [dependency for dependency_list in dependencies2.values() for dependency in dependency_list]
+    schemes_and_dependencies_to_compile = list(schemes_in_files.values()) + \
+            [dependency for dependency_list in list(dependencies1.values()) for dependency in dependency_list] + \
+            [dependency for dependency_list in list(dependencies2.values()) for dependency in dependency_list]
     # Remove duplicates
     return (success, list(set(schemes_and_dependencies_to_compile)))
 


### PR DESCRIPTION
## Description

This PR fixes a bug that shows up with Python 3 only, for which dict.values() does not automatically return a list (unlike in Python 2).

## Testing

For (regression) testing information, see https://github.com/ufs-community/ufs-weather-model/pull/201.

## Dependencies

https://github.com/NCAR/ccpp-framework/pull/322
https://github.com/NOAA-EMC/fv3atm/pull/171
https://github.com/ufs-community/ufs-weather-model/pull/201
