### PR TITLE
initialized_set_block bug fix

### DIFF
--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1638,7 +1638,7 @@ end module {module}
                                             name=self._name)
             else:
                 initialized_test_block = ''
-                initialized_set_block  = ''
+                initialized_set_block  = 'initialized(:) = .true.'
             
             
             # Create subroutine

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1631,13 +1631,16 @@ end module {module}
                                             target_name_flag=ccpp_error_code_target_name,
                                             target_name_msg=ccpp_error_msg_target_name,
                                             name=self._name)
+                initialized_set_block = Group.initialized_set_blocks[ccpp_stage].format(
+                                            ccpp_var_name = ccpp_var.local_name,
+                                            target_name_flag=ccpp_error_code_target_name,
+                                            target_name_msg=ccpp_error_msg_target_name,
+                                            name=self._name)
             else:
                 initialized_test_block = ''
-            initialized_set_block = Group.initialized_set_blocks[ccpp_stage].format(
-                                        ccpp_var_name = ccpp_var.local_name,
-                                        target_name_flag=ccpp_error_code_target_name,
-                                        target_name_msg=ccpp_error_msg_target_name,
-                                        name=self._name)
+                initialized_set_block  = ''
+            
+            
             # Create subroutine
             local_subs += Group.sub.format(subroutine=subroutine,
                                            argument_list=sub_argument_list,


### PR DESCRIPTION
When trying to update the latest UFS to use the latest CCPP framework hash, one of the regression tests using CMEPS uses a suite that doesn't have any schemes with a non-empty `init` phase. Due to this, the subroutine generated for the `init` phase in the cap doesn't have access to a ccpp_t instance. Yet, in mkstatic.py a line like `initialized({ccpp_var_name}%ccpp_instance) = .true.` is put in the subroutine regardless, resulting in a compilation error. 

A fix is to pass the ccpp_t_instance into the group cap for the `init` phase when it is otherwise empty so that `initialized({ccpp_var_name}%ccpp_instance) = .true.` has access to the ccpp_t_instance.

User interface changes?: No

Fixes: No issue started

Testing:
  test removed:
  unit tests:
  system tests: UFS RTs (re-running as of 2023/10/12), SCM RTs (completed successfully)
  manual testing:

