### PR TITLE
scripts/ccpp_prebuild.py: sort schemes before creating makefile snippets to avoid recompiling

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -664,6 +664,8 @@ def generate_schemes_makefile(schemes, schemes_makefile, schemes_cmakefile, sche
     cmakefile.filename = schemes_cmakefile + '.tmp'
     sourcefile = SchemesSourcefile()
     sourcefile.filename = schemes_sourcefile + '.tmp'
+    # Sort schemes so that the order remains the same (for cmake to avoid) recompiling
+    schemes.sort()
     # Generate list of schemes with absolute path
     schemes_with_abspath = [ os.path.abspath(scheme) for scheme in schemes ]
     makefile.write(schemes_with_abspath)


### PR DESCRIPTION
As the title says. Sorting the schemes avoids unnecessary recompiling.

The problem of a different order in the auto-generated cmake/gnumake/shell snippets that contain the list of schemes and dependencies to compile doesn't happen on my Mac, but on hera for example.

This PR will be combined with other PRs for the UFS weather model in the near future, but please review and approve when you get the chance.