### PR TITLE
Dummy-allocate inactive local variables

### DIFF
--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -161,7 +161,7 @@ class Var(object):
     def actions(self, values):
         if isinstance(values, dict):
             for key in values.keys():
-                if key in ['in', 'out'] and isstring(values[key]):
+                if key in ['in', 'out', 'in_inactive', 'out_inactive'] and isstring(values[key]):
                     self._actions[key] = values[key]
                 else:
                     raise Exception('Invalid values for variable attribute actions.')


### PR DESCRIPTION
Allocate dummy inactive local variables to size 0.

This is a temporary fix for the RRFS branch that is needed to compile with -check all. Using this flag, 
even if variables are not used within a scheme, they are checked for their allocation status, and 
unallocated variables lead to a runtime error. This fix goes with the other temporary fixes in 
ccpp-physics, fv3atm, etc. for the RRFS branch only. This issue is address more completely via 
https://github.com/NCAR/ccpp-framework/pull/529, and will be pulled into main when ready.

User interface changes?: No

Fixes: temporarily addresses https://github.com/ufs-community/ufs-weather-model/issues/2023

Testing: 
  test removed:
  unit tests:
  system tests: See https://github.com/ufs-community/ufs-weather-model/pull/2158 for testing results.
  manual testing:

