### PR TITLE
Merge NCAR feature/transition-to-capgen-1 (prepare for cap_gen.py, step 1) to master

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -511,6 +511,7 @@ def compare_metadata(metadata_define, metadata_request):
             if var.units == metadata_define[var_name][0].units:
                 continue
             # Register conversion, depending on the intent for this subroutine.
+            logging.debug('Registering unit conversion for variable {0} in {1}'.format(var_name, var.container))
             if var.intent=='inout':
                 var.convert_from(metadata_define[var_name][0].units)
                 var.convert_to(metadata_define[var_name][0].units)

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -146,7 +146,6 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                 else:
                     container = encode_container(module_name, new_metadata_header.title)
         else:
-            logging.warning("DH DEBUG: new_metadata_header.property_table, new_metadata_header.title, scheme_name: {} {} {}".format(new_metadata_header.property_table, new_metadata_header.title, scheme_name))
             # Scheme property tables
             if new_metadata_header.property_table and new_metadata_header.title == scheme_name:
                 # If this is a ccpp-table-properties table for a scheme, it can only contain dependencies;
@@ -171,7 +170,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             # make sense), we swap the standard name and add a note to the long name
             legacy_note = ''
             if standard_name == 'horizontal_loop_extent' and scheme_name and \
-                    (table_name.endswith("_init") or table_name.endswith("finalize")):
+                    (table_name.endswith("_init") or table_name.endswith("_finalize")):
                 logging.warn("Legacy extension - replacing variable 'horizontal_loop_extent'" + \
                              " with 'horizontal_dimension' in table {}".format(table_name))
                 standard_name = 'horizontal_dimension'


### PR DESCRIPTION
This PR updates master with the combined changes in NCAR's feature/transition-to-capgen-1 branch. The changes are tiny and are not strictly required for the transition, but provide better information in the log files produced by `ccpp_prebuild.py`

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/508
https://github.com/NCAR/ccpp-framework/pull/330
https://github.com/NOAA-EMC/fv3atm/pull/186
https://github.com/ufs-community/ufs-weather-model/pull/216

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/216