### PR TITLE
Add system test for doxygen comments between metadata hooks and CCPP entry point (subroutine)

### DIFF
--- a/test/advection_test/cld_ice.F90
+++ b/test/advection_test/cld_ice.F90
@@ -10,6 +10,7 @@ MODULE cld_ice
 
    PUBLIC :: cld_ice_init
    PUBLIC :: cld_ice_run
+   PUBLIC :: cld_ice_final
 
    real(kind_phys), private :: tcld = HUGE(1.0_kind_phys)
 
@@ -70,5 +71,27 @@ CONTAINS
       tcld = tfreeze - 20.0_kind_phys
 
    end subroutine cld_ice_init
+
+   !> \section arg_table_cld_ice_final  Argument Table
+   !! \htmlinclude arg_table_cld_ice_final.html
+   !!
+
+   !> @{
+   !! This routine does nothing, but it tests if blank
+   !! lines and doxygen comments between metadata hooks
+   !! and the subroutine are parsed correctly.
+   !! @{
+
+   subroutine cld_ice_final(errmsg, errflg)
+
+      character(len=512), intent(out)   :: errmsg
+      integer,            intent(out)   :: errflg
+
+      errmsg = ''
+      errflg = 0
+
+   end subroutine cld_ice_final
+   !! @}
+   !! @}
 
 END MODULE cld_ice

--- a/test/advection_test/cld_ice.meta
+++ b/test/advection_test/cld_ice.meta
@@ -96,3 +96,21 @@
   dimensions = ()
   type = integer
   intent = out
+[ccpp-arg-table]
+  name = cld_ice_final
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out


### PR DESCRIPTION

Add system test for doxygen comments between metadata hooks and CCPP entry point (subroutine) to make sure various doxygen comments and blank lines are parsed correctly/ignored between CCPP metadata hooks and the Fortran subroutines.

Issue https://github.com/NCAR/ccpp-framework/issues/369 reports that certain doxygen comments between the metadata hooks and the subroutines are "not parsed correctly" (i.e. are  not ignored). I was going to fix this problem and found that the current `capgen` metadata parser can handle those cases just fine. I added a CCPP entry point to cover these tests.

User interface changes?: No

"Fixes https://github.com/NCAR/ccpp-framework/issues/369"

Testing:
  test removed: None
  unit tests: None
  system tests: Add one system test to cover blank lines and doxygen comments between metadata hooks and subroutines; note: `test/run_tests.sh` passes.
  manual testing: None
