### PR TITLE
Merge main into feature capgen 2021/11/05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ endif (NOT PROJECT)
 #------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.0)
 
-project(ccpp
-        VERSION 4.0.0
-        LANGUAGES C CXX Fortran)
+project(ccpp_framework
+        VERSION 5.0.0
+        LANGUAGES Fortran)
 
 # Use rpaths on MacOSX
 set(CMAKE_MACOSX_RPATH 1)
@@ -33,26 +33,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 if (OPENMP)
   include(detect_openmp)
   detect_openmp()
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
   set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
-  message(STATUS "Enable OpenMP support for C/C++/Fortran compiler")
+  message(STATUS "Enable OpenMP support")
 else (OPENMP)
-  message (STATUS "Disable OpenMP support for C/C++/Fortran compiler")
+  message (STATUS "Disable OpenMP support")
 endif (OPENMP)
-
-#------------------------------------------------------------------------------
-# The Fortran compiler/linker flag inserted by cmake to create shared libraries
-# with the Intel compiler is deprecated (-i_dynamic), correct here.
-# CMAKE_Fortran_COMPILER_ID = {"Intel", "PGI", "GNU", "Clang", "MSVC", ...}
-if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
-    string(REPLACE "-i_dynamic" "-shared-intel"
-           CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS
-           "${CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS}")
-    string(REPLACE "-i_dynamic" "-shared-intel"
-           CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS
-           "${CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS}")
-endif()
 
 #------------------------------------------------------------------------------
 # Set a default build type if none was specified
@@ -62,15 +47,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "Coverage")
-endif()
-
-#------------------------------------------------------------------------------
-# The PGI compiler can not find any cap routines in their library.
-# This is due to how it labels subroutines within a modules.
-# For example the subroutine b() in the moduel a(), gets named a_b.
-# GCC and Intel do NOT do this, it is name simply as b.
-if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI")
-    message(STATUS "WARNING: PGI compiler is not fully ISO_C compliant; working solution involves a hack pgifix.py")
 endif()
 
 #------------------------------------------------------------------------------
@@ -98,7 +74,7 @@ add_subdirectory(doc)
 #------------------------------------------------------------------------------
 # Configure and enable packaging
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Common Community Physics Package - Framework")
-set(CPACK_PACKAGE_VENDOR "GMTB NOAA/NCAR")
+set(CPACK_PACKAGE_VENDOR "DTC NOAA/NCAR")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -23,11 +23,10 @@ from metadata_table import MetadataTable, parse_metadata_file
 # commented out, no check is performed. This is the case for 'type' and 'kind' right now, since models use their
 # own derived data types and kind types.
 VALID_ITEMS = {
-    'header' : ['local_name', 'standard_name', 'long_name', 'units', 'rank', 'type', 'kind', 'intent', 'optional'],
+    'header' : ['local_name', 'standard_name', 'long_name', 'units', 'rank', 'type', 'kind', 'intent'],
     #'type' : ['character', 'integer', 'real', ...],
     #'kind' : ['default', 'kind_phys', ...],
     'intent' : ['none', 'in', 'out', 'inout'],
-    'optional' : ['T', 'F'],
     }
 
 # Mandatory variables that every scheme needs to have
@@ -41,7 +40,6 @@ CCPP_MANDATORY_VARIABLES = {
                                rank          = '',
                                kind          = 'len=*',
                                intent        = 'out',
-                               optional      = 'F',
                                active        = 'T',
                                ),
     'ccpp_error_flag' : Var(local_name    = 'ierr',
@@ -53,7 +51,6 @@ CCPP_MANDATORY_VARIABLES = {
                             rank          = '',
                             kind          = '',
                             intent        = 'out',
-                            optional      = 'F',
                             active        = 'T',
                             ),
     }
@@ -222,7 +219,6 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                           container     = container,
                           kind          = kind,
                           intent        = new_var.get_prop_value('intent'),
