### PR TITLE
Vertical transform bugfix for variables with only a vertical dimension

### DIFF
--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -808,13 +808,13 @@ class VarCompatObj:
                      _DOCTEST_RUNENV) #doctest: +ELLIPSIS
     <var_props.VarCompatObj object at 0x...>
 
-    # Test that a 2-D var with no vertical transform works
+    # Test that a 1-D var with no vertical transform works
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var1_lname", False, \
                      "var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var2_lname", False, \
                      _DOCTEST_RUNENV) #doctest: +ELLIPSIS
     <var_props.VarCompatObj object at 0x...>
 
-    # Test that a 2-D var with vertical flipping works and that it
+    # Test that a 1-D var with vertical flipping works and that it
     # produces the correct reverse transformation
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var1_lname", False,\
                      "var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var2_lname", True, \

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -941,9 +941,6 @@ class VarCompatObj:
         # end if
         if self.__compat:
             # Check dimensions
-            ##XXgoldyXX: For now, we always have to create a dimension
-            ##           transform because we do not know if the vertical
-            ##           dimension is flipped.
             if var1_dims or var2_dims:
                 _, vdim_ind = find_vertical_dimension(var1_dims)
                 if (var1_dims != var2_dims):
@@ -978,13 +975,6 @@ class VarCompatObj:
            "var2" (i.e., "vertical_layer_dimension" or
            "vertical_interface_dimension").
         """
-        # Dimension transform (Indices handled externally)
-#        if isinstance(rvar_indices, str):
- #           rvar_indices = (rvar_indices,)
-        # end if
-  #      if isinstance(lvar_indices, str):
-   #         lvar_indices = (lvar_indices,)
-        # end if
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
 
@@ -1024,13 +1014,6 @@ class VarCompatObj:
            "var2" (i.e., "vertical_layer_dimension" or
            "vertical_interface_dimension").
         """
-        # Dimension transforms (Indices handled externally)
-#        if isinstance(lvar_indices, str):
- #           lvar_indices = (lvar_indices,)
-        # end if
-  #      if isinstance(rvar_indices, str):
-   #         rvar_indices = (rvar_indices,)
-        # end if
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
 

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -975,6 +975,7 @@ class VarCompatObj:
            "var2" (i.e., "vertical_layer_dimension" or
            "vertical_interface_dimension").
         """
+        # Dimension transform (Indices handled externally)
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
 
@@ -1014,6 +1015,7 @@ class VarCompatObj:
            "var2" (i.e., "vertical_layer_dimension" or
            "vertical_interface_dimension").
         """
+        # Dimension transforms (Indices handled externally)
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
 

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -814,6 +814,13 @@ class VarCompatObj:
                      _DOCTEST_RUNENV) #doctest: +ELLIPSIS
     <var_props.VarCompatObj object at 0x...>
 
+    # Test that a 2-D var with vertical flipping works and that it
+    # produces the correct reverse transformation
+    >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var1_lname", False,\
+                     "var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var2_lname", True, \
+                     _DOCTEST_RUNENV).reverse_transform("var1_lname", "var2_lname", 'k', 'nk-k+1')
+    'var1_lname(nk-k+1) = var2_lname(k)'
+
     # Test that a 2-D var with unit conversion m->km works
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m",  ['horizontal_dimension'], "var1_lname", False, \
                      "var_stdname", "real", "kind_phys", "km", ['horizontal_dimension'], "var2_lname", False, \
@@ -955,6 +962,12 @@ class VarCompatObj:
            "vertical_interface_dimension").
         """
         # Dimension transform (Indices handled externally)
+        if isinstance(rvar_indices, str):
+            rvar_indices = (rvar_indices,)
+        # end if
+        if isinstance(lvar_indices, str):
+            lvar_indices = (lvar_indices,)
+        # end if
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
 
@@ -995,6 +1008,12 @@ class VarCompatObj:
            "vertical_interface_dimension").
         """
         # Dimension transforms (Indices handled externally)
+        if isinstance(lvar_indices, str):
+            lvar_indices = (lvar_indices,)
+        # end if
+        if isinstance(rvar_indices, str):
+            rvar_indices = (rvar_indices,)
+        # end if
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
 

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -818,7 +818,7 @@ class VarCompatObj:
     # produces the correct reverse transformation
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var1_lname", False,\
                      "var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var2_lname", True, \
-                     _DOCTEST_RUNENV).reverse_transform("var1_lname", "var2_lname", 'k', 'nk-k+1')
+                     _DOCTEST_RUNENV).reverse_transform("var1_lname", "var2_lname", ('k',), ('nk-k+1',))
     'var1_lname(nk-k+1) = var2_lname(k)'
 
     # Test that a 2-D var with unit conversion m->km works
@@ -939,6 +939,23 @@ class VarCompatObj:
                 self.has_vert_transforms = True
             # end if
         # end if
+        if self.__compat:
+            # Check dimensions
+            ##XXgoldyXX: For now, we always have to create a dimension
+            ##           transform because we do not know if the vertical
+            ##           dimension is flipped.
+            if var1_dims or var2_dims:
+                _, vdim_ind = find_vertical_dimension(var1_dims)
+                if (var1_dims != var2_dims):
+                    self.__dim_transforms = self._get_dim_transforms(var1_dims,
+                                                                     var2_dims)
+                    self.__compat = self.__dim_transforms is not None
+                # end if
+            # end if
+            if not self.__compat:
+                incompat_reason.append('dimensions')
+            # end if
+        # end if
         self.__incompat_reason = " and ".join([x for x in incompat_reason if x])
 
     def forward_transform(self, lvar_lname, rvar_lname, rvar_indices, lvar_indices,
@@ -962,11 +979,11 @@ class VarCompatObj:
            "vertical_interface_dimension").
         """
         # Dimension transform (Indices handled externally)
-        if isinstance(rvar_indices, str):
-            rvar_indices = (rvar_indices,)
+#        if isinstance(rvar_indices, str):
+ #           rvar_indices = (rvar_indices,)
         # end if
-        if isinstance(lvar_indices, str):
-            lvar_indices = (lvar_indices,)
+  #      if isinstance(lvar_indices, str):
+   #         lvar_indices = (lvar_indices,)
         # end if
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
@@ -1008,11 +1025,11 @@ class VarCompatObj:
            "vertical_interface_dimension").
         """
         # Dimension transforms (Indices handled externally)
-        if isinstance(lvar_indices, str):
-            lvar_indices = (lvar_indices,)
+#        if isinstance(lvar_indices, str):
+ #           lvar_indices = (lvar_indices,)
         # end if
-        if isinstance(rvar_indices, str):
-            rvar_indices = (rvar_indices,)
+  #      if isinstance(rvar_indices, str):
+   #         rvar_indices = (rvar_indices,)
         # end if
         lhs_term = f"{lvar_lname}({','.join(lvar_indices)})"
         rhs_term = f"{rvar_lname}({','.join(rvar_indices)})"

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -808,6 +808,12 @@ class VarCompatObj:
                      _DOCTEST_RUNENV) #doctest: +ELLIPSIS
     <var_props.VarCompatObj object at 0x...>
 
+    # Test that a 2-D var with no vertical transform works
+    >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var1_lname", False, \
+                     "var_stdname", "real", "kind_phys", "m", ['vertical_layer_dimension'], "var2_lname", False, \
+                     _DOCTEST_RUNENV) #doctest: +ELLIPSIS
+    <var_props.VarCompatObj object at 0x...>
+
     # Test that a 2-D var with unit conversion m->km works
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m",  ['horizontal_dimension'], "var1_lname", False, \
                      "var_stdname", "real", "kind_phys", "km", ['horizontal_dimension'], "var2_lname", False, \
@@ -924,23 +930,6 @@ class VarCompatObj:
             if var1_top != var2_top:
                 self.__compat            = True
                 self.has_vert_transforms = True
-            # end if
-        # end if
-        if self.__compat:
-            # Check dimensions
-            ##XXgoldyXX: For now, we always have to create a dimension
-            ##           transform because we do not know if the vertical
-            ##           dimension is flipped.
-            if var1_dims or var2_dims:
-                _, vdim_ind = find_vertical_dimension(var1_dims)
-                if (var1_dims != var2_dims) or (vdim_ind >= 0):
-                    self.__dim_transforms = self._get_dim_transforms(var1_dims,
-                                                                     var2_dims)
-                    self.__compat = self.__dim_transforms is not None
-                # end if
-            # end if
-            if not self.__compat:
-                incompat_reason.append('dimensions')
             # end if
         # end if
         self.__incompat_reason = " and ".join([x for x in incompat_reason if x])


### PR DESCRIPTION
Enable 1D variables with only a vertical dimension by removing code that always adds a dimension transform.

var_props.py:
* adjust logic that always adds vertical transform and is prohibiting 1D variables with a vertical coordinate

User interface changes?: No

Testing:
  test removed:
  unit tests: Add doctests for vertical-only coordinate (not flipped and flipped)
  system tests:
  manual testing:

