### PR TITLE
Updates to unit tests in test_metadata_scheme_file.py:

### DIFF
--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.F90
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.F90
@@ -1,21 +1,21 @@
 ! Test parameterization with no vertical level
 !
 
-MODULE preproc_defs_test5
+MODULE CCPPeq1_var_in_fort_meta
 
   USE ccpp_kinds, ONLY: kind_phys
 
   IMPLICIT NONE
   PRIVATE
 
-  PUBLIC :: preproc_defs_test5_finalize
+  PUBLIC :: CCPPeq1_var_in_fort_meta_run
 
 CONTAINS
 
-  !> \section arg_table_preproc_defs_test5_finalize  Argument Table
-  !! \htmlinclude arg_table_preproc_defs_test5_finalize.html
+  !> \section arg_table_CCPPeq1_var_in_fort_meta_run  Argument Table
+  !! \htmlinclude arg_table_CCPPeq1_var_in_fort_meta_run.html
   !!
-  subroutine preproc_defs_test5_finalize (foo, &
+  subroutine CCPPeq1_var_in_fort_meta_run (foo, &
 #ifdef CCPP
                                      bar, &
 #endif
@@ -33,6 +33,6 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine preproc_defs_test5_finalize
+  end subroutine CCPPeq1_var_in_fort_meta_run
 
-END MODULE preproc_defs_test5
+END MODULE CCPPeq1_var_in_fort_meta

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = CCPPeq1_var_in_fort_meta
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_in_fort_meta.meta
@@ -1,11 +1,25 @@
+[ccpp-table-properties]
+  name = CCPPeq1_var_in_fort_meta
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
-  name = preproc_defs_test5_finalize
+  name = CCPPeq1_var_in_fort_meta_run
   type = scheme
 [ foo ]
   standard_name = horizontal_loop_extent
   type = integer
   units = count
   dimensions = ()
+  intent = in
+[ bar ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.F90
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.F90
@@ -1,21 +1,21 @@
 ! Test parameterization with no vertical level
 !
 
-MODULE preproc_defs_test2
+MODULE CCPPeq1_var_missing_in_fort
 
   USE ccpp_kinds, ONLY: kind_phys
 
   IMPLICIT NONE
   PRIVATE
 
-  PUBLIC :: preproc_defs_test2_run
+  PUBLIC :: CCPPeq1_var_missing_in_fort_run
 
 CONTAINS
 
-  !> \section arg_table_preproc_defs_test2_run  Argument Table
-  !! \htmlinclude arg_table_preproc_defs_test2_run.html
+  !> \section arg_table_CCPPeq1_var_missing_in_fort_run  Argument Table
+  !! \htmlinclude arg_table_CCPPeq1_var_missing_in_fort_run.html
   !!
-  subroutine preproc_defs_test2_run (foo, &
+  subroutine CCPPeq1_var_missing_in_fort_run (foo, &
 #ifndef CCPP
                                      bar, &
 #endif
@@ -33,6 +33,6 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine preproc_defs_test2_run
+  end subroutine CCPPeq1_var_missing_in_fort_run
 
-END MODULE preproc_defs_test2
+END MODULE CCPPeq1_var_missing_in_fort

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.meta
@@ -1,5 +1,11 @@
+[ccpp-table-properties]
+  name = CCPPeq1_var_missing_in_fort
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
-  name = preproc_defs_test4_init
+  name = CCPPeq1_var_missing_in_fort_run
   type = scheme
 [ foo ]
   standard_name = horizontal_loop_extent

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_fort.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = CCPPeq1_var_missing_in_fort
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.F90
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.F90
@@ -1,28 +1,28 @@
 ! Test parameterization with no vertical level
 !
 
-MODULE preproc_defs_test4
+MODULE CCPPeq1_var_missing_in_meta
 
   USE ccpp_kinds, ONLY: kind_phys
 
   IMPLICIT NONE
   PRIVATE
 
-  PUBLIC :: preproc_defs_test4_init
+  PUBLIC :: CCPPeq1_var_missing_in_meta_finalize
 
 CONTAINS
 
-  !> \section arg_table_preproc_defs_test4_init  Argument Table
-  !! \htmlinclude arg_table_preproc_defs_test4_init.html
+  !> \section arg_table_CCPPeq1_var_missing_in_meta_finalize  Argument Table
+  !! \htmlinclude arg_table_CCPPeq1_var_missing_in_meta_finalize.html
   !!
-  subroutine preproc_defs_test4_init (foo, &
-#if CCPP > 1
+  subroutine CCPPeq1_var_missing_in_meta_finalize (foo, &
+#ifdef CCPP
                                      bar, &
 #endif
                                      errmsg, errflg)
 
     integer,            intent(in)    :: foo
-#if CCPP > 1
+#ifdef CCPP
     real(kind_phys),    intent(in)    :: bar
 #endif
     character(len=512), intent(out)   :: errmsg
@@ -33,6 +33,6 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine preproc_defs_test4_init
+  end subroutine CCPPeq1_var_missing_in_meta_finalize
 
-END MODULE preproc_defs_test4
+END MODULE CCPPeq1_var_missing_in_meta

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = CCPPeq1_var_missing_in_meta
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPeq1_var_missing_in_meta.meta
@@ -1,19 +1,17 @@
+[ccpp-table-properties]
+  name = CCPPeq1_var_missing_in_meta
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
-  name = preproc_defs_test3_run
+  name = CCPPeq1_var_missing_in_meta_finalize
   type = scheme
 [ foo ]
   standard_name = horizontal_loop_extent
   type = integer
   units = count
   dimensions = ()
-  intent = in
-[ bar ]
-  standard_name = time_step_for_physics
-  long_name = time step
-  units = s
-  dimensions = ()
-  type = real
-  kind = kind_phys
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message

--- a/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.F90
+++ b/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.F90
@@ -1,28 +1,28 @@
 ! Test parameterization with no vertical level
 !
 
-MODULE preproc_defs_test3
+MODULE CCPPgt1_var_in_fort_meta
 
   USE ccpp_kinds, ONLY: kind_phys
 
   IMPLICIT NONE
   PRIVATE
 
-  PUBLIC :: preproc_defs_test3_run
+  PUBLIC :: CCPPgt1_var_in_fort_meta_init
 
 CONTAINS
 
-  !> \section arg_table_preproc_defs_test3_run  Argument Table
-  !! \htmlinclude arg_table_preproc_defs_test3_run.html
+  !> \section arg_table_CCPPgt1_var_in_fort_meta_init  Argument Table
+  !! \htmlinclude arg_table_CCPPgt1_var_in_fort_meta_init.html
   !!
-  subroutine preproc_defs_test3_run (foo, &
-#ifdef CCPP
+  subroutine CCPPgt1_var_in_fort_meta_init (foo, &
+#if CCPP > 1
                                      bar, &
 #endif
                                      errmsg, errflg)
 
     integer,            intent(in)    :: foo
-#ifdef CCPP
+#if CCPP > 1
     real(kind_phys),    intent(in)    :: bar
 #endif
     character(len=512), intent(out)   :: errmsg
@@ -33,6 +33,6 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine preproc_defs_test3_run
+  end subroutine CCPPgt1_var_in_fort_meta_init
 
-END MODULE preproc_defs_test3
+END MODULE CCPPgt1_var_in_fort_meta

--- a/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = CCPPgt1_var_in_fort_meta
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPgt1_var_in_fort_meta.meta
@@ -1,11 +1,25 @@
+[ccpp-table-properties]
+  name = CCPPgt1_var_in_fort_meta
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
-  name = preproc_defs_test1_run
+  name = CCPPgt1_var_in_fort_meta_init
   type = scheme
 [ foo ]
   standard_name = horizontal_loop_extent
   type = integer
   units = count
   dimensions = ()
+  intent = in
+[ bar ]
+  standard_name = time_step_for_physics
+  long_name = time step
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message

--- a/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.F90
+++ b/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.F90
@@ -1,21 +1,21 @@
 ! Test parameterization with no vertical level
 !
 
-MODULE preproc_defs_test1
+MODULE CCPPnotset_var_missing_in_meta
 
   USE ccpp_kinds, ONLY: kind_phys
 
   IMPLICIT NONE
   PRIVATE
 
-  PUBLIC :: preproc_defs_test1_run
+  PUBLIC :: CCPPnotset_var_missing_in_meta_run
 
 CONTAINS
 
-  !> \section arg_table_preproc_defs_test1_run  Argument Table
-  !! \htmlinclude arg_table_preproc_defs_test1_run.html
+  !> \section arg_table_CCPPnotset_var_missing_in_meta_run  Argument Table
+  !! \htmlinclude arg_table_CCPPnotset_var_missing_in_meta_run.html
   !!
-  subroutine preproc_defs_test1_run (foo, &
+  subroutine CCPPnotset_var_missing_in_meta_run (foo, &
 #ifndef CCPP
                                      bar, &
 #endif
@@ -33,6 +33,6 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine preproc_defs_test1_run
+  end subroutine CCPPnotset_var_missing_in_meta_run
 
-END MODULE preproc_defs_test1
+END MODULE CCPPnotset_var_missing_in_meta

--- a/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = CCPPnotset_var_missing_in_meta
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.meta
+++ b/test/unit_tests/sample_scheme_files/CCPPnotset_var_missing_in_meta.meta
@@ -1,19 +1,17 @@
+[ccpp-table-properties]
+  name = CCPPnotset_var_missing_in_meta
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
-  name = preproc_defs_test2_run
+  name = CCPPnotset_var_missing_in_meta_run
   type = scheme
 [ foo ]
   standard_name = horizontal_loop_extent
   type = integer
   units = count
   dimensions = ()
-  intent = in
-[ bar ]
-  standard_name = time_step_for_physics
-  long_name = time step
-  units = s
-  dimensions = ()
-  type = real
-  kind = kind_phys
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message

--- a/test/unit_tests/sample_scheme_files/invalid_dummy_arg.meta
+++ b/test/unit_tests/sample_scheme_files/invalid_dummy_arg.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = invalid_dummy_arg
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = invalid_dummy_arg_run
   type = scheme

--- a/test/unit_tests/sample_scheme_files/invalid_dummy_arg.meta
+++ b/test/unit_tests/sample_scheme_files/invalid_dummy_arg.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = invalid_dummy_arg
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/invalid_subr_stmnt.meta
+++ b/test/unit_tests/sample_scheme_files/invalid_subr_stmnt.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = invalid_subr_stmnt
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/invalid_subr_stmnt.meta
+++ b/test/unit_tests/sample_scheme_files/invalid_subr_stmnt.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = invalid_subr_stmnt
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = invalid_subr_stmnt_init
   type = scheme

--- a/test/unit_tests/sample_scheme_files/mismatch_intent.meta
+++ b/test/unit_tests/sample_scheme_files/mismatch_intent.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = mismatch_intent
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/mismatch_intent.meta
+++ b/test/unit_tests/sample_scheme_files/mismatch_intent.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = mismatch_intent
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = mismatch_intent_run
   type = scheme

--- a/test/unit_tests/sample_scheme_files/missing_arg_table.meta
+++ b/test/unit_tests/sample_scheme_files/missing_arg_table.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = missing_arg_table
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = missing_arg_table_init
   type = scheme

--- a/test/unit_tests/sample_scheme_files/missing_arg_table.meta
+++ b/test/unit_tests/sample_scheme_files/missing_arg_table.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = missing_arg_table
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/missing_fort_header.meta
+++ b/test/unit_tests/sample_scheme_files/missing_fort_header.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = missing_fort_header
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = missing_fort_header_run
   type = scheme

--- a/test/unit_tests/sample_scheme_files/missing_fort_header.meta
+++ b/test/unit_tests/sample_scheme_files/missing_fort_header.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = missing_fort_header
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/reorder.meta
+++ b/test/unit_tests/sample_scheme_files/reorder.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = reorder
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/reorder.meta
+++ b/test/unit_tests/sample_scheme_files/reorder.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = reorder
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = reorder_finalize
   type = scheme

--- a/test/unit_tests/sample_scheme_files/temp_adjust.meta
+++ b/test/unit_tests/sample_scheme_files/temp_adjust.meta
@@ -1,7 +1,6 @@
 [ccpp-table-properties]
   name = temp_adjust
   type = scheme
-  dependencies = 
   
 ########################################################################
 [ccpp-arg-table]

--- a/test/unit_tests/sample_scheme_files/temp_adjust.meta
+++ b/test/unit_tests/sample_scheme_files/temp_adjust.meta
@@ -1,3 +1,9 @@
+[ccpp-table-properties]
+  name = temp_adjust
+  type = scheme
+  dependencies = 
+  
+########################################################################
 [ccpp-arg-table]
   name = temp_adjust_run
   type = scheme


### PR DESCRIPTION
  - Update unit tests to include ccpp-table-properites
  - Rename sample files preproc_defs_test*.meta to be more descriptive
  - Rename sample files preproc_defs_test*.F90 to be more descriptive

pylint rated at 10.00/10 for test_metadata_scheme_file.py
All tests pass for test_metadata_scheme_file.py

Still need to update test_metadata_table.py