### PR TITLE
feature/transition-to-capgen-1: improve logging output for unit conversions

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -511,6 +511,7 @@ def compare_metadata(metadata_define, metadata_request):
             if var.units == metadata_define[var_name][0].units:
                 continue
             # Register conversion, depending on the intent for this subroutine.
+            logging.debug('Registering unit conversion for variable {0} in {1}'.format(var_name, var.container))
             if var.intent=='inout':
                 var.convert_from(metadata_define[var_name][0].units)
                 var.convert_to(metadata_define[var_name][0].units)


### PR DESCRIPTION
Add additional information to CCPP prebuild log when/before performing unit conversions.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/506
https://github.com/NCAR/ccpp-framework/pull/327
https://github.com/NCAR/fv3atm/pull/64
https://github.com/NCAR/ufs-weather-model/pull/65

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/65.
