### PR TITLE
Remove overly restrictive testing of doxygen comments when looking for scheme tables from scripts/metadata_parser.py

### DIFF
--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -169,30 +169,38 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
             # DH* 2020-05-26
             # Legacy extension for inconsistent metadata (use of horizontal_dimension versus horizontal_loop_extent).
             # Since horizontal_dimension and horizontal_loop_extent have the same attributes (otherwise it doesn't
-            # make sense), we swap the standard name and add a note to the long name
+            # make sense), we swap the standard name and add a note to the long name - 2021-05-26: this is now an error.
             legacy_note = ''
             if standard_name == 'horizontal_loop_extent' and scheme_name and \
                     (table_name.endswith("_init") or table_name.endswith("_finalize")):
-                logging.warn("Legacy extension - replacing variable 'horizontal_loop_extent'" + \
-                             " with 'horizontal_dimension' in table {}".format(table_name))
-                standard_name = 'horizontal_dimension'
-                legacy_note = ' replaced by horizontal dimension (legacy extension)'
+                #logging.warn("Legacy extension - replacing variable 'horizontal_loop_extent'" + \
+                #             " with 'horizontal_dimension' in table {}".format(table_name))
+                #standard_name = 'horizontal_dimension'
+                #legacy_note = ' replaced by horizontal dimension (legacy extension)'
+                raise Exception("Legacy extension DISABLED: replacing variable 'horizontal_loop_extent'" + \
+                                " with 'horizontal_dimension' in table {}".format(table_name))
             elif standard_name == 'horizontal_dimension' and scheme_name and table_name.endswith("_run"):
-                logging.warn("Legacy extension - replacing variable 'horizontal_dimension' " + \
-                             "with 'horizontal_loop_extent' in table {}".format(table_name))
-                standard_name = 'horizontal_loop_extent'
-                legacy_note = ' replaced by horizontal loop extent (legacy extension)'
+                #logging.warn("Legacy extension - replacing variable 'horizontal_dimension'" + \
+                #             " with 'horizontal_loop_extent' in table {}".format(table_name))
+                #standard_name = 'horizontal_loop_extent'
+                #legacy_note = ' replaced by horizontal loop extent (legacy extension)'
+                raise Exception("Legacy extension DISABLED: replacing variable 'horizontal_dimension'" + \
+                                " with 'horizontal_loop_extent' in table {}".format(table_name))
             # Adjust dimensions
             dimensions = new_var.get_prop_value('dimensions')
             if scheme_name and (table_name.endswith("_init") or table_name.endswith("_finalize")) \
                     and 'horizontal_loop_extent' in dimensions:
-                logging.warn("Legacy extension - replacing dimension 'horizontal_loop_extent' with 'horizontal_dimension' " + \
-                             "for variable {} in table {}".format(standard_name,table_name))
-                dimensions = ['horizontal_dimension' if x=='horizontal_loop_extent' else x for x in dimensions]
+                #logging.warn("Legacy extension - replacing dimension 'horizontal_loop_extent' with 'horizontal_dimension' " + \
+                #             "for variable {} in table {}".format(standard_name,table_name))
+                #dimensions = ['horizontal_dimension' if x=='horizontal_loop_extent' else x for x in dimensions]
+                raise Exception("Legacy extension DISABLED: replacing dimension 'horizontal_loop_extent' with 'horizontal_dimension' " + \
+                                "for variable {} in table {}".format(standard_name,table_name))
             elif scheme_name and table_name.endswith("_run") and 'horizontal_dimension' in dimensions:
-                logging.warn("Legacy extension - replacing dimension 'horizontal_dimension' with 'horizontal_loop_extent' " + \
-                             "for variable {} in table {}".format(standard_name,table_name))
-                dimensions = ['horizontal_loop_extent' if x=='horizontal_dimension' else x for x in dimensions]
+                #logging.warn("Legacy extension - replacing dimension 'horizontal_dimension' with 'horizontal_loop_extent' " + \
+                #             "for variable {} in table {}".format(standard_name,table_name))
+                #dimensions = ['horizontal_loop_extent' if x=='horizontal_dimension' else x for x in dimensions]
+                raise Exception("Legacy extension DISABLED: replacing dimension 'horizontal_dimension' with 'horizontal_loop_extent' " + \
+                                "for variable {} in table {}".format(standard_name,table_name))
             # *DH  2020-05-26
             if new_var.get_prop_value('active').lower() == '.true.':
                 active = 'T'

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -380,8 +380,6 @@ def parse_variable_tables(filepath, filename):
                 header_line_number = current_line_number + 1
                 line_counter += 1
                 continue
-            elif (words[0].startswith('!!') or words[0].startswith('!>')) and '\section' in words[0]:
-                raise Exception("Malformatted table found in {0} / {1} / {2}".format(filename, module_name, table_name))
             # If an argument table is found, parse it
             if in_table:
                 words = line.split('|')


### PR DESCRIPTION
This PR removes an overly restrictive and unnecessary test of doxygen comments when looking for scheme tables from scripts/metadata_parser.py.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/627
https://github.com/NCAR/ccpp-framework/pull/366
https://github.com/NOAA-EMC/fv3atm/pull/285
https://github.com/ufs-community/ufs-weather-model/pull/529

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/529