### PR TITLE
Fix error message for unit conversions involving unit "1"

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -187,6 +187,9 @@ def string_to_python_identifier(string):
     string = string.replace("-","_minus_")
     # Replace plus signs with _plus_
     string = string.replace("+","_plus_")
+    # "1" is a valid unit
+    if string == "1":
+        string = "one"
     # Test that the resulting string is a valid Python identifier
     if re.match("[_A-Za-z][_a-zA-Z0-9]*$", string) and not keyword.iskeyword(string):
         return string

--- a/test/unit_tests/test_common.py
+++ b/test/unit_tests/test_common.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python3
+"""
+-----------------------------------------------------------------------
+ Description:  Contains unit tests for functions in common.py
+
+ Assumptions:
+
+ Command line arguments: none
+
+ Usage: python test_common.py         # run the unit tests
+-----------------------------------------------------------------------
+"""
+import sys
+import os
+import logging
+import unittest
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_DIR = os.path.abspath(os.path.join(TEST_DIR, os.pardir, os.pardir, "scripts"))
+
+if not os.path.exists(SCRIPTS_DIR):
+    raise ImportError("Cannot find scripts directory")
+
+sys.path.append(SCRIPTS_DIR)
+
+# pylint: disable=wrong-import-position
+import common
+# pylint: enable=wrong-import-position
+
+class CommonTestCase(unittest.TestCase):
+
+    """Tests functionality of functions in common.py"""
+
+    def test_string_to_python_identifier(self):
+        """Test string_to_python_identifier() function"""
+
+        # Test various successful combinations
+        self.assertEqual(common.string_to_python_identifier("Test 1"),"Test_1")
+        self.assertEqual(common.string_to_python_identifier("Test.2"),"Test_p_2")
+        self.assertEqual(common.string_to_python_identifier("Test-3"),"Test_minus_3")
+        self.assertEqual(common.string_to_python_identifier("Test+4"),"Test_plus_4")
+        self.assertEqual(common.string_to_python_identifier("1"),"one")
+        self.assertEqual(common.string_to_python_identifier(" Test all--even +."),
+                                                            "_Test_all_minus__minus_even__plus__p_")
+        # Test expected failures
+        self.assertRaises(Exception,common.string_to_python_identifier,"else")
+        self.assertRaises(Exception,common.string_to_python_identifier,"1 ")
+        self.assertRaises(Exception,common.string_to_python_identifier,"0")
+        self.assertRaises(Exception,common.string_to_python_identifier,"Disallowed character!")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As described in #458, there is a problem with the unit converter if
attempting to convert from unit "1" to any other value: while this
should result in an error (units of "1" can't be converted to anything 
else), the error that results is not descriptive (due to "1" not being a
valid python function name). This change adds an if statement to
correctly pass "1" as a valid unit so that the correct error message 
is printed.

User interface changes?: No

Fixes: #458 Unit converter does not handle units = 1 correctly for incompatible conversions

Testing:
  test removed: None
  unit tests: All existing passed. Added new unit test for validating the string_to_python_identifier() function for both valid and invalid inputs
  system tests: None
  manual testing: Ran ccpp_prebuild with SCM with a modified metadata file to confirm both error and fix (posted comment in issue with more details).

