### PR TITLE
Add openmpi install to CI

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -39,6 +39,7 @@ jobs:
         ls
         cd ompi-4.1.6
         ls
+        ./autogen.pl
         ./configure --prefix=/home/runner/ompi-4.1.6
         make -j4
         make install

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -31,7 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
     - name: Install open mpi
       run: |
         wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
@@ -43,8 +42,8 @@ jobs:
         ./configure --prefix=/home/runner/ompi-4.1.6
         make -j4
         make install
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/home/runner/ompi-4.1.6/lib
-
+        echo "LD_LIBRARY_PATH=/home/runner/ompi-4.1.6/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=/home/runner/ompi-4.1.6/bin:$PATH" >> $GITHUB_ENV
     - name: ccpp-prebuild unit tests
       run: |
         export PYTHONPATH=$(pwd)/scripts:$(pwd)/scripts/parse_tools

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         python-version: ["3.8","3.9","3.10","3.11","3.12"]
 
+    env:
+      MPIHOME: /home/runner/openmpi
+
     steps:
     - uses: actions/checkout@v4
 
@@ -31,6 +34,18 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Install open mpi
+      run: |
+        wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
+        tar -xvf v4.1.6.tar.gz
+        ls
+        cd openmpi-v4.1.6
+        ./configure --prefix=${MPIHOME}
+        make -j4
+        make install
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MPIHOME}/lib
+
     - name: ccpp-prebuild unit tests
       run: |
         export PYTHONPATH=$(pwd)/scripts:$(pwd)/scripts/parse_tools

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -35,9 +35,7 @@ jobs:
       run: |
         wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
         tar -xvf v4.1.6.tar.gz
-        ls
         cd ompi-4.1.6
-        ls
         ./autogen.pl
         ./configure --prefix=/home/runner/ompi-4.1.6
         make -j4

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -19,9 +19,6 @@ jobs:
       matrix:
         python-version: ["3.8","3.9","3.10","3.11","3.12"]
 
-    env:
-      MPIHOME: /home/runner/openmpi
-
     steps:
     - uses: actions/checkout@v4
 
@@ -41,6 +38,7 @@ jobs:
         tar -xvf v4.1.6.tar.gz
         ls
         cd ompi-4.1.6
+        ls
         ./configure --prefix=/home/runner/ompi-4.1.6
         make -j4
         make install

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -40,11 +40,11 @@ jobs:
         wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
         tar -xvf v4.1.6.tar.gz
         ls
-        cd openmpi-v4.1.6
-        ./configure --prefix=${MPIHOME}
+        cd ompi-4.1.6
+        ./configure --prefix=/home/runner/ompi-4.1.6
         make -j4
         make install
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MPIHOME}/lib
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/home/runner/ompi-4.1.6/lib
 
     - name: ccpp-prebuild unit tests
       run: |


### PR DESCRIPTION
This PR adds to the CCPP Prebuild CI test to install open-mpi v4.1.6, which is now a requirement for CCPP.

