### PR TITLE
ccpp_prebuild.py: add support for chunked arrays

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -30,6 +30,10 @@ CCPP_BLOCK_COUNT         = 'ccpp_block_count'
 CCPP_BLOCK_SIZES         = 'ccpp_block_sizes'
 CCPP_THREAD_NUMBER       = 'ccpp_thread_number'
 
+CCPP_CHUNK_EXTENT          = 'ccpp_chunk_extent'
+CCPP_HORIZONTAL_LOOP_BEGIN = 'horizontal_loop_begin'
+CCPP_HORIZONTAL_LOOP_END   = 'horizontal_loop_end'
+
 CCPP_HORIZONTAL_LOOP_EXTENT = 'horizontal_loop_extent'
 CCPP_HORIZONTAL_DIMENSION   = 'horizontal_dimension'
 

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1350,12 +1350,12 @@ end module {module}
                                             # Use correct horizontal variables in run phase
                                             if ccpp_stage == 'run' and dims[1].lower() == CCPP_HORIZONTAL_LOOP_EXTENT:
                                                 # Provide backward compatibility with blocked data structures
-                                                if CCPP_BLOCK_COUNT in metadata_define.keys():
-                                                    dim0 = metadata_define[CCPP_CONSTANT_ONE][0].local_name
-                                                    dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_EXTENT][0].local_name
-                                                else:
+                                                if CCPP_HORIZONTAL_LOOP_BEGIN in metadata_define.keys():
                                                     dim0 = metadata_define[CCPP_HORIZONTAL_LOOP_BEGIN][0].local_name
                                                     dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_END][0].local_name
+                                                else:
+                                                    dim0 = metadata_define[CCPP_CONSTANT_ONE][0].local_name
+                                                    dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_EXTENT][0].local_name
                                             else:
                                                 if not dims[1].lower() in metadata_define.keys():
                                                     raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -118,11 +118,11 @@ def extract_dimensions_from_local_name(local_name):
                 parent_delimiter_index = i
                 break
             i -= 1
-    print(f"{local_name[parent_delimiter_index+1:]}")
     if '(' in local_name[parent_delimiter_index+1:]:
         dim_string_start = local_name[parent_delimiter_index+1:].find('(')
         dim_string_end = local_name[parent_delimiter_index+1:].rfind(')')
         dim_string = local_name[parent_delimiter_index+1:][dim_string_start:dim_string_end+1]
+        # DH* TODO REMOVE DEBUG STATEMENT
         logging.info(f"found dim_string '{dim_string}' in '{local_name}'")
         # Now that we have a dim_string, find all dimensions in this string;
         # ignore outermost opening and closing parentheses.
@@ -1354,17 +1354,8 @@ end module {module}
                                                     dim0 = metadata_define[CCPP_CONSTANT_ONE][0].local_name
                                                     dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_EXTENT][0].local_name
                                                 else:
-                                                ## Again provide backward compatibility with blocked data structures.
-                                                ## The following is a limitation of ccpp_prebuild, but I don't know any case
-                                                ## where this would be used in the currently supported models. We
-                                                ## can't have both CCPP_HORIZONTAL_LOOP_BEGIN+CCPP_HORIZONTAL_LOOP_END
-                                                ## and CCPP_HORIZONTAL_LOOP_EXTENT coming from the host model.
-                                                #if CCPP_HORIZONTAL_LOOP_BEGIN in additional_variables_required + arguments[scheme_name][subroutine_name]:
                                                     dim0 = metadata_define[CCPP_HORIZONTAL_LOOP_BEGIN][0].local_name
                                                     dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_END][0].local_name
-                                                #else:
-                                                #    dim0 = metadata_define[CCPP_CONSTANT_ONE][0].local_name
-                                                #    dim1 = metadata_define[CCPP_HORIZONTAL_LOOP_EXTENT][0].local_name
                                             else:
                                                 if not dims[1].lower() in metadata_define.keys():
                                                     raise Exception('Dimension {}, required by variable {}, not defined in host model metadata'.format(
@@ -1372,6 +1363,7 @@ end module {module}
                                                 dim1 = metadata_define[dims[1].lower()][0].local_name
                                     # Single dimensions are indices
                                     else:
+                                        # DH* TODO UPDATE EXCEPTION MESSAGE AND REMOVE COMMENTS BELOW
                                         raise Exception("THIS SHOULD NOT HAPPEN WITH CAPGEN'S METADATA PARSER")
                                         #try:
                                         #    dim1 = int(dim)
@@ -1389,6 +1381,7 @@ end module {module}
                                         #    dim1 = metadata_define[dim.lower()][0].local_name
                                         #dim0 = dim1
 
+                                    # DH* TODO REMOVE THIS ENTIRE BLOCK
                                     # Handle horizontal dimensions correctly
                                     if ccpp_stage == 'run':
                                         # This should not happen when parsing metadata with capgen's metadata parser, remove?
@@ -1410,6 +1403,8 @@ end module {module}
                                                 CCPP_LOOP_EXTENT in dims:
                                             raise Exception(f"Invalid metadata for scheme {scheme_name}: " + \
                                                             f"horizontal dimension for {var_standard_name} is {var.dimensions}")
+                                    # *DH
+
                                 if dim0 == dim1:
                                     array_size.append('1')
                                     dim_substrings.append(f'{dim1}')
@@ -1446,8 +1441,8 @@ end module {module}
                             var_size_expected = 1
 
                         # To assist debugging efforts, check if arrays have the correct size (ignore scalars for now)
-                        # DH* 20231226 this doesn't make much sense anymore. let's rather check that the lower and upper bounds
-                        # are correct.
+                        # DH* 20231226 This doesn't make much sense anymore. In a future PR, let's rather check that
+                        # the lower and upper bounds of the arrays are correct.
                         assign_test = ''
                         if debug:
                             if ccpp_stage in ['init', 'timestep_init', 'timestep_finalize', 'finalize'] and \
@@ -1477,8 +1472,6 @@ end module {module}
                         if ccpp_stage in ['init', 'timestep_init', 'timestep_finalize', 'finalize'] and \
                                 CCPP_INTERNAL_VARIABLES[CCPP_BLOCK_NUMBER] in local_vars[var_standard_name]['name'] and \
                                 '{}:{}'.format(CCPP_CONSTANT_ONE,CCPP_HORIZONTAL_DIMENSION) in var.dimensions:
-                            ## Need to reset dim_string since this is handled separately for blocked data
-                            #dim_string = ''
                             # Reuse existing temporary variable, if possible
                             if local_vars[var_standard_name]['name'] in tmpvars.keys():
                                 # If the variable already has a local variable (tmpvar), reuse it
@@ -1690,8 +1683,6 @@ end module {module}
            actions_in=actions_in.rstrip('\n'))
 
                             # Add to argument list
-                            #if var.local_name == 'qgraupel': #dim_string_target_name and dim_string and var.local_name == 'qgraupel':
-                            #    raise Exception(f"{var.local_name}: {dim_string_target_name}, {dim_string}; replace? {local_vars[var_standard_name]['name']} --> ")
                             arg = '{local_name}={var_name}{dim_string},'.format(local_name=var.local_name, 
                                 var_name=local_vars[var_standard_name]['name'].replace(dim_string_target_name, ''), dim_string=dim_string)
                         else:

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -122,8 +122,6 @@ def extract_dimensions_from_local_name(local_name):
         dim_string_start = local_name[parent_delimiter_index+1:].find('(')
         dim_string_end = local_name[parent_delimiter_index+1:].rfind(')')
         dim_string = local_name[parent_delimiter_index+1:][dim_string_start:dim_string_end+1]
-        # DH* TODO REMOVE DEBUG STATEMENT
-        logging.info(f"found dim_string '{dim_string}' in '{local_name}'")
         # Now that we have a dim_string, find all dimensions in this string;
         # ignore outermost opening and closing parentheses.
         opened = 0
@@ -1377,9 +1375,11 @@ end module {module}
                                     else:
                                         raise Exception("THIS SHOULD NOT HAPPEN WITH CAPGEN'S METADATA PARSER")
 
-                                    # DH* TODO REMOVE THIS ENTIRE BLOCK - create a test suite to make sure these things are caught
+                                    # DH* TODO REMOVE THIS ENTIRE BLOCK in a future PR to feature/capgen
+                                    # This block should not be needed, the metadata parser should take care
+                                    # of flagging invalid dimensions for the host model or the physics.
+                                    # TODO: create a test suite to make sure these things are caught
                                     # by the metadata parser - do this on the feature/capgen branch!
-                                    # Handle horizontal dimensions correctly
                                     if ccpp_stage == 'run':
                                         # This should not happen when parsing metadata with capgen's metadata parser, remove?
                                         if dims[1] == CCPP_HORIZONTAL_LOOP_EXTENT and not dim0:
@@ -1402,14 +1402,7 @@ end module {module}
                                                             f"horizontal dimension for {var_standard_name} is {var.dimensions}")
                                     # *DH
 
-                                # DH* TODO: move this to a function "is_horizontal_dimension" ?
-                                # maybe combine with some of the above logic to get the correct dimensions
-                                # depending on phase etc?
-                                # We only want to be explicit about horizontal dimensions, for which we need
-                                # to subset in certain cases (therefore do it always). Other dimensions are
-                                # passed as ':'.
-                                #
-                                # DH* TODO: WE CANNOT ACTIVATE USING EXPLICIT HORIZONTAL BLOCKS
+                                # DH* TODO: WE CANNOT ACTIVATE USING EXPLICIT HORIZONTAL DIMENSIONS
                                 # UNTIL WE HAVE SOLVED THE PROBLEM WITH INACTIVE (NON-ALLOCATED)
                                 # ARRAYS. THIS MUST BE ADDRESSED BEFORE WE SWITCH TO CONTIGUOUS
                                 # ARRAYS FOR MODELS LIKE THE UFS-WEATHER-MODEL!
@@ -1429,7 +1422,7 @@ end module {module}
                                         array_size.append(f'({dim1}-{dim0}+1)')
                                         dim_substrings.append(f':')
 
-                            # Now we need to compare dim_substringa with a possible dim_string_target_name and merge them
+                            # Now we need to compare dim_substrings with a possible dim_string_target_name and merge them
                             if dimensions_target_name:
                                 if len(dimensions_target_name) < len(dim_substrings):
                                     raise Exception("THIS SHOULD NOT HAPPEN")

--- a/scripts/mkstatic.py
+++ b/scripts/mkstatic.py
@@ -1460,7 +1460,7 @@ end module {module}
           ierr = 1
           return
         end if
-'''.format(var_name=local_vars[var_standard_name]['name'], dim_string=dim_string, var_size_expected=var_size_expected,
+'''.format(var_name=local_vars[var_standard_name]['name'].replace(dim_string_target_name, ''), dim_string=dim_string, var_size_expected=var_size_expected,
            ccpp_errmsg=CCPP_INTERNAL_VARIABLES[CCPP_ERROR_MSG_VARIABLE], group_name = self.name,
            subroutine_name=subroutine_name)
                         # end if debug

--- a/src/ccpp_types.F90
+++ b/src/ccpp_types.F90
@@ -35,8 +35,10 @@ module ccpp_types
     integer, parameter :: CCPP_DEFAULT_LOOP_CNT = -999
     integer, parameter :: CCPP_DEFAULT_LOOP_MAX = -999
 
-    !> @var The default values for block and thread numbers indicating invalid data
-    integer, parameter :: CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER = -999
+    !> @var The default values for block, chunk and thread numbers indicating invalid data
+    integer, parameter :: CCPP_DEFAULT_BLOCK_NUMBER = -999
+    integer, parameter :: CCPP_DEFAULT_CHUNK_NUMBER = -999
+    integer, parameter :: CCPP_DEFAULT_THREAD_NUMBER = -999
 
 !! \section arg_table_ccpp_t
 !! \htmlinclude ccpp_t.html
@@ -56,8 +58,9 @@ module ccpp_types
        character(len=512)                                  :: errmsg = ''
        integer                                             :: loop_cnt = CCPP_DEFAULT_LOOP_CNT
        integer                                             :: loop_max = CCPP_DEFAULT_LOOP_MAX
