### PR TITLE
Fix ccpp-framework errors with Python 3.11

### DIFF
--- a/scripts/ccpp_state_machine.py
+++ b/scripts/ccpp_state_machine.py
@@ -3,11 +3,11 @@
 # CCPP framework imports
 from state_machine import StateMachine
 
-_INIT_ST = r"(?:(?i)init(?:ial(?:ize)?)?)"
-_FINAL_ST = r"(?:(?i)final(?:ize)?)"
-_RUN_ST = r"(?:(?i)run)"
-_TS_INIT_ST = r"(?:(?i)timestep_init(?:ial(?:ize)?)?)"
-_TS_FINAL_ST = r"(?:(?i)timestep_final(?:ize)?)"
+_INIT_ST = r"(?:init(?:ial(?:ize)?)?)"
+_FINAL_ST = r"(?:final(?:ize)?)"
+_RUN_ST = r"(?:run)"
+_TS_INIT_ST = r"(?:timestep_init(?:ial(?:ize)?)?)"
+_TS_FINAL_ST = r"(?:timestep_final(?:ize)?)"
 
 # Allowed CCPP transitions
 # pylint: disable=bad-whitespace

--- a/scripts/state_machine.py
+++ b/scripts/state_machine.py
@@ -162,8 +162,8 @@ class StateMachine:
         if len(value) != 3:
             raise ValueError("Invalid transition ({}), should be of the form (inital_state, final_state, regex).".format(value))
         # end if
-        regex = re.compile(value[2] + r"$")
-        function = re.compile(FORTRAN_ID + r"_(" + value[2] + r")$")
+        regex = re.compile(value[2] + r"$", flags=re.IGNORECASE)
+        function = re.compile(FORTRAN_ID + r"_(" + value[2] + r")$", flags=re.IGNORECASE)
         self.__stt__[key] = (value[0], value[1], regex, function)
 
     def __delitem__(self, key):

--- a/scripts/state_machine.py
+++ b/scripts/state_machine.py
@@ -30,7 +30,7 @@ class StateMachine:
     >>> StateMachine([('ab','a','b','a')]).final_state('ab')
     'b'
     >>> StateMachine([('ab','a','b','a')]).transition_regex('ab')
-    re.compile('a$')
+    re.compile('a$', re.IGNORECASE)
     >>> StateMachine([('ab','a','b','a')]).function_match('foo_a', transition='ab')
     ('foo', 'a', 'ab')
     >>> StateMachine([('ab','a','b',r'ax?')]).function_match('foo_a', transition='ab')


### PR DESCRIPTION
Fix Python 3.11 errors as described in https://github.com/NCAR/ccpp-framework/issues/457

With these changes, the error from
```
cd tests
PYTHONPATH=$PWD/../scripts/parse_tools:$PWD/../scripts:$PYTHONPATH python3.11 test_metadata_parser.py
```
is fixed. I asked @DusanJovic-NOAA to test this branch with the ufs-weather-model on his Fedora 37 machine, which uses Python 3.11 as default, and I would like to ask @mkavulich @grantfirl @dustinswales to test this branch with their versions of Python in the CCPP-SCM, please.

As noted in https://github.com/NCAR/ccpp-framework/issues/457, I cannot run the unit tests in ccpp-framework that require `pytest`. I ran the following unit tests successfully with Python 3.11:
```
cd tests
PYTHONPATH=$PWD/../scripts/parse_tools:$PWD/../scripts:$PYTHONPATH python3.11 test_metadata_parser.py
```
I then ran all unit tests successfully with the native Python 3.10 installation on Ubuntu 22.04:
```
cd tests
PYTHONPATH=$PWD/../scripts/parse_tools:$PWD/../scripts:$PYTHONPATH python3.11 test_metadata_parser.py
PYTHONPATH=$PWD/../scripts/parse_tools:$PWD/../scripts:$PYTHONPATH python3.11 test_mkstatic.py
cd ..
cd test
./pylint_test.sh # average code rating about 8.5/10
./run_doctest.sh
./run_tests.sh
```
User interface changes?: No

Fixes: https://github.com/NCAR/ccpp-framework/issues/457 (to be confirmed)

Testing: see above