-                          optional      = 'T' if new_var.get_prop_value('optional') else 'F',
                           active        = active,
                           )
                 # Check for duplicates in same table

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -15,6 +15,12 @@ sys.path.append(os.path.join(os.path.split(__file__)[0], 'fortran_tools'))
 from parse_fortran import FtypeTypeDecl
 from parse_checkers import registered_fortran_ddt_names
 from metadata_table import MetadataTable, parse_metadata_file
+from framework_env import CCPPFrameworkEnv
+
+_DUMMY_RUN_ENV = CCPPFrameworkEnv(None, ndict={'host_files':'',
+                                               'scheme_files':'',
+                                               'suites':''})
+
 
 # Output: This routine converts the argument tables for all subroutines / typedefs / kind / module variables
 # into dictionaries suitable to be used with ccpp_prebuild.py (which generates the fortran code for the caps)
@@ -104,7 +110,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
         new_metadata_headers = NEW_METADATA_SAVE[filename]
     else:
         new_metadata_headers = parse_metadata_file(filename, known_ddts=registered_fortran_ddt_names(),
-                                                                    logger=logging.getLogger(__name__))
+                                                                                run_env=_DUMMY_RUN_ENV)
         NEW_METADATA_SAVE[filename] = new_metadata_headers
 
     # Record dependencies for the metadata table (only applies to schemes)

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -142,6 +142,9 @@ class Var:
     >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'ino'}, ParseSource('vname', 'SCHEME', ParseContext()), _MVAR_DUMMY_RUN_ENV) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ParseSyntaxError: Invalid intent variable property, 'ino', at <standard input>:1
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in', 'optional' : 'false'}, ParseSource('vname', 'SCHEME', ParseContext())) #doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ParseSyntaxError: Invalid variable property name, 'optional', at <standard input>:1
     """
 
     ## Prop lists below define all the allowed CCPP Metadata attributes

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -142,7 +142,7 @@ class Var:
     >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'ino'}, ParseSource('vname', 'SCHEME', ParseContext()), _MVAR_DUMMY_RUN_ENV) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ParseSyntaxError: Invalid intent variable property, 'ino', at <standard input>:1
-    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in', 'optional' : 'false'}, ParseSource('vname', 'SCHEME', ParseContext())) #doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm/s', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in', 'optional' : 'false'}, ParseSource('vname', 'SCHEME', ParseContext()), _MVAR_DUMMY_RUN_ENV) #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ParseSyntaxError: Invalid variable property name, 'optional', at <standard input>:1
     """

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -32,7 +32,6 @@ class Var(object):
         self._container     = None
         self._kind          = None
         self._intent        = None
-        self._optional      = None
         self._active        = None
         self._target        = None
         self._actions       = { 'in' : None, 'out' : None }
@@ -122,17 +121,6 @@ class Var(object):
         if not value in ['none', 'in', 'out', 'inout']:
             raise ValueError('Invalid value {0} for variable property intent'.format(value))
         self._intent = value
-
-    @property
-    def optional(self):
-        '''Get the optional attribute of the variable.'''
-        return self._optional
-
-    @optional.setter
-    def optional(self, value):
-        if not value in ['T', 'F']:
-            raise ValueError('Invalid value {0} for variable property optional'.format(value))
-        self._optional = value
 
     @property
     def active(self):
@@ -281,7 +269,6 @@ class Var(object):
         rank          = {s.rank} *
         kind          = {s.kind} *
         intent        = {s.intent}
-        optional      = {s.optional}
         active        = {s.active}
         target        = {s.target}
         container     = {s.container}

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -15,7 +15,7 @@ import xml.etree.ElementTree as ET
 from common import encode_container
 from common import CCPP_STAGES
 from common import CCPP_ERROR_FLAG_VARIABLE, CCPP_ERROR_MSG_VARIABLE, CCPP_LOOP_COUNTER, CCPP_LOOP_EXTENT