-       integer                                             :: blk_no = CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER
-       integer                                             :: thrd_no = CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER
+       integer                                             :: blk_no = CCPP_DEFAULT_BLOCK_NUMBER
+       integer                                             :: chunk_no = CCPP_DEFAULT_CHUNK_NUMBER
+       integer                                             :: thrd_no = CCPP_DEFAULT_THREAD_NUMBER
        integer                                             :: ccpp_instance = 1
 
     contains
@@ -74,8 +77,9 @@ contains
        class(ccpp_t) :: ccpp_d
        logical :: initialized
        !
-       initialized = (ccpp_d%blk_no /= CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER .and. &
-                      ccpp_d%thrd_no /= CCPP_DEFAULT_BLOCK_AND_THREAD_NUMBER)
+       initialized = ccpp_d%thrd_no /= CCPP_DEFAULT_THREAD_NUMBER .and. &
+                     (ccpp_d%blk_no /= CCPP_DEFAULT_BLOCK_NUMBER .and. &
+                      ccpp_d%chunk_no /= CCPP_DEFAULT_CHUNK_NUMBER)
     end function ccpp_t_initialized
 
 end module ccpp_types

--- a/src/ccpp_types.F90
+++ b/src/ccpp_types.F90
@@ -77,9 +77,9 @@ contains
        class(ccpp_t) :: ccpp_d
        logical :: initialized
        !
-       initialized = ccpp_d%thrd_no /= CCPP_DEFAULT_THREAD_NUMBER .and. &
-                     (ccpp_d%blk_no /= CCPP_DEFAULT_BLOCK_NUMBER .and. &
-                      ccpp_d%chunk_no /= CCPP_DEFAULT_CHUNK_NUMBER)
+       initialized = ccpp_d%thrd_no /= CCPP_DEFAULT_THREAD_NUMBER .or. &
+                     ccpp_d%blk_no /= CCPP_DEFAULT_BLOCK_NUMBER .or. &
+                     ccpp_d%chunk_no /= CCPP_DEFAULT_CHUNK_NUMBER
     end function ccpp_t_initialized
 
 end module ccpp_types

--- a/src/ccpp_types.meta
+++ b/src/ccpp_types.meta
@@ -38,6 +38,12 @@
   units = index
   dimensions = ()
   type = integer
+[chunk_no]
+  standard_name = ccpp_chunk_number
+  long_name = number of chunk for using array chunks in CCPP
+  units = index
+  dimensions = ()
+  type = integer
 [thrd_no]
   standard_name = ccpp_thread_number
   long_name = number of thread for threading in CCPP

--- a/test_prebuild/test_chunked_data/CMakeLists.txt
+++ b/test_prebuild/test_chunked_data/CMakeLists.txt
@@ -1,0 +1,90 @@
+#------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.0)
+
+project(ccpp_chunked_data
+        VERSION 1.0.0
+        LANGUAGES Fortran)
+
+#------------------------------------------------------------------------------
+# Request a static build
+option(BUILD_SHARED_LIBS "Build a shared library" OFF)
+
+#------------------------------------------------------------------------------
+# Set the sources: physics type definitions
+set(TYPEDEFS $ENV{CCPP_TYPEDEFS})
+if(TYPEDEFS)
+  message(STATUS "Got CCPP TYPEDEFS from environment variable: ${TYPEDEFS}")
+else(TYPEDEFS)
+  include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_TYPEDEFS.cmake)
+  message(STATUS "Got CCPP TYPEDEFS from cmakefile include file: ${TYPEDEFS}")
+endif(TYPEDEFS)
+
+# Generate list of Fortran modules from the CCPP type
+# definitions that need need to be installed
+foreach(typedef_module ${TYPEDEFS})
+    list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/${typedef_module})
+endforeach()
+
+#------------------------------------------------------------------------------
+# Set the sources: physics schemes
+set(SCHEMES $ENV{CCPP_SCHEMES})
+if(SCHEMES)
+  message(STATUS "Got CCPP SCHEMES from environment variable: ${SCHEMES}")
+else(SCHEMES)
+  include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_SCHEMES.cmake)
+  message(STATUS "Got CCPP SCHEMES from cmakefile include file: ${SCHEMES}")
+endif(SCHEMES)
+
+# Set the sources: physics scheme caps
+set(CAPS $ENV{CCPP_CAPS})
+if(CAPS)
+  message(STATUS "Got CCPP CAPS from environment variable: ${CAPS}")
+else(CAPS)
+  include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_CAPS.cmake)
+  message(STATUS "Got CCPP CAPS from cmakefile include file: ${CAPS}")
+endif(CAPS)
+
+# Set the sources: physics scheme caps
+set(API $ENV{CCPP_API})
+if(API)
+  message(STATUS "Got CCPP API from environment variable: ${API}")
+else(API)
+  include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_API.cmake)
+  message(STATUS "Got CCPP API from cmakefile include file: ${API}")
+endif(API)
+
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O0 -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check -ggdb -fbacktrace -ffree-line-length-none")
+
+#------------------------------------------------------------------------------
+add_library(ccpp_chunked_data STATIC ${SCHEMES} ${CAPS} ${API})
+# Generate list of Fortran modules from defined sources
+foreach(source_f90 ${CAPS} ${API})
+    get_filename_component(tmp_source_f90 ${source_f90} NAME)
+    string(REGEX REPLACE ".F90" ".mod" tmp_module_f90 ${tmp_source_f90})
+    string(TOLOWER ${tmp_module_f90} module_f90)
+    list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/${module_f90})
+endforeach()
+
+set_target_properties(ccpp_chunked_data PROPERTIES VERSION ${PROJECT_VERSION}
+                      SOVERSION ${PROJECT_VERSION_MAJOR})
+
+add_executable(test_chunked_data.x main.F90)
+add_dependencies(test_chunked_data.x ccpp_chunked_data)
+target_link_libraries(test_chunked_data.x ccpp_chunked_data)
+set_target_properties(test_chunked_data.x PROPERTIES LINKER_LANGUAGE Fortran)
+
+# Define where to install the library
+install(TARGETS ccpp_chunked_data
+        EXPORT ccpp_chunked_data-targets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib
+)
+# Export our configuration
+install(EXPORT ccpp_chunked_data-targets
+        FILE ccpp_chunked_data-config.cmake
+        DESTINATION lib/cmake
+)
+# Define where to install the C headers and Fortran modules
+#install(FILES ${HEADERS_C} DESTINATION include)
+install(FILES ${MODULES_F90} DESTINATION include)

--- a/test_prebuild/test_chunked_data/README.md
+++ b/test_prebuild/test_chunked_data/README.md
@@ -1,0 +1,13 @@
+# How to build the chunked data test
+
+1. Set compiler environment as appropriate for your system
+2. Run the following commands:
+```
+cd test_prebuild/test_chunked_data/
+rm -fr build
+mkdir build
+../../scripts/ccpp_prebuild.py --config=ccpp_prebuild_config.py --builddir=build
+cd build
+cmake .. 2>&1 | tee log.cmake
+make 2>&1 | tee log.make
+```

--- a/test_prebuild/test_chunked_data/ccpp_prebuild_config.py
+++ b/test_prebuild/test_chunked_data/ccpp_prebuild_config.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+# CCPP prebuild config for GFDL Finite-Volume Cubed-Sphere Model (FV3)
+
+###############################################################################
+# Definitions                                                                 #
+###############################################################################
+
+HOST_MODEL_IDENTIFIER = "FV3"
+
+# Add all files with metadata tables on the host model side and in CCPP,
+# relative to basedir = top-level directory of host model. This includes
+# kind and type definitions used in CCPP physics. Also add any internal
+# dependencies of these files to the list.
+VARIABLE_DEFINITION_FILES = [
+    # actual variable definition files
+    '../../src/ccpp_types.F90',
+    'data.F90',
+    ]
+
+TYPEDEFS_NEW_METADATA = {
+    'ccpp_types' : {
+        'ccpp_t' : 'cdata',
+        'ccpp_types' : '',
+        },
+    'data' : {
+        'chunked_data_type' : 'chunked_data_instance(cdata%blk_no)',
+        'data' : '',
+        },
+    }
+
+# Add all physics scheme files relative to basedir
+SCHEME_FILES = [
+    'chunked_data_scheme.F90',
+    ]
+
+# Default build dir, relative to current working directory,
+# if not specified as command-line argument
+DEFAULT_BUILD_DIR = 'build'
+
+# Auto-generated makefile/cmakefile snippets that contain all type definitions
+TYPEDEFS_MAKEFILE   = '{build_dir}/CCPP_TYPEDEFS.mk'
+TYPEDEFS_CMAKEFILE  = '{build_dir}/CCPP_TYPEDEFS.cmake'
+TYPEDEFS_SOURCEFILE = '{build_dir}/CCPP_TYPEDEFS.sh'
+
+# Auto-generated makefile/cmakefile snippets that contain all schemes
+SCHEMES_MAKEFILE   = '{build_dir}/CCPP_SCHEMES.mk'
+SCHEMES_CMAKEFILE  = '{build_dir}/CCPP_SCHEMES.cmake'
+SCHEMES_SOURCEFILE = '{build_dir}/CCPP_SCHEMES.sh'
+
+# Auto-generated makefile/cmakefile snippets that contain all caps
+CAPS_MAKEFILE   = '{build_dir}/CCPP_CAPS.mk'
+CAPS_CMAKEFILE  = '{build_dir}/CCPP_CAPS.cmake'
+CAPS_SOURCEFILE = '{build_dir}/CCPP_CAPS.sh'
+
+# Directory where to put all auto-generated physics caps
+CAPS_DIR = '{build_dir}'
+
+# Directory where the suite definition files are stored
+SUITES_DIR = '.'
+
+# Optional arguments - only required for schemes that use
+# optional arguments. ccpp_prebuild.py will throw an exception
+# if it encounters a scheme subroutine with optional arguments
+# if no entry is made here. Possible values are: 'all', 'none',
+# or a list of standard_names: [ 'var1', 'var3' ].
+OPTIONAL_ARGUMENTS = {}
+
+# Directory where to write static API to
+STATIC_API_DIR = '{build_dir}'
+STATIC_API_CMAKEFILE  = '{build_dir}/CCPP_API.cmake'
+STATIC_API_SOURCEFILE = '{build_dir}/CCPP_API.sh'
+
+# Directory for writing HTML pages generated from metadata files
+METADATA_HTML_OUTPUT_DIR = '{build_dir}'
+
+# HTML document containing the model-defined CCPP variables
+HTML_VARTABLE_FILE = '{build_dir}/CCPP_VARIABLES_CHUNKED_DATA.html'
+
+# LaTeX document containing the provided vs requested CCPP variables
+LATEX_VARTABLE_FILE = '{build_dir}/CCPP_VARIABLES_CHUNKED_DATA.tex'

--- a/test_prebuild/test_chunked_data/ccpp_prebuild_config.py
+++ b/test_prebuild/test_chunked_data/ccpp_prebuild_config.py
@@ -24,7 +24,7 @@ TYPEDEFS_NEW_METADATA = {
         'ccpp_types' : '',
         },
     'data' : {
-        'chunked_data_type' : 'chunked_data_instance(cdata%blk_no)',
+        'chunked_data_type' : 'chunked_data_instance',
         'data' : '',
         },
     }

--- a/test_prebuild/test_chunked_data/chunked_data_scheme.F90
+++ b/test_prebuild/test_chunked_data/chunked_data_scheme.F90
@@ -1,0 +1,118 @@
+!>\file chunked_data_scheme.F90
+!! This file contains a chunked_data_scheme CCPP scheme that does nothing
+!! except requesting the minimum, mandatory variables.
+
+module chunked_data_scheme
+
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   implicit none
+
+   private
+   public :: chunked_data_scheme_init, &
+             chunked_data_scheme_timestep_init, &
+             chunked_data_scheme_run, &
+             chunked_data_scheme_timestep_finalize, &
+             chunked_data_scheme_finalize
+
+   ! This is for unit testing only
+   integer, parameter, dimension(4) :: data_array_sizes = (/6,6,6,3/)
+
+   contains
+
+!! \section arg_table_chunked_data_scheme_init Argument Table
+!! \htmlinclude chunked_data_scheme_init.html
+!!
+   subroutine chunked_data_scheme_init(data_array, errmsg, errflg)
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+      integer,          intent(in)  :: data_array(:)
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+      ! Check size of data array
+      write(error_unit,'(a,i3)') 'In chunked_data_scheme_init: checking size of data array to be', sum(data_array_sizes)
+      if (size(data_array)/=sum(data_array_sizes)) then
+         write(errmsg,'(2(a,i3))') "Error, expected size(data_array)==", sum(data_array_sizes), "but got ", size(data_array)
+         errflg = 1
+         return
+      end if
+   end subroutine chunked_data_scheme_init
+
+!! \section arg_table_chunked_data_scheme_timestep_init Argument Table
+!! \htmlinclude chunked_data_scheme_timestep_init.html
+!!
+   subroutine chunked_data_scheme_timestep_init(data_array, errmsg, errflg)
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+      integer,          intent(in)  :: data_array(:)
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+      ! Check size of data array
+      write(error_unit,'(a,i3)') 'In chunked_data_scheme_timestep_init: checking size of data array to be', sum(data_array_sizes)
+      if (size(data_array)/=sum(data_array_sizes)) then
+         write(errmsg,'(2(a,i3))') "Error, expected size(data_array)==", sum(data_array_sizes), " but got ", size(data_array)
+         errflg = 1
+         return
+      end if
+   end subroutine chunked_data_scheme_timestep_init
+
+!! \section arg_table_chunked_data_scheme_run Argument Table
+!! \htmlinclude chunked_data_scheme_run.html
+!!
+   subroutine chunked_data_scheme_run(nb, data_array, errmsg, errflg)
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+      integer,          intent(in)  :: nb
+      integer,          intent(in)  :: data_array(:)
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+      ! Check size of data array
+      write(error_unit,'(2(a,i3))') 'In chunked_data_scheme_run: checking size of data array for block', nb, ' to be', data_array_sizes(nb)
+      if (size(data_array)/=data_array_sizes(nb)) then
+         write(errmsg,'(a,i4)') "Error in chunked_data_scheme_run, expected size(data_array)==6, got ", size(data_array)
+         errflg = 1
+         return
+      end if
+   end subroutine chunked_data_scheme_run
+
+   !! \section arg_table_chunked_data_scheme_timestep_finalize Argument Table
+   !! \htmlinclude chunked_data_scheme_timestep_finalize.html
+   !!
+      subroutine chunked_data_scheme_timestep_finalize(data_array, errmsg, errflg)
+         character(len=*), intent(out) :: errmsg
+         integer,          intent(out) :: errflg
+         integer,          intent(in)  :: data_array(:)
+         ! Initialize CCPP error handling variables
+         errmsg = ''
+         errflg = 0
+         ! Check size of data array
+         write(error_unit,'(a,i3)') 'In chunked_data_scheme_timestep_finalize: checking size of data array to be', sum(data_array_sizes)
+         if (size(data_array)/=sum(data_array_sizes)) then
+            write(errmsg,'(2(a,i3))') "Error, expected size(data_array)==", sum(data_array_sizes), "but got ", size(data_array)
+            errflg = 1
+            return
+         end if
+      end subroutine chunked_data_scheme_timestep_finalize
+
+!! \section arg_table_chunked_data_scheme_finalize Argument Table
+!! \htmlinclude chunked_data_scheme_finalize.html
+!!
+   subroutine chunked_data_scheme_finalize(data_array, errmsg, errflg)
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+      integer,          intent(in)  :: data_array(:)
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+      ! Check size of data array
+      write(error_unit,'(a,i3)') 'In chunked_data_scheme_finalize: checking size of data array to be', sum(data_array_sizes)
+      if (size(data_array)/=sum(data_array_sizes)) then
+         write(errmsg,'(2(a,i3))') "Error, expected size(data_array)==", sum(data_array_sizes), "but got ", size(data_array)
+         errflg = 1
+         return
+      end if
+   end subroutine chunked_data_scheme_finalize
+
+end module chunked_data_scheme

--- a/test_prebuild/test_chunked_data/chunked_data_scheme.F90
+++ b/test_prebuild/test_chunked_data/chunked_data_scheme.F90
@@ -60,17 +60,17 @@ module chunked_data_scheme
 !! \section arg_table_chunked_data_scheme_run Argument Table
 !! \htmlinclude chunked_data_scheme_run.html
 !!
-   subroutine chunked_data_scheme_run(nb, data_array, errmsg, errflg)
+   subroutine chunked_data_scheme_run(nchunk, data_array, errmsg, errflg)
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
-      integer,          intent(in)  :: nb
+      integer,          intent(in)  :: nchunk
       integer,          intent(in)  :: data_array(:)
       ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
       ! Check size of data array
-      write(error_unit,'(2(a,i3))') 'In chunked_data_scheme_run: checking size of data array for block', nb, ' to be', data_array_sizes(nb)
-      if (size(data_array)/=data_array_sizes(nb)) then
+      write(error_unit,'(2(a,i3))') 'In chunked_data_scheme_run: checking size of data array for chunk', nchunk, ' to be', data_array_sizes(nchunk)
+      if (size(data_array)/=data_array_sizes(nchunk)) then
          write(errmsg,'(a,i4)') "Error in chunked_data_scheme_run, expected size(data_array)==6, got ", size(data_array)
          errflg = 1
          return

--- a/test_prebuild/test_chunked_data/chunked_data_scheme.meta
+++ b/test_prebuild/test_chunked_data/chunked_data_scheme.meta
@@ -1,0 +1,147 @@
+[ccpp-table-properties]
+  name = chunked_data_scheme
+  type = scheme
+  dependencies =
+
+########################################################################
+[ccpp-arg-table]
+  name = chunked_data_scheme_init
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[data_array]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+
+########################################################################
+[ccpp-arg-table]
+  name = chunked_data_scheme_timestep_init
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[data_array]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+
+########################################################################
+[ccpp-arg-table]
+  name = chunked_data_scheme_run
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[nb]
+  standard_name = ccpp_block_number
+  long_name = number of block for explicit data blocking in CCPP
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[data_array]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = in
+
+########################################################################
+[ccpp-arg-table]
+  name = chunked_data_scheme_timestep_finalize
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[data_array]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+
+########################################################################
+[ccpp-arg-table]
+  name = chunked_data_scheme_finalize
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[data_array]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+

--- a/test_prebuild/test_chunked_data/chunked_data_scheme.meta
+++ b/test_prebuild/test_chunked_data/chunked_data_scheme.meta
@@ -76,9 +76,9 @@
   dimensions = ()
   type = integer
   intent = out
-[nb]
-  standard_name = ccpp_block_number
-  long_name = number of block for explicit data blocking in CCPP
+[nchunk]
+  standard_name = ccpp_chunk_number
+  long_name = number of chunk for chunked arrays in CCPP
   units = index
   dimensions = ()
   type = integer

--- a/test_prebuild/test_chunked_data/data.F90
+++ b/test_prebuild/test_chunked_data/data.F90
@@ -9,15 +9,15 @@ module data
 
     private
 
-    public nblks, blksz, ncols
-    public ccpp_data_domain, ccpp_data_blocks, chunked_data_type, chunked_data_instance
+    public nchunks, chunksize, ncols
+    public ccpp_data_domain, ccpp_data_chunks, chunked_data_type, chunked_data_instance
 
-    integer, parameter :: nblks = 4
+    integer, parameter :: nchunks = 4
     type(ccpp_t), target :: ccpp_data_domain
-    type(ccpp_t), dimension(nblks), target :: ccpp_data_blocks
+    type(ccpp_t), dimension(nchunks), target :: ccpp_data_chunks
 
-    integer, parameter, dimension(nblks) :: blksz = (/6,6,6,3/)
-    integer, parameter :: ncols = sum(blksz)
+    integer, parameter, dimension(nchunks) :: chunksize = (/6,6,6,3/)
+    integer, parameter :: ncols = sum(chunksize)
 
 !! \section arg_table_chunked_data_type
 !! \htmlinclude chunked_data_type.html
@@ -28,7 +28,7 @@ module data
       procedure :: create  => chunked_data_create
    end type chunked_data_type
 
-   type(chunked_data_type), dimension(nblks) :: chunked_data_instance
+   type(chunked_data_type) :: chunked_data_instance
 
 contains
 

--- a/test_prebuild/test_chunked_data/data.F90
+++ b/test_prebuild/test_chunked_data/data.F90
@@ -9,7 +9,7 @@ module data
 
     private
 
-    public nchunks, chunksize, ncols
+    public nchunks, chunksize, chunk_begin, chunk_end, ncols
     public ccpp_data_domain, ccpp_data_chunks, chunked_data_type, chunked_data_instance
 
     integer, parameter :: nchunks = 4
@@ -17,6 +17,8 @@ module data
     type(ccpp_t), dimension(nchunks), target :: ccpp_data_chunks
 
     integer, parameter, dimension(nchunks) :: chunksize = (/6,6,6,3/)
+    integer, parameter, dimension(nchunks) :: chunk_begin = (/1,7,13,19/)
+    integer, parameter, dimension(nchunks) :: chunk_end = (/6,12,18,21/)
     integer, parameter :: ncols = sum(chunksize)
 
 !! \section arg_table_chunked_data_type

--- a/test_prebuild/test_chunked_data/data.F90
+++ b/test_prebuild/test_chunked_data/data.F90
@@ -1,0 +1,41 @@
+module data
+
+!! \section arg_table_data Argument Table
+!! \htmlinclude data.html
+!!
+    use ccpp_types,    only: ccpp_t
+
+    implicit none
+
+    private
+
+    public nblks, blksz, ncols
+    public ccpp_data_domain, ccpp_data_blocks, chunked_data_type, chunked_data_instance
+
+    integer, parameter :: nblks = 4
+    type(ccpp_t), target :: ccpp_data_domain
+    type(ccpp_t), dimension(nblks), target :: ccpp_data_blocks
+
+    integer, parameter, dimension(nblks) :: blksz = (/6,6,6,3/)
+    integer, parameter :: ncols = sum(blksz)
+
+!! \section arg_table_chunked_data_type
+!! \htmlinclude chunked_data_type.html
+!!
+   type chunked_data_type
+      integer, dimension(:), allocatable :: array_data
+   contains
+      procedure :: create  => chunked_data_create
+   end type chunked_data_type
+
+   type(chunked_data_type), dimension(nblks) :: chunked_data_instance
+
+contains
+
+   subroutine chunked_data_create(chunked_data_instance, ncol)
+      class(chunked_data_type), intent(inout) :: chunked_data_instance
+      integer, intent(in) :: ncol
+      allocate(chunked_data_instance%array_data(ncol))
+   end subroutine chunked_data_create
+
+end module data

--- a/test_prebuild/test_chunked_data/data.meta
+++ b/test_prebuild/test_chunked_data/data.meta
@@ -9,8 +9,9 @@
   standard_name = chunked_data_array
   long_name = chunked data array
   units = 1
-  dimensions = (horizontal_loop_extent)
+  dimensions = (ccpp_constant_one:horizontal_dimension)
   type = integer
+# Todo: define an additional array running from -1 to ncols-2
 
 [ccpp-table-properties]
   name = data
@@ -25,24 +26,6 @@
   units = DDT
   dimensions = ()
   type = ccpp_t
-[nblks]
-  standard_name = ccpp_block_count
-  long_name = for explicit data blocking: number of blocks
-  units = count
-  dimensions = ()
-  type = integer
-[blksz]
-  standard_name = ccpp_block_sizes
-  long_name = for explicit data blocking: block sizes of all blocks
-  units = count
-  dimensions = (ccpp_block_count)
-  type = integer
-[blksz(ccpp_block_number)]
-  standard_name = horizontal_loop_extent
-  long_name = horizontal loop extent
-  units = count
-  dimensions = ()
-  type = integer
 [ncols]
   standard_name = horizontal_dimension
   long_name = horizontal dimension
@@ -55,15 +38,9 @@
   units = DDT
   dimensions = ()
   type = chunked_data_type
-[chunked_data_instance(ccpp_block_number)]
+[chunked_data_instance]
   standard_name = chunked_data_type_instance
   long_name = instance of derived data type chunked_data_type
   units = DDT
   dimensions = ()
-  type = chunked_data_type
-[chunked_data_instance]
-  standard_name = chunked_data_type_instance_all_blocks
-  long_name = instance of derived data type chunked_data_type
-  units = DDT
-  dimensions = (ccpp_block_count)
   type = chunked_data_type

--- a/test_prebuild/test_chunked_data/data.meta
+++ b/test_prebuild/test_chunked_data/data.meta
@@ -32,6 +32,36 @@
   units = count
   dimensions = ()
   type = integer
+[nchunks]
+  standard_name = ccpp_chunk_extent
+  long_name = number of chunks of array data used in run phase
+  units = count
+  dimensions = ()
+  type = integer
+[chunk_begin]
+  standard_name = horizontal_loop_begin_all_chunks
+  long_name = first index for horizontal loop extent in run phase
+  units = index
+  dimensions = (ccpp_chunk_extent)
+  type = integer
+[chunk_begin(ccpp_chunk_number)]
+  standard_name = horizontal_loop_begin
+  long_name = first index for horizontal loop extent in run phase
+  units = index
+  dimensions = ()
+  type = integer
+[chunk_end]
+  standard_name = horizontal_loop_end_all_chunks
+  long_name = last index for horizontal loop extent in run phase
+  units = index
+  dimensions = (ccpp_chunk_extent)
+  type = integer
+[chunk_end(ccpp_chunk_number)]
+  standard_name = horizontal_loop_end
+  long_name = last index for horizontal loop extent in run phase
+  units = index
+  dimensions = ()
+  type = integer
 [chunked_data_type]
   standard_name = chunked_data_type
   long_name = definition of type chunked_data_type

--- a/test_prebuild/test_chunked_data/data.meta
+++ b/test_prebuild/test_chunked_data/data.meta
@@ -1,0 +1,69 @@
+[ccpp-table-properties]
+  name = chunked_data_type
+  type = ddt
+  dependencies =
+[ccpp-arg-table]
+  name = chunked_data_type
+  type = ddt
+[array_data]
+  standard_name = chunked_data_array
+  long_name = chunked data array
+  units = 1
+  dimensions = (horizontal_loop_extent)
+  type = integer
+
+[ccpp-table-properties]
+  name = data
+  type = module
+  dependencies =
+[ccpp-arg-table]
+  name = data
+  type = module
+[cdata]
+  standard_name = ccpp_t_instance
+  long_name = instance of derived data type ccpp_t
+  units = DDT
+  dimensions = ()
+  type = ccpp_t
+[nblks]
+  standard_name = ccpp_block_count
+  long_name = for explicit data blocking: number of blocks
+  units = count
+  dimensions = ()
+  type = integer
+[blksz]
+  standard_name = ccpp_block_sizes
+  long_name = for explicit data blocking: block sizes of all blocks
+  units = count
+  dimensions = (ccpp_block_count)
+  type = integer
+[blksz(ccpp_block_number)]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+[ncols]
+  standard_name = horizontal_dimension
+  long_name = horizontal dimension
+  units = count
+  dimensions = ()
+  type = integer
+[chunked_data_type]
+  standard_name = chunked_data_type
+  long_name = definition of type chunked_data_type
+  units = DDT
+  dimensions = ()
+  type = chunked_data_type
+[chunked_data_instance(ccpp_block_number)]
+  standard_name = chunked_data_type_instance
+  long_name = instance of derived data type chunked_data_type
+  units = DDT
+  dimensions = ()
+  type = chunked_data_type
+[chunked_data_instance]
+  standard_name = chunked_data_type_instance_all_blocks
+  long_name = instance of derived data type chunked_data_type
+  units = DDT
+  dimensions = (ccpp_block_count)
+  type = chunked_data_type

--- a/test_prebuild/test_chunked_data/main.F90
+++ b/test_prebuild/test_chunked_data/main.F90
@@ -24,14 +24,17 @@ program test_chunked_data
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    ! For physics running over the entire domain,
-   ! ccpp_thread_number is not used; set to safe value
-   ccpp_data_domain%thrd_no = 1
-   ccpp_data_domain%chunk_no = 1
+   ! ccpp_thread_number and ccpp_chunk_number are
+   ! set to 0, indicating that arrays are to be sent
+   ! following their dimension specification in the
+   ! metadata (must match horizontal_dimension).
+   ccpp_data_domain%thrd_no = 0
+   ccpp_data_domain%chunk_no = 0
 
    ! Loop over all blocks and threads for ccpp_data_chunks
    do ic=1,nchunks
       ! Assign the correct block numbers, only one thread
-      ccpp_data_chunks(ic)%blk_no = ic
+      ccpp_data_chunks(ic)%chunk_no = ic
       ccpp_data_chunks(ic)%thrd_no = 1
    end do
 

--- a/test_prebuild/test_chunked_data/main.F90
+++ b/test_prebuild/test_chunked_data/main.F90
@@ -1,0 +1,107 @@
+program test_chunked_data
+
+   use, intrinsic :: iso_fortran_env, only: error_unit
+
+   use ccpp_types, only: ccpp_t
+   use data, only: nblks, blksz, ncols
+   use data, only: ccpp_data_domain, ccpp_data_blocks, &
+                   chunked_data_type, chunked_data_instance
+
+   use ccpp_static_api, only: ccpp_physics_init, &
+                              ccpp_physics_timestep_init, &
+                              ccpp_physics_run, &
+                              ccpp_physics_timestep_finalize, &
+                              ccpp_physics_finalize
+
+   implicit none
+
+   character(len=*), parameter :: ccpp_suite = 'chunked_data_suite'
+   integer :: ib, ierr
+   type(ccpp_t), pointer :: cdata => null()
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP init step                                 !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   ! For physics running over the entire domain, block and thread
+   ! number are not used; set to safe values
+   ccpp_data_domain%blk_no = 1
+   ccpp_data_domain%thrd_no = 1
+
+   ! Loop over all blocks and threads for ccpp_data_blocks
+   do ib=1,nblks
+      ! Assign the correct block numbers, only one thread
+      ccpp_data_blocks(ib)%blk_no = ib
+      ccpp_data_blocks(ib)%thrd_no = 1
+   end do
+
+   do ib=1,size(chunked_data_instance)
+      allocate(chunked_data_instance(ib)%array_data(blksz(ib)))
+      write(error_unit,'(2(a,i3))') "Allocated array_data for block", ib, " to size", size(chunked_data_instance(ib)%array_data)
+   end do
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP physics init step                         !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   cdata => ccpp_data_domain
+   call ccpp_physics_init(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
+   if (ierr/=0) then
+      write(error_unit,'(a)') "An error occurred in ccpp_physics_init:"
+      write(error_unit,'(a)') trim(cdata%errmsg)
+      stop 1
+   end if
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP physics timestep init step                !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   cdata => ccpp_data_domain
+   call ccpp_physics_timestep_init(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
+   if (ierr/=0) then
+      write(error_unit,'(a)') "An error occurred in ccpp_physics_timestep_init:"
+      write(error_unit,'(a)') trim(cdata%errmsg)
+      stop 1
+   end if
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP physics run step                          !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   do ib=1,nblks
+      cdata => ccpp_data_blocks(ib)
+      call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
+      if (ierr/=0) then
+         write(error_unit,'(a,i3,a)') "An error occurred in ccpp_physics_run for block", ib, ":"
+         write(error_unit,'(a)') trim(cdata%errmsg)
+         stop 1
+      end if
+   end do
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP physics timestep finalize step            !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   cdata => ccpp_data_domain
+   call ccpp_physics_timestep_finalize(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
+   if (ierr/=0) then
+      write(error_unit,'(a)') "An error occurred in ccpp_physics_timestep_init:"
+      write(error_unit,'(a)') trim(cdata%errmsg)
+      stop 1
+   end if
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! CCPP physics finalize step                     !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   cdata => ccpp_data_domain
+   call ccpp_physics_finalize(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
+   if (ierr/=0) then
+      write(error_unit,'(a)') "An error occurred in ccpp_physics_timestep_init:"
+      write(error_unit,'(a)') trim(cdata%errmsg)
+      stop 1
+   end if
+
+contains
+
+end program test_chunked_data

--- a/test_prebuild/test_chunked_data/main.F90
+++ b/test_prebuild/test_chunked_data/main.F90
@@ -31,9 +31,9 @@ program test_chunked_data
    ccpp_data_domain%thrd_no = 0
    ccpp_data_domain%chunk_no = 0
 
-   ! Loop over all blocks and threads for ccpp_data_chunks
+   ! Loop over all chunks and threads for ccpp_data_chunks
    do ic=1,nchunks
-      ! Assign the correct block numbers, only one thread
+      ! Assign the correct chunk numbers, only one thread
       ccpp_data_chunks(ic)%chunk_no = ic
       ccpp_data_chunks(ic)%thrd_no = 1
    end do
@@ -73,7 +73,7 @@ program test_chunked_data
       cdata => ccpp_data_chunks(ic)
       call ccpp_physics_run(cdata, suite_name=trim(ccpp_suite), ierr=ierr)
       if (ierr/=0) then
-         write(error_unit,'(a,i3,a)') "An error occurred in ccpp_physics_run for block", ic, ":"
+         write(error_unit,'(a,i3,a)') "An error occurred in ccpp_physics_run for chunk", ic, ":"
          write(error_unit,'(a)') trim(cdata%errmsg)
          stop 1
       end if

--- a/test_prebuild/test_chunked_data/suite_chunked_data_suite.xml
+++ b/test_prebuild/test_chunked_data/suite_chunked_data_suite.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="chunked_data_suite" version="1">
+  <group name="chunked_data_group">
+    <subcycle loop="1">
+      <scheme>chunked_data_scheme</scheme>
+    </subcycle>
+  </group>
+</suite>


### PR DESCRIPTION
## Description

Add support for using chunked arrays to `ccpp_prebuild.py` while maintaining backward compatibility with the use of blocked data structures.

This PR adds support (and a test) for using chunked arrays as an alternative to blocked data structures to `ccpp_prebuild.py`. The idea behind this is that we can convert the ufs-weather-model to using contiguous arrays that are sent in chunks to the physics for (OpenMP-)parallel processing in the time integration (`run`) phase. The expectation is that this is at least as fast as the current implementation that uses blocked data structures (because the need to copy non-contiguous arrays into contiguous arrays and back for the `init`, `timestep_init`, `timestep_finalize` and `finalize` phases is removed). There is also evidence from extensive testing with CESM by CISL that sending chunks of contiguous arrays is faster.

**Note.** This PR does not yet make any changes for the ufs-weather-model, NEPTUNE or the SCM. It only provides the capability (and a test case that can serve as a how-to) for using contiguous arrays that can be sent to the physics in chunks in the `run` phase. There are limitations with how we (within `ccpp_prebuild`) treat inactive (unallocated) host model data that do not allow us to switch over to contiguous arrays immediately. I left several notes in the files changed in this PR to highlight the problems. **We need to find a different way to handle inactive data as a next step so that we can make the switch to contiguous arrays afterwards. This will have the positive (!) side effect that it will address concerns raised by NCO that the current approach violates operational requirements.**

User interface changes?: No

## Issues

Fixes https://github.com/NCAR/ccpp-framework/issues/520

## Testing

  test removed: none
  test added: added `test_prebuild/test_chunked_data/*`
  unit/system tests: all capgen unit/system tests pass (`test/run_test.sh`); all ccpp_prebuild unit/system tests pass (everything in `test_prebuild`)
  end-to-end tests: full regression tests with ufs-weather-model on Hera with Intel and GNU against existing baseline; all tests pass; **see also https://github.com/ufs-community/ufs-weather-model/pull/2066 for final regression testing**
  manual testing: extensively tested on my macOS with apple-clang+gfortran

## Dependencies / associated PRs

This PR is part of a set of PRs that need to be tested and merged together:
- https://github.com/ufs-community/ccpp-physics/pull/150
- https://github.com/NCAR/ccpp-framework/pull/519 (see here for initial regression testing on Hera)
- https://github.com/NOAA-EMC/fv3atm/pull/747
- https://github.com/ufs-community/ufs-weather-model/pull/2066 (see here for final regression testing)
