### PR TITLE
Fix capgen Fortran parser to recognize nested subroutines/functions

### DIFF
--- a/test/capgen_test/temp_calc_adjust.F90
+++ b/test/capgen_test/temp_calc_adjust.F90
@@ -33,7 +33,18 @@ CONTAINS
       errmsg = ''
       errflg = 0
 
-      temp_calc = 1.0_kind_phys
+      call temp_calc_adjust_nested_subroutine(temp_calc)
+
+   CONTAINS
+
+      ELEMENTAL SUBROUTINE temp_calc_adjust_nested_subroutine(temp)
+
+         REAL(kind_phys),    intent(out)   :: temp
+         !-------------------------------------------------------------
+
+         temp = 1.0_kind_phys
+
+      END SUBROUTINE temp_calc_adjust_nested_subroutine
 
    END SUBROUTINE temp_calc_adjust_run
 


### PR DESCRIPTION
Fixes https://github.com/NCAR/ccpp-framework/issues/359 (https://github.com/NCAR/ccpp-framework/issues/359).

The `capgen` Fortran parser is updated to know whether it is inside a `contains` section of a CCPP scheme. If so, the contents is ignored until an `end subroutine scheme_name_ccpp_phase` (e.g. `end subroutine mp_thompson_run`) is found.

Note that this fix requires that `end subroutine` statements are labeled with the subroutine name, i.e. `subroutine mp_thompson_run` requires the end statement to be `end subroutine mp_thompson_run` and not just `end_subroutine`). This has been a soft requirement for `ccpp_prebuild.py`, which warns users that an unlabeled `end subroutine` statement was found, but in must cases was able to proceed.

A more complicated solution that does not require labeled `end subroutine` statements would require counting the number of `[begin] subroutine` and `end subroutine` statements inside `contains` regions.

User interface changes?: No (since labeled `end subroutine` statements have been a soft requirement for `ccpp_prebuild.py` from the beginning)

Fixes #359.

Testing: The existing test of scheme `temp_calc_adjust` was extended to include a `contains` section in `temp_calc_adjust_run`. Without the changes to `scripts/fortran_tools/parse_fortran_file.py` in this PR, the `capgen` test for this scheme failed. After making the changes suggested here, all tests pass (`cd tests && ./run_test.sh`).
