### PR TITLE
CCPP-physics Issue #127 Fix

### DIFF
--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1617,7 +1617,7 @@ end module {module}
             #the initialized_set_block for the init phase tries to reference the unavailable ccpp_t variable.
             if (ccpp_stage == 'init' and not self.parents[ccpp_stage]):
                 ccpp_var.intent = 'in'
-                self.parents[ccpp_stage].update({ccpp_var.local_name:ccpp_var})
+                self.parents[ccpp_stage].update({ccpp_var.standard_name:ccpp_var})
 
             # Get list of arguments, module use statement and variable definitions for this subroutine (=stage for the group)
             (self.arguments[ccpp_stage], sub_module_use, sub_var_defs) = create_arguments_module_use_var_defs(


### PR DESCRIPTION
This PR is a bugfix for https://github.com/ufs-community/ccpp-physics/issues/127

https://github.com/NCAR/ccpp-framework/pull/503 was merged to fix the case when no scheme within a group has an init phase. A bug was introduced described in the ccpp-physics issue above. This fix ensures that the ccpp_t_instance variable is only passed once in the caps.

User interface changes?: No

Fixes: 

https://github.com/ufs-community/ccpp-physics/issues/127

Testing:
  test removed:
  unit tests:
  system tests: tested with UFS RTs 
[RegressionTests_hera.log](https://github.com/NCAR/ccpp-framework/files/13677899/RegressionTests_hera.log)
Note that the CMEPS tests are still passing in particular.
  manual testing: Tested with the SCM using the SDF supplied in https://github.com/ufs-community/ccpp-physics/issues/127 with compilation and running. Also examined the produced caps to make sure the double `cdata` argument has been removed.

