### PR TITLE
Fix metadata2html.py, add some more documentation to ccpp_prebuild.py

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -154,6 +154,7 @@ def clean_files(config):
     return success
 
 def get_all_suites(suites_dir):
+    """Assemble a list of all suite definition files in suites_dir"""
     success = False
     logging.info("No suites were given, compiling a list of all suites")
     sdfs = []
@@ -209,7 +210,7 @@ def convert_local_name_from_new_metadata(metadata, standard_name, typedefs_new_m
 
     # The local name (incl. the array reference) is in new metadata format
     local_name = var.local_name
-    logging.info("Converting local name {0} of variable {1} from new to old metadata".format(local_name, standard_name))
+    logging.debug("Converting local name {0} of variable {1} from new to old metadata".format(local_name, standard_name))
     if "(" in local_name:
         (actual_var_name, array_reference) = split_var_name_and_array_reference(local_name)
         indices = array_reference.lstrip('(').rstrip(')').split(',')

--- a/scripts/mkdoc.py
+++ b/scripts/mkdoc.py
@@ -85,10 +85,13 @@ def metadata_to_latex(metadata_define, metadata_request, model, filename):
 
     var_names = sorted(list(set(list(metadata_define.keys()) + list(metadata_request.keys()))))
 
+    styledir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                            '../doc/DevelopersGuide'))
+
     latex = '''\\documentclass[12pt,letterpaper,oneside,landscape]{{scrbook}}
 
 \\usepackage{{import}}
-\\import{{../common/}}{{gmtb.sty}}
+\\import{{{styledir}/}}{{gmtb.sty}}
 \\renewcommand{{\\thesection}}{{\\arabic{{section}}}}
 \\renewcommand{{\\thesubsection}}{{\\arabic{{section}}.\\arabic{{subsection}}}}
 
@@ -96,7 +99,7 @@ def metadata_to_latex(metadata_define, metadata_request, model, filename):
 
 \\section{{CCPP variables provided by model {model} vs requested by pool of physics}}\\label{{sec_ccpp_variables}}
 \\subsection{{List of variables}}
-\\begin{{longtable}}{{l}}'''.format(model=model)
+\\begin{{longtable}}{{l}}'''.format(model=model, styledir=styledir)
 
     for var_name in var_names:
         if var_name in metadata_define.keys():


### PR DESCRIPTION
This PR fixes https://github.com/NCAR/ccpp-framework/issues/437, see description there, and provides an additional comment for one subroutine in `ccpp_prebuild.py`

User interface changes?: No

Fixes: #437 

Testing:
- `metadata2html.py` works for in-source and out-of-source builds
- ufs-weather-model compiles and runs and gives b4b identical results
