### PR TITLE
Bug fix and improvement for ccpp_track_variables tool

### DIFF
--- a/scripts/ccpp_track_variables.py
+++ b/scripts/ccpp_track_variables.py
@@ -28,16 +28,16 @@ def parse_arguments():
     parser.add_argument('-s', '--sdf', help='suite definition file to parse', required=True)
     parser.add_argument('-m', '--metadata_path',
                         help='path to CCPP scheme metadata files', required=True)
-    parser.add_argument('-c', '--config', 
+    parser.add_argument('-c', '--config',
                         help='path to CCPP prebuild configuration file', required=True)
-    parser.add_argument('-v', '--variable', help='variable to track through CCPP suite', 
+    parser.add_argument('-v', '--variable', help='variable to track through CCPP suite',
                         required=True)
-    parser.add_argument('--debug', action='store_true', help='enable debugging output', 
+    parser.add_argument('--debug', action='store_true', help='enable debugging output',
                         default=False)
 
     args = parser.parse_args()
 
-    return(args)
+    return args
 
 def setup_logging(debug):
     """Sets up the logging module and logging level."""
@@ -108,7 +108,7 @@ def create_var_graph(suite, var, config, metapath, run_env):
     partial_matches = {}
     for group in suite.call_tree:
         run_env.logger.debug(f"for group {group} ")
-        # Create a list of tuples that will hold the in/out information for each scheme in this group
+        # Create list of tuples that will hold the in/out information for each scheme in this group
         var_graph[group] = []
         for scheme in suite.call_tree[group]:
             run_env.logger.debug(f"reading meta file for scheme {scheme} ")
@@ -122,10 +122,11 @@ def create_var_graph(suite, var, config, metapath, run_env):
             run_env.logger.debug(f"reading metadata file {scheme_filename} for scheme {scheme}")
 
             new_metadata_headers = parse_metadata_file(scheme_filename,
-                                                   known_ddts=registered_fortran_ddt_names(), run_env=run_env)
+                                                       known_ddts=registered_fortran_ddt_names(),
+                                                       run_env=run_env)
             for scheme_metadata in new_metadata_headers:
                 if scheme_metadata.table_name != scheme:
-                    # Some metadata files contain information for multiple schemes, 
+                    # Some metadata files contain information for multiple schemes,
                     # need to make sure we only read the relevant section
                     continue
                 for section in scheme_metadata.sections():
@@ -146,8 +147,8 @@ def create_var_graph(suite, var, config, metapath, run_env):
                     if not found_var:
                         run_env.logger.debug(f"Did not find variable {var} in scheme {section.title}")
                     elif exact_match:
-                        run_env.logger.debug(f"Exact match found for variable {var} in scheme {section.title},"
-                                             f" intent {intent}")
+                        run_env.logger.debug(f"Exact match found for variable {var} in scheme "
+                                             f"{section.title}, intent {intent}")
                         var_graph[group].append((section.title,intent))
                         var_graph_empty = False
                     else:
@@ -170,13 +171,14 @@ def create_var_graph(suite, var, config, metapath, run_env):
     return (success,var_graph)
 
 def main():
-    """Main routine that traverses a CCPP suite and outputs the list of schemes that use given variable"""
+    """Main routine that traverses a CCPP suite and outputs the list of schemes that use given
+       variable, broken down by group"""
 
     args = parse_arguments()
 
     logger = setup_logging(args.debug)
 
-    #Use new capgen class CCPPFrameworkEnv 
+    #Use new capgen class CCPPFrameworkEnv
     run_env = CCPPFrameworkEnv(logger, host_files="", scheme_files="", suites="")
 
     suite = parse_suite(args.sdf,run_env)
@@ -187,7 +189,7 @@ def main():
 
     # Variables defined by the host model; this call is necessary because it converts some old
     # metadata formats so they can be used later in the script
-    (success, _, _) = gather_variable_definitions(config['variable_definition_files'], 
+    (success, _, _) = gather_variable_definitions(config['variable_definition_files'],
                                                    config['typedefs_new_metadata'])
     if not success:
         raise Exception('Call to gather_variable_definitions failed.')

--- a/scripts/ccpp_track_variables.py
+++ b/scripts/ccpp_track_variables.py
@@ -124,6 +124,10 @@ def create_var_graph(suite, var, config, metapath, run_env):
             new_metadata_headers = parse_metadata_file(scheme_filename,
                                                    known_ddts=registered_fortran_ddt_names(), run_env=run_env)
             for scheme_metadata in new_metadata_headers:
+                if scheme_metadata.table_name != scheme:
+                    # Some metadata files contain information for multiple schemes, 
+                    # need to make sure we only read the relevant section
+                    continue
                 for section in scheme_metadata.sections():
                     found_var = []
                     intent = ''
@@ -190,7 +194,7 @@ def main():
 
     (success, var_graph) = create_var_graph(suite, args.variable, config, args.metadata_path, run_env)
     if success:
-        print(f"For suite {suite.sdf_name}, the following schemes (in order for each group)"
+        print(f"For suite {suite.sdf_name}, the following schemes (in order for each group) "
               f"use the variable {args.variable}:")
         for group in var_graph:
             if var_graph[group]:

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -504,7 +504,7 @@ end module {module}
         self._sdf_name = None
         self._all_schemes_called = None
         self._all_subroutines_called = None
-        self._call_tree = []
+        self._call_tree = {}
         self._caps = None
         self._module = None
         self._subroutines = None
@@ -570,14 +570,16 @@ end module {module}
         self._all_subroutines_called = []
 
         if make_call_tree:
-            # Call tree of all schemes in SDF (with duplicates and subcycles)
-            self._call_tree = []
+            # Call tree of all schemes in SDF. call_tree is a dictionary, with keys corresponding to each group in a suite, and
+            # the value associated with each key being an ordered list of the schemes in each group (with duplicates and subcycles)
+            self._call_tree = {}
 
         # Build hierarchical structure as in SDF
         self._groups = []
         for group_xml in suite_xml:
             subcycles = []
 
+            self._call_tree[group_xml.attrib['name']] = []
             # Add suite-wide init scheme to group 'init', similar for finalize
             if group_xml.tag.lower() == 'init' or group_xml.tag.lower() == 'finalize':
                 self._all_schemes_called.append(group_xml.text)
@@ -606,7 +608,7 @@ end module {module}
                     # Populate call tree from SDF's heirarchical structure, including multiple calls in subcycle loops
                     for loop in range(0,int(subcycle_xml.get('loop'))):
                         for scheme_xml in subcycle_xml:
-                            self._call_tree.append(scheme_xml.text)
+                            self._call_tree[group_xml.attrib['name']].append(scheme_xml.text)
 
             self._groups.append(Group(name=group_xml.get('name'), subcycles=subcycles, suite=self._name))
 


### PR DESCRIPTION
This PR changes the output slightly, so that the ordered lists of schemes are now broken down by group. This is done because different groups in a physics suite can be called in different orders depending on the logic of the host model, so only within each group is a set of schemes guaranteed to be called in that order.

This PR also fixes a bug in ccpp_track_variables.py that double-counted variables in schemes that have .meta files containing descriptions of more than one scheme.

Finally, this PR has some small improvements suggested by pylint, including removing trailing whitespace and trimming long lines.

Cases with partial matches or no matches found will not be affected by this change.

User interface changes?: No

Fixes: #450 (duplicate counting of schemes)

Testing:
Ran script against multiple xmls and confirmed new behavior removes duplicate schemes in script output. Also output is now broken down by group.

Here is an example of old output vs new:

## Old

```
framework/scripts/ccpp_track_variables.py --config=config/ccpp_prebuild_config.py -s=suites/suite_FV3_GFS_v16_noahmp.xml -v air_temperature_of_new_state -m ./physics/physics/
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_gas_optics_rrtmgp
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_arry
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_1scl
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_2str
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_nstr
For suite suites/suite_FV3_GFS_v16_noahmp.xml, the following schemes (in order) use the variable air_temperature_of_new_state:
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
get_phi_fv3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
dcyc2t3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
ozphys_2015_run (intent in)
get_phi_fv3_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
GFS_DCNV_generic_pre_run (intent in)
GFS_DCNV_generic_post_run (intent in)
samfdeepcnv_run (intent inout)
GFS_DCNV_generic_pre_run (intent in)
GFS_DCNV_generic_post_run (intent in)
GFS_SCNV_generic_pre_run (intent in)
GFS_SCNV_generic_post_run (intent in)
samfshalcnv_run (intent inout)
GFS_SCNV_generic_pre_run (intent in)
GFS_SCNV_generic_post_run (intent in)
GFS_suite_stateout_reset_run (intent out)
GFS_suite_stateout_update_run (intent out)
GFS_suite_interstitial_3_run (intent in)
GFS_MP_generic_pre_run (intent in)
GFS_MP_generic_post_run (intent in)
gfdl_cloud_microphys_run (intent inout)
GFS_MP_generic_pre_run (intent in)
GFS_MP_generic_post_run (intent in)
maximum_hourly_diagnostics_run (intent in)
GFS_stochastics_run (intent inout)
```

## New

```
framework/scripts/ccpp_track_variables.py --config=config/ccpp_prebuild_config.py -s=suites/suite_FV3_GFS_v16_noahmp.xml -v air_temperature_of_new_state -m ./physics/physics/
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_gas_optics_rrtmgp
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_arry
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_1scl
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_2str
WARNING:root:Encountered closing statement "end type" without type name; assume type_name is ty_optical_props_nstr
For suite suites/suite_FV3_GFS_v16_noahmp.xml, the following schemes (in order for each group) use the variable air_temperature_of_new_state:
In group physics
  GFS_suite_stateout_reset_run (intent out)
  dcyc2t3_run (intent in)
  GFS_suite_stateout_update_run (intent out)
  ozphys_2015_run (intent in)
  get_phi_fv3_run (intent in)
  GFS_suite_interstitial_3_run (intent in)
  GFS_DCNV_generic_pre_run (intent in)
  samfdeepcnv_run (intent inout)
  GFS_DCNV_generic_post_run (intent in)
  GFS_SCNV_generic_pre_run (intent in)
  samfshalcnv_run (intent inout)
  GFS_SCNV_generic_post_run (intent in)
  GFS_MP_generic_pre_run (intent in)
  gfdl_cloud_microphys_run (intent inout)
  GFS_MP_generic_post_run (intent in)
  maximum_hourly_diagnostics_run (intent in)
In group stochastics
  GFS_stochastics_run (intent inout)
```