### PR TITLE
Add more unit tests for routines in common.py

### DIFF
--- a/test/unit_tests/test_common.py
+++ b/test/unit_tests/test_common.py
@@ -16,12 +16,15 @@ import logging
 import unittest
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_FILE = os.path.basename(os.path.abspath(__file__))
 SCRIPTS_DIR = os.path.abspath(os.path.join(TEST_DIR, os.pardir, os.pardir, "scripts"))
+SAMPLE_FILES_DIR = os.path.join(TEST_DIR, "sample_files")
 
 if not os.path.exists(SCRIPTS_DIR):
     raise ImportError("Cannot find scripts directory")
 
 sys.path.append(SCRIPTS_DIR)
+logging.disable(logging.CRITICAL)
 
 # pylint: disable=wrong-import-position
 import common
@@ -30,6 +33,55 @@ import common
 class CommonTestCase(unittest.TestCase):
 
     """Tests functionality of functions in common.py"""
+
+    def test_execute(self):
+        """Test execute() function"""
+
+        # Input for successful test: ls command on this file
+        self.assertEqual(common.execute(f"ls {TEST_FILE}"),(0,f"{TEST_FILE}",""))
+
+        # Input for failing test (no exception): exit 1 from a subshell
+        self.assertEqual(common.execute(f"(exit 1)",abort=False),(1,"",f""))
+
+        # Input for failing test (raise exception): exit 1 from a subshell
+        self.assertRaises(Exception,common.execute,f"(exit 1)",abort=True)
+
+    def test_split_var_name_and_array_reference(self):
+        """Test split_var_name_and_array_reference() function"""
+
+        self.assertEqual(common.split_var_name_and_array_reference("foo(:,a,1:ddt%ngas)"),
+                         ("foo","(:,a,1:ddt%ngas)"))
+
+    def test_encode_container(self):
+        """Test encode_container() function"""
+
+        modulename = "ABCD1234"
+        typename = "COMPLEX"
+        schemename = "testscheme"
+        subroutinename = "testsubroutine"
+        self.assertEqual(common.encode_container(modulename),f"MODULE_{modulename}")
+        self.assertEqual(common.encode_container(modulename,typename),f"MODULE_{modulename} TYPE_{typename}")
+        self.assertEqual(common.encode_container(modulename,schemename,subroutinename),
+                         f"MODULE_{modulename} SCHEME_{schemename} SUBROUTINE_{subroutinename}")
+        self.assertRaises(Exception,common.encode_container,modulename,typename,schemename,subroutinename)
+        self.assertRaises(Exception,common.encode_container)
+
+    def test_decode_container(self):
+        """Test decode_container() function"""
+
+        modulename = "ABCD1234"
+        typename = "COMPLEX"
+        schemename = "testscheme"
+        subroutinename = "testsubroutine"
+        self.assertEqual(common.decode_container(f"MODULE_{modulename}"),f"MODULE {modulename}")
+        self.assertEqual(common.decode_container(f"MODULE_{modulename} TYPE_{typename}"),
+                                                 f"MODULE {modulename} TYPE {typename}")
+        self.assertEqual(common.decode_container(f"MODULE_{modulename} SCHEME_{schemename} SUBROUTINE_{subroutinename}"),
+                                                 f"MODULE {modulename} SCHEME {schemename} SUBROUTINE {subroutinename}")
+        self.assertRaises(Exception,common.decode_container,
+                          f"MODULE_{modulename} TYPE_{typename} SCHEME_{schemename} SUBROUTINE_{subroutinename}")
+        self.assertRaises(Exception,common.decode_container,"That dog won't hunt, Monsignor")
+        self.assertRaises(Exception,common.decode_container)
 
     def test_string_to_python_identifier(self):
         """Test string_to_python_identifier() function"""

--- a/test/unit_tests/test_common.py
+++ b/test/unit_tests/test_common.py
@@ -24,7 +24,7 @@ if not os.path.exists(SCRIPTS_DIR):
     raise ImportError("Cannot find scripts directory")
 
 sys.path.append(SCRIPTS_DIR)
-logging.disable(logging.CRITICAL)
+logging.disable(level=logging.CRITICAL)
 
 # pylint: disable=wrong-import-position
 import common

--- a/test/unit_tests/test_var_transforms.py
+++ b/test/unit_tests/test_var_transforms.py
@@ -8,7 +8,7 @@
 
  Command line arguments: none
 
- Usage: python test_var_transform.py         # run the unit tests
+ Usage: python test_var_transforms.py         # run the unit tests
 -----------------------------------------------------------------------
 """
 import sys


### PR DESCRIPTION
This PR is a demo to begin adding more unit test coverage to the CCPP-framework. Since a unit test was recently added for the `test_string_to_python_identifier` function in `common.py`, I added unit tests for the remaining functions in that file.

To run these unit tests, simply navigate to the `test/unit_tests` directory and run the script (with Python 3.7 or higher):

```
python test_common.py 
.....
----------------------------------------------------------------------
Ran 5 tests in 0.023s

OK
```

User interface changes?: No

Fixes: No issue specific to this change. This test focuses on the `ccpp_prebuild` portion of code, but should be a stepping stone to a number of issues relating to `capgen` unit tests.

Testing:
  unit tests: All passed