-from common import CCPP_BLOCK_NUMBER, CCPP_BLOCK_COUNT, CCPP_BLOCK_SIZES, CCPP_INTERNAL_VARIABLES
+from common import CCPP_BLOCK_NUMBER, CCPP_BLOCK_COUNT, CCPP_BLOCK_SIZES, CCPP_THREAD_NUMBER, CCPP_INTERNAL_VARIABLES
 from common import CCPP_CONSTANT_ONE, CCPP_HORIZONTAL_DIMENSION, CCPP_HORIZONTAL_LOOP_EXTENT
 from common import FORTRAN_CONDITIONAL_REGEX_WORDS, FORTRAN_CONDITIONAL_REGEX
 from common import CCPP_TYPE, STANDARD_VARIABLE_TYPES, STANDARD_CHARACTER_TYPE
@@ -661,9 +661,10 @@ end module {module}
     def arguments(self, value):
         self._arguments = value
 
-    def write(self, metadata_request, metadata_define, arguments):
+    def write(self, metadata_request, metadata_define, arguments, debug):
         """Create caps for all groups in the suite and for the entire suite
-        (calling the group caps one after another)"""
+        (calling the group caps one after another). Add additional code for
+        debugging if debug flag is True."""
         # Set name of module and filename of cap
         self._module = 'ccpp_{suite_name}_cap'.format(suite_name=self._name)
         self.filename = '{module_name}.F90'.format(module_name=self._module)
@@ -674,7 +675,7 @@ end module {module}
         # require adjusting the intent of the variables.
         module_use = ''
         for group in self._groups:
-            group.write(metadata_request, metadata_define, arguments)
+            group.write(metadata_request, metadata_define, arguments, debug)
             for subroutine in group.subroutines:
                 module_use += '   use {m}, only: {s}\n'.format(m=group.module, s=subroutine)
             for ccpp_stage in CCPP_STAGES.keys():
@@ -892,7 +893,10 @@ end module {module}
         for key, value in kwargs.items():
             setattr(self, "_"+key, value)
 
-    def write(self, metadata_request, metadata_define, arguments):
+    def write(self, metadata_request, metadata_define, arguments, debug):
+        """Create caps for all stages of this group. Add additional code for
+        debugging if debug flag is True."""
+
         # Create an inverse lookup table of local variable names defined (by the host model) and standard names
         standard_name_by_local_name_define = collections.OrderedDict()
         for standard_name in metadata_define.keys():
@@ -972,6 +976,9 @@ end module {module}
                                 except ValueError:
                                     if not dim in local_vars.keys() and \
                                             not dim in additional_variables_required + arguments[scheme_name][subroutine_name]:
+                                        if not dim in metadata_define.keys():
+                                            raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(
+                                                                                                                       dim, var_standard_name))
                                         logging.debug("Adding dimension {} for variable {}".format(dim, var_standard_name))
                                         additional_variables_required.append(dim)
 
@@ -1040,7 +1047,6 @@ end module {module}
                             # of host model variables and set necessary default values
                             var = copy.deepcopy(metadata_define[var_standard_name][0])
                             var.intent = 'in'
-                            var.optional = 'F'
 
                         if not var_standard_name in local_vars.keys():
                             # The full name of the variable as known to the host model
@@ -1137,6 +1143,71 @@ end module {module}
                         if not var_standard_name in arguments[scheme_name][subroutine_name]:
                             continue
 
+                        # To assist debugging efforts, check if arrays have the correct size (ignore scalars for now)
+                        assign_test = ''
+                        if debug:
+                            if ccpp_stage in ['init', 'timestep_init', 'timestep_finalize', 'finalize'] and \
+                                    CCPP_INTERNAL_VARIABLES[CCPP_BLOCK_NUMBER] in local_vars[var_standard_name]['name'] and \
+                                    '{}:{}'.format(CCPP_CONSTANT_ONE,CCPP_HORIZONTAL_DIMENSION) in var.dimensions:
+                                # We don't need extra tests for blocked arrays, because the de-blocking logic below
+                                # will catch any out of bound reads with the appropriate compiler flags. It naturally
+                                # deals with non-uniform block sizes etc.
+                                pass
+                            elif var.rank:
+                                array_size = []
+                                for dim in var.dimensions:
+                                    # This is not supported/implemented: tmpvar would have one dimension less
+                                    # than the original array, and the metadata requesting the variable would
+                                    # not pass the initial test that host model variables and scheme variables
+                                    # have the same rank.
+                                    if dim == CCPP_BLOCK_NUMBER:
+                                        raise Exception("{} cannot be part of the dimensions of variable {}".format(
+                                                                              CCPP_BLOCK_NUMBER, var_standard_name))
+                                    else:
+                                        # Handle dimensions like "A:B", "A:3", "-1:Z"
+                                        if ':' in dim:
+                                            dims = [ x.lower() for x in dim.split(':')]
+                                            try:
+                                                dim0 = int(dims[0])
+                                                dim0 = dims[0]
+                                            except ValueError:
+                                                if not dims[0].lower() in metadata_define.keys():
+                                                    raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(
+                                                                                                                   dims[0].lower(), var_standard_name))
+                                                dim0 = metadata_define[dims[0].lower()][0].local_name
+                                            try:
+                                                dim1 = int(dims[1])
+                                                dim1 = dims[1]
+                                            except ValueError:
+                                                if not dims[1].lower() in metadata_define.keys():
+                                                    raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(
+                                                                                                                   dims[1].lower(), var_standard_name))
+                                                dim1 = metadata_define[dims[1].lower()][0].local_name
+                                        # Single dimensions
+                                        else:
+                                            dim0 = 1
+                                            try:
+                                                dim1 = int(dim)
+                                                dim1 = dim
+                                            except ValueError:
+                                                if not dim.lower() in metadata_define.keys():
+                                                    raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(
+                                                                                                                       dim.lower(), var_standard_name))
+                                                dim1 = metadata_define[dim.lower()][0].local_name
+                                    array_size.append('({last}-{first}+1)'.format(last=dim1, first=dim0))
+                                var_size_expected  = '({})'.format('*'.join(array_size))
+                                assign_test = '''        ! Check if variable {var_name} is associated/allocated and has the correct size
+        if (size({var_name})/={var_size_expected}) then
+          write({ccpp_errmsg}, '(2(a,i8))') 'Detected size mismatch for variable {var_name} in group {group_name} before {subroutine_name}, expected ', &
+                                           {var_size_expected}, ' but got ', size({var_name})
+          ierr = 1
+          return
+        end if
+'''.format(var_name=local_vars[var_standard_name]['name'], var_size_expected=var_size_expected,
+           ccpp_errmsg=CCPP_INTERNAL_VARIABLES[CCPP_ERROR_MSG_VARIABLE], group_name = self.name,
+           subroutine_name=subroutine_name)
+                        # end if debug
+
                         # kind_string is used for automated unit conversions, i.e. foo_kind_phys
                         kind_string = '_' + local_vars[var_standard_name]['kind'] if local_vars[var_standard_name]['kind'] else ''
 
@@ -1197,7 +1268,8 @@ end module {module}
                                 var_defs_manual.append('integer :: ib, nb')
 
                                 # Define actions before. Always copy data in, independent of intent.
-                                actions_in = '''        allocate({tmpvar}({dims}))
+                                actions_in = '''        ! Allocate local variable to copy blocked data {var} into a contiguous array
+        allocate({tmpvar}({dims}))
         ib = 1
         do nb=1,{block_count}
           {tmpvar}({dimpad_before}ib:ib+{block_size}-1{dimpad_after}) = {var}
@@ -1273,11 +1345,23 @@ end module {module}
                         # Variables stored in blocked data structures but without horizontal dimension not supported at this time (doesn't make sense anyway)
                         elif ccpp_stage in ['init', 'timestep_init', 'timestep_finalize', 'finalize'] and \
                                 CCPP_INTERNAL_VARIABLES[CCPP_BLOCK_NUMBER] in local_vars[var_standard_name]['name']:
-                            raise Exception("Variables stored in blocked data structures but without horizontal dimension not supported at this time: {}".format(var_standard_name))
+                            raise Exception("Variables stored in blocked data structures but without horizontal dimension not supported in phases ' + \
+                                            'init, timestep_init, timestep_finalize, finalize at this time: {} in {}".format(var_standard_name, subroutine_name))
+
+                        # Limitations for UFS: Variables stored in threaded data structures (i.e. only for one block at a time) in GFS_interstitial DDT
+                        # are not supported at this time (doesn't make sense anyway)
+                        elif ccpp_stage in ['init', 'timestep_init', 'timestep_finalize', 'finalize'] and \
+                                CCPP_INTERNAL_VARIABLES[CCPP_THREAD_NUMBER] in local_vars[var_standard_name]['name']:
+                            raise Exception("Variables stored in thread-specific data structures (GFS_interstitial DDT) are not supported in phases ' + \
+                                            'init, timestep_init, timestep_finalize, finalize at this time: {} in {}".format(var_standard_name, subroutine_name))
 
                         # Unit conversions without converting blocked data structures
                         elif var.actions['in'] or var.actions['out']:
-                            actions_in = ''
+                            # If requested, check that arrays are allocated/associated and have the correct size
+                            if debug:
+                                actions_in = assign_test
+                            else:
+                                actions_in = ''
                             actions_out = ''
                             if local_vars[var_standard_name]['name'] in tmpvars.keys():
                                 # If the variable already has a local variable (tmpvar), reuse it
@@ -1327,14 +1411,24 @@ end module {module}
 
                         # Ordinary variables, no blocked data or unit conversions
                         elif var_standard_name in arguments[scheme_name][subroutine_name]:
-                            # Add to argument list if required
+                            if debug and assign_test:
+                                actions_in = assign_test
+                                # Add the conditionals for the "before" operations
+                                actions_before += '''
+      if ({conditional}) then
+{actions_in}
+      end if
+'''.format(conditional=conditionals[var_standard_name],
+           actions_in=actions_in.rstrip('\n'))
+
+                            # Add to argument list
                             arg = '{local_name}={var_name},'.format(local_name=var.local_name, 
                                                                     var_name=local_vars[var_standard_name]['name'])
                         else:
                             arg = ''
                         args += arg
                         length += len(arg)
-                        # Split args so that lines don't exceed 260 characters (for PGI)
+                        # Split args so that lines don't get too long
                         if length > 70 and not var_standard_name == arguments[scheme_name][subroutine_name][-1]:
                             args += ' &\n                  '
                             length = 0
@@ -1371,12 +1465,14 @@ end module {module}
                     if ccpp_loop_extent_target_name and ccpp_stage == 'run':
                         subcycle_body_prefix += '''
       ! Set loop extent variable for the following subcycle
-      {loop_extent_var_name} = {loop_cnt_max}\n\n'''.format(loop_extent_var_name=ccpp_loop_extent_target_name,
-                                                                                   loop_cnt_max=subcycle.loop)
+      {loop_extent_var_name} = {loop_cnt_max}
+'''.format(loop_extent_var_name=ccpp_loop_extent_target_name,
+                                  loop_cnt_max=subcycle.loop)
                     elif ccpp_loop_extent_target_name:
                         subcycle_body_prefix += '''
       ! Set loop extent variable for the following subcycle
-      {loop_extent_var_name} = 1\n\n'''.format(loop_extent_var_name=ccpp_loop_extent_target_name)
+      {loop_extent_var_name} = 1
+'''.format(loop_extent_var_name=ccpp_loop_extent_target_name)
                     # Create subcycle (Fortran do loop) if needed
                     if subcycle.loop > 1 and ccpp_stage == 'run':
                         subcycle_body_prefix += '''
@@ -1392,7 +1488,8 @@ end module {module}
       {loop_var_name} = 1\n'''.format(loop_var_name=ccpp_loop_counter_target_name)
 
                 # Add this subcycle's Fortran body to the group body
-                body += subcycle_body_prefix + subcycle_body + subcycle_body_suffix
+                if subcycle_body:
+                    body += subcycle_body_prefix + subcycle_body + subcycle_body_suffix
 
             # Get list of arguments, module use statement and variable definitions for this subroutine (=stage for the group)
             (self.arguments[ccpp_stage], sub_module_use, sub_var_defs) = create_arguments_module_use_var_defs(

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -50,6 +50,14 @@ def check_units(test_val, prop_dict, error):
             test_val = None
         # end if
     # end if
+    # DH* REMOVE AFTER TESTING WITH UFS
+    # DH* 20210812
+    # Temporary workaround to convert unit 'none' (used for
+    # dimensionless quantities in ccpp-physics/UFS/SCM) to '1'
+    if test_val and test_val.lower() == 'none':
+        test_val = '1'
+    # *DH 20210812
+    # *DH REMOVE AFTER TESTING WITH UFS
     return test_val
 
 def check_dimensions(test_val, prop_dict, error, max_len=0):

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -50,14 +50,6 @@ def check_units(test_val, prop_dict, error):
             test_val = None
         # end if
     # end if
-    # DH* REMOVE AFTER TESTING WITH UFS
-    # DH* 20210812
-    # Temporary workaround to convert unit 'none' (used for
-    # dimensionless quantities in ccpp-physics/UFS/SCM) to '1'
-    if test_val and test_val.lower() == 'none':
-        test_val = '1'
-    # *DH 20210812
-    # *DH REMOVE AFTER TESTING WITH UFS
     return test_val
 
 def check_dimensions(test_val, prop_dict, error, max_len=0):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,9 +58,9 @@ set(${PACKAGE}_LIB_DIRS
 
 #------------------------------------------------------------------------------
 # Define the executable and what to link
-add_library(ccpp STATIC ${SOURCES_F90})
-target_link_libraries(ccpp LINK_PUBLIC ${LIBS} ${CMAKE_DL_LIBS})
-set_target_properties(ccpp PROPERTIES VERSION ${PROJECT_VERSION}
+add_library(ccpp_framework STATIC ${SOURCES_F90})
+target_link_libraries(ccpp_framework LINK_PUBLIC ${LIBS} ${CMAKE_DL_LIBS})
+set_target_properties(ccpp_framework PROPERTIES VERSION ${PROJECT_VERSION}
                                       SOVERSION ${PROJECT_VERSION_MAJOR}
                                       LINK_FLAGS ${CMAKE_Fortran_FLAGS})
 
@@ -68,28 +68,28 @@ set_target_properties(ccpp PROPERTIES VERSION ${PROJECT_VERSION}
 # Installation
 #
 if (PROJECT STREQUAL "CCPP-FV3")
-  target_include_directories(ccpp PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  target_include_directories(ccpp_framework PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
       $<INSTALL_INTERFACE:include>
   )
 elseif (PROJECT STREQUAL "CCPP-SCM")
-  target_include_directories(ccpp PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  target_include_directories(ccpp_framework PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
       $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   )
 endif (PROJECT STREQUAL "CCPP-FV3")
 
 # Define where to install the library
-install(TARGETS ccpp
-        EXPORT ccpp-targets
+install(TARGETS ccpp_framework
+        EXPORT ccpp_framework-targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION lib
 )
 
 # Export our configuration
-install(EXPORT ccpp-targets
-        FILE ccpp-config.cmake
+install(EXPORT ccpp_framework-targets
+        FILE ccpp_framework-config.cmake
         DESTINATION lib/cmake
 )
 


### PR DESCRIPTION
## Description

Merge main into feature capgen 2021/11/05

Updates include:
- remove support for optional arguments in `ccpp_prebuild` scripts
- add debugging features to `ccpp_prebuild` scripts
- update the `ccpp_prebuild` cmake build
- resolve conflicts from merge, a tiny change for one doctest in `metavar.py`, update call to parse_metadata_file in prebuild's `metadata_parser.py`

All changes except commits 0159166bd4a1b670ed94ab5a06018ca500b4eb1d and ee22e68deeb745228071cf511bdb56a662bb46a4 have been reviewed and approved before they were merged into main.

User interface changes?: No

Testing:
- `test/run_test.sh` passes
- `PYTHONPATH=$PWD/scripts:$PWD/scripts/parse_tools pytest` passes
- latest ufs-weather-model code compiles when making several bugfixes for invalid units in fv3atm and ccpp-physics

After this PR is merged, I will create the reverse PR to update main with the refactored feature/capgen code. That merge will bring the bug fixes for invalid units in fv3atm and ccpp-physics into the authoritative repositories.

A surprisingly clean merge.