### PR TITLE
Implementation of CCPP timestep_init and timestep_final phases

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -13,7 +13,7 @@ import sys
 
 # CCPP framework imports
 from common import encode_container, decode_container, decode_container_as_dict, execute
-from common import CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE, CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
+from common import CCPP_STAGES, CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE, CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
 from common import STANDARD_VARIABLE_TYPES, STANDARD_INTEGER_TYPE, CCPP_TYPE
 from common import SUITE_DEFINITION_FILENAME_PATTERN
 from common import split_var_name_and_array_reference
@@ -341,6 +341,9 @@ def filter_metadata(metadata, arguments, dependencies, schemes_in_files, suites)
         for var in metadata[var_name][:]:
             container_string = decode_container(var.container)
             subroutine = container_string[container_string.find('SUBROUTINE')+len('SUBROUTINE')+1:]
+            # Replace the full CCPP stage name with the abbreviated version
+            for ccpp_stage in CCPP_STAGES.keys():
+                subroutine = subroutine.replace(ccpp_stage, CCPP_STAGES[ccpp_stage])
             for suite in suites:
                 if subroutine in suite.all_subroutines_called:
                     keep = True

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from collections import OrderedDict
 import keyword
 import logging
 import os
@@ -7,7 +8,16 @@ import re
 import subprocess
 import sys
 
-CCPP_STAGES = [ 'init', 'run', 'finalize' ]
+# This dictionary contains short names for the different CCPP stages,
+# because Fortran does not allow subroutine names with more than 63 characters
+# Important: 'timestep_init' and 'timestep_finalize' need to come first so that
+# a pattern match won't pick "init" for a CCPP subroutine name "xyz_timestep_init"
+CCPP_STAGES = OrderedDict()
+CCPP_STAGES['timestep_init']     = 'tsinit'
+CCPP_STAGES['timestep_finalize'] = 'tsfinal'
+CCPP_STAGES['init']              = 'init'
+CCPP_STAGES['run']               = 'run'
+CCPP_STAGES['finalize']          = 'final'
 
 CCPP_ERROR_FLAG_VARIABLE = 'ccpp_error_flag'
 CCPP_ERROR_MSG_VARIABLE  = 'ccpp_error_message'


### PR DESCRIPTION
This PR contains the following changes:
- Implementation of CCPP `timestep_init` and `timestep_final` phases
- Use CCPP_stages dictionary to abbreviate `timestep_init` and `timestep_final` as `tsinit` and `tsfinal` in cap subroutine names
- Drop requirement that CCPP schemes have to have subroutines for each phase, even if those are empty and don't have CCPP metadata tables

Associated PRs:

https://github.com/ufs-community/ufs-weather-model/pull/337
https://github.com/NOAA-EMC/fv3atm/pull/217
https://github.com/NCAR/ccpp-physics/pull/534
https://github.com/NCAR/ccpp-framework/pull/344
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/47

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/337.