### PR TITLE
scripts/mkstatic.py: always copy data in, independent of the intent

### DIFF
--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1192,9 +1192,8 @@ end module {module}
                                 # Add necessary local variables for looping over blocks
                                 var_defs_manual.append('integer :: ib, nb')
 
-                                # Define actions before, depending on intent
-                                if var.intent in [ 'in', 'inout' ]:
-                                    actions_in = '''        allocate({tmpvar}({dims}))
+                                # Define actions before. Always copy data in, independent of intent.
+                                actions_in = '''        allocate({tmpvar}({dims}))
         ib = 1
         do nb=1,{block_count}
           {tmpvar}({dimpad_before}ib:ib+{block_size}-1{dimpad_after}) = {var}
@@ -1208,12 +1207,7 @@ end module {module}
            dimpad_before=dimpad_before,
            dimpad_after=dimpad_after,
            )
-                                else:
-                                    actions_in = '''        allocate({tmpvar}({dims}))
-'''.format(tmpvar=tmpvar.local_name,
-           dims=','.join(alloc_dimensions),
-           )
-                                # Define actions after, depending on intent
+                                # Define actions after, depending on intent.
                                 if var.intent in [ 'inout', 'out' ]:
                                     actions_out = '''        ib = 1
         do nb=1,{block_count}


### PR DESCRIPTION
Because physics schemes do not know the size of each dimension of a variable allocated by the host model, we need to always copy data in when data is converted from blocked data structures into contiguous arrays.

A discussion of the meaning of `intent(out)` for a physics scheme will be held at the ccpp-framework developer meeting on 04/27/2021.

Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/368
https://github.com/NCAR/ccpp-physics/pull/641
https://github.com/NOAA-EMC/fv3atm/pull/291
https://github.com/ufs-community/ufs-weather-model/pull/541

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/541