### PR TITLE
Limit suite names to 37 characters or less

### DIFF
--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -25,6 +25,10 @@ from mkcap import Var
 
 ###############################################################################
 
+# Limit suite names to 37 characters; this keeps cap names below 64 characters
+# Cap names of 64 characters or longer can cause issues with some compilers.
+SUITE_NAME_MAX_CHARS = 37
+
 # Maximum number of dimensions of an array allowed by the Fortran 2008 standard
 FORTRAN_ARRAY_MAX_DIMS = 15
 
@@ -624,6 +628,12 @@ end module {module}
         if not (os.path.basename(self._sdf_name) == 'suite_{}.xml'.format(self._name)):
             logging.critical("Invalid suite name {0} in suite definition file {1}.".format(
                                                                self._name, self._sdf_name))
+            success = False
+            return success
+
+        # Check if suite name is too long
+        if len(self._name) > SUITE_NAME_MAX_CHARS:
+            logging.critical(f"Suite name {self._name} has more than the allowed {SUITE_NAME_MAX_CHARS} characters")
             success = False
             return success
 


### PR DESCRIPTION
Per discussion on #337, this implements a hard cap on suite names of 37 characters for ccpp_prebuild.

User interface changes?: [ Yes ]
If a user attempts to run ccpp_prebuild with a suite name longer than 37 characters, prebuild will fail with an error message indicating the problem.

Fixes: Part of #337 (ccpp_prebuild only)

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: Ran ccpp_prebuild.py both stand-alone and for SCM, script ran successfully for existing suites, and failed as expected when a new long suite name was introduced. Will run more tests if requested.

