### PR TITLE
Bug fix in metavar.py: optional var props with a default value need t…

### DIFF
--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -202,7 +202,7 @@ class Var:
                     VariableProperty('active', str, optional_in=True,
                                      default_in='.true.'),
                     VariableProperty('polymorphic', bool, optional_in=True,
-                                     default_in='.false.')]
+                                     default_in=False)]
 
 # XXgoldyXX: v debug only
     __to_add = VariableProperty('valid_values', str,

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -116,8 +116,14 @@ class Var:
     ['Bob', 'Ray']
     >>> Var.get_prop('active') #doctest: +ELLIPSIS
     <var_props.VariableProperty object at 0x...>
+    >>> Var.get_prop('active').get_default_val({})
+    '.true.'
     >>> Var.get_prop('active').valid_value('flag_for_aerosol_physics')
     'flag_for_aerosol_physics'
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'DDT', ParseContext()), _MVAR_DUMMY_RUN_ENV).get_prop_value('active')
+    '.true.'
+    >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in', 'active' : 'child_is_home==.true.'}, ParseSource('vname', 'DDT', ParseContext()), _MVAR_DUMMY_RUN_ENV).get_prop_value('active')
+    'child_is_home==.true.'
     >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()), _MVAR_DUMMY_RUN_ENV).get_prop_value('long_name')
     'Hi mom'
     >>> Var({'local_name' : 'foo', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '()', 'type' : 'real', 'intent' : 'in'}, ParseSource('vname', 'SCHEME', ParseContext()), _MVAR_DUMMY_RUN_ENV).get_prop_value('intent')
@@ -496,7 +502,7 @@ class Var:
             pvalue = self._prop_dict[name]
         elif name in Var.__var_propdict:
             vprop = Var.__var_propdict[name]
-            if vprop.has_default_func:
+            if vprop.optional:
                 pvalue = vprop.get_default_val(self._prop_dict,
                                                context=self.context)
             else:


### PR DESCRIPTION
Fix return value for optional variable properties that are not set  by the variable and that have a default value (instead of a default function). Credits go to @gold2718 for suggesting this bug fix.

See https://github.com/NCAR/ccpp-framework/issues/509 for a description.

**Note** due to the updates in this PR, there is a change in which properties show up in places like the `datatable.xml` file. This triggered a desire to add a CI test for the `ccpp_track_variables.py` script (see #511).

User interface changes?: No

Fixes https://github.com/NCAR/ccpp-framework/issues/509

Testing:
- test removed: n/a
- unit tests: added 3 doctests in `metavar.py`
- system tests: I ran `cd test && ./run_fortran_tests.sh` on my macOS and all tests passed (noting that `var_action_test` is skipped on the `feature/capgen` branch because of the failing unit conversion tests)
- manual testing: ran the doctests on `metavar.py` as described in the issue
- CI: all tests pass (after adding https://github.com/NCAR/ccpp-framework/pull/508/commits/294eecf673a3af7486bb6b3f00f0f6eb80d838b0)
