### PR TITLE
DO NOT MERGE: Add CCPP SCM CI to framework.

### DIFF
--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -20,11 +20,11 @@ jobs:
       bacio_ROOT: /home/runner/bacio
       sp_ROOT:    /home/runner/NCEPLIBS-sp
       w3emc_ROOT: /home/runner/myw3emc
-      SCM_ROOT:   /home/runner/work/ccpp-scm
+      SCM_ROOT:   /home/runner/ccpp-scm
       suites:     SCM_GFS_v15p2,SCM_GFS_v16,SCM_GFS_v17_p8,SCM_HRRR,SCM_RRFS_v1beta,SCM_RAP,SCM_WoFS_v0
       suites_ps:  SCM_GFS_v15p2_ps,SCM_GFS_v16_ps,SCM_GFS_v17_p8_ps,SCM_HRRR_ps,SCM_RRFS_v1beta_ps,SCM_RAP_ps,SCM_WoFS_v0_ps
-      dir_rt:     /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}
-      dir_bl:     /home/runner/work/ccpp-scm/test/BL-${{matrix.build-type}}
+      dir_rt:     /home/runner/ccpp-scm/test/artifact-${{matrix.build-type}}
+      dir_bl:     /home/runner/ccpp-scm/test/BL-${{matrix.build-type}}
 
     # Workflow steps
     steps:
@@ -211,12 +211,12 @@ jobs:
     - name: Run SCM RTs
       run: |
         cd ${SCM_ROOT}/scm/bin
-        ./run_scm.py --file /home/runner/work/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1
+        ./run_scm.py --file /home/runner/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1
 
     - name: Gather SCM RT output
       run: |
         cd ${SCM_ROOT}/test
-        mkdir /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}
+        mkdir /home/runner/ccpp-scm/test/artifact-${{matrix.build-type}}
         ./ci_util.py -b ${{matrix.build-type}}
 
     - name: Create directory for SCM RT baselines
@@ -237,4 +237,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: rt-baselines-${{matrix.build-type}}
-        path: /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}
+        path: /home/runner/ccpp-scm/test/artifact-${{matrix.build-type}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -37,15 +37,6 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Store remote-URL for current ccpp-framework code
-      run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
-
-    - name: Store branch name for current ccpp-framework code
-      run: echo "GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD`" >> $GITHUB_ENV
-
-    - name: Store hash for HEAD of current ccpp-framework code
-      run: echo "GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
-
     - name: Checkout latest CCPP SCM code.
       run: |
         git clone https://github.com/NCAR/ccpp-scm.git
@@ -55,18 +46,9 @@ jobs:
         cd ${SCM_ROOT}
         git submodule update --init --recursive
 
-    - name: Update ccpp-framework hash in ccpp-scm
+    - name: Update ccpp-framework hash in ccpp-scm.
       run: |
         cd ${SCM_ROOT}/ccpp/framework
-        echo ${{ github.repository }}
-        echo ${{ github.head_ref }}
-        echo ${{ github.event.pull_request.head.repo.name }}
-        echo ${{ github.event.pull_request.head.repo.clone_url }}
-        echo $GIT_REMOTE_URL
-        echo $GIT_REMOTE_BRANCH
-        echo ${{github.repository}}
-        echo ${{ github.event.pull_request.head.sha }}
-        echo $GITHUB_SHA
         git remote add remote_local ${{ github.event.pull_request.head.repo.clone_url }}
         git fetch remote_local ${{ github.head_ref }}
         git checkout remote_local/${{ github.head_ref }}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -58,21 +58,16 @@ jobs:
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
         cd ${SCM_ROOT}/ccpp/framework
-        echo "Slug URL variables"
-        echo " - ${{ env.GITHUB_REF_SLUG_URL }}"
-        echo " - ${{ env.GITHUB_HEAD_REF_SLUG_URL }}"
-        echo " - ${{ env.GITHUB_BASE_REF_SLUG_URL }}"
-        echo " - ${{ env.GITHUB_REPOSITORY_SLUG_URL }}"
-        echo " - "
+        echo ${{ github.repositoryUrl }}
         echo ${{ github.head_ref }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}
         echo ${{ github.event.pull_request.head.sha }}
         echo $GITHUB_SHA
-        git remote add remote_local $GIT_REMOTE_URL
-        git fetch remote_local $GIT_REMOTE_BRANCH
-        git checkout remote_local/$GIT_REMOTE_BRANCH
+        git remote add remote_local ${{ github.repositoryUrl }}
+        git fetch remote_local ${{ github.head_ref }}
+        git checkout remote_local/${{ github.head_ref }}
 
     #######################################################################################
     # Python setup

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -51,6 +51,7 @@ jobs:
 
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
+        ls ${SCM_ROOT}
         cd ${SCM_ROOT}/ccpp/framework
         ls ${SCM_ROOT}
         echo $GIT_REMOTE_URL

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -58,6 +58,7 @@ jobs:
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
         cd ${SCM_ROOT}/ccpp/framework
+        echo ${{ github.head_ref }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -55,7 +55,6 @@ jobs:
         git submodule update --init --recursive
 
     - name: Update ccpp-framework hash in ccpp-scm
-      if: github.event.pull_request == false
       run: |
         cd ${SCM_ROOT}/ccpp/framework
         echo $GIT_REMOTE_URL

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Checkout latest CCPP SCM code.
       run: |
-        git clone --recursive https://github.com/NCAR/ccpp-scm.git
+        git clone https://github.com/NCAR/ccpp-scm.git
 
     - name: Initialize submodules
       run: |
@@ -55,6 +55,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Update ccpp-framework hash in ccpp-scm
+      if: github.event.pull_request == false
       run: |
         cd ${SCM_ROOT}/ccpp/framework
         echo $GIT_REMOTE_URL

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -60,6 +60,8 @@ jobs:
         cd ${SCM_ROOT}/ccpp/framework
         echo ${{ github.repository }}
         echo ${{ github.head_ref }}
+        echo ${{ github.event.pull_request.head.repo.name }}
+        echo ${{ github.event.pull_request.head.repo.url }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -31,6 +31,7 @@ jobs:
     #######################################################################################
     # Initial
     #######################################################################################
+
     - name: Checkout current framework code (into /home/runner/work/ccpp-framework/)
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -1,0 +1,214 @@
+name: CI test to build and run the CCPP SCM regression tests
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  run_scm_rts:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        fortran-compiler: [gfortran-11]
+        build-type:       [Release, Debug]
+        py-version:       [3.9.12]
+
+    # Environmental variables
+    env:
+      NFHOME:     /home/runner/netcdf-fortran
+      NFVERSION:  v4.5.3
+      bacio_ROOT: /home/runner/bacio
+      sp_ROOT:    /home/runner/NCEPLIBS-sp
+      w3emc_ROOT: /home/runner/myw3emc
+      SCM_ROOT:   /home/runner/work/ccpp-scm/ccpp-scm
+      suites:     SCM_GFS_v15p2,SCM_GFS_v16,SCM_GFS_v17_p8,SCM_HRRR,SCM_RRFS_v1beta,SCM_RAP,SCM_WoFS_v0
+      suites_ps:  SCM_GFS_v15p2_ps,SCM_GFS_v16_ps,SCM_GFS_v17_p8_ps,SCM_HRRR_ps,SCM_RRFS_v1beta_ps,SCM_RAP_ps,SCM_WoFS_v0_ps
+      dir_rt:     /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
+      dir_bl:     /home/runner/work/ccpp-scm/ccpp-scm/test/BL-${{matrix.build-type}}
+
+    # Workflow steps
+    steps:
+    #######################################################################################
+    # Initial
+    #######################################################################################
+    - name: Checkout SCM code (into /home/runner/work/ccpp-scm/)
+      uses: actions/checkout@v3
+
+    - name: Initialize submodules
+      run: git submodule update --init --recursive
+
+    #######################################################################################
+    # Python setup
+    #######################################################################################
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{matrix.py-version}}
+
+    - name: Add conda to system path
+      run: |
+        echo $CONDA/bin >> $GITHUB_PATH
+
+    - name: Install NetCDF Python libraries
+      run: |
+        conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
+
+    - name: Update system packages
+      run: sudo apt-get update
+
+    #######################################################################################
+    # Install FORTRAN dependencies
+    #######################################################################################
+    - name: Environment for gfortran compiler
+      if: contains(matrix.fortran-compiler, 'gnu')
+      run: |
+        echo "FC=gfortran-11" >> $GITHUB_ENV
+        echo "CC=gcc-11"      >> $GITHUB_ENV
+
+    - name: Environment for ifort compiler
+      if: contains(matrix.fortran-compiler, 'intel')
+      run: |
+        echo "CC=icx"         >> $GITHUB_ENV
+        echo "FC=ifort"       >> $GITHUB_ENV
+
+    - name: Cache bacio library v2.4.1
+      id: cache-bacio-fortran
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/bacio
+        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-key
+
+    - name: Install bacio library v2.4.1
+      if: steps.cache-bacio-fortran.outputs.cache-hit != 'true'
+      run: |
+        git clone --branch v2.4.1 https://github.com/NOAA-EMC/NCEPLIBS-bacio.git bacio
+        cd bacio && mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=${bacio_ROOT} ../
+        make -j2
+        make install
+        echo "bacio_DIR=/home/runner/bacio/lib/cmake/bacio" >> $GITHUB_ENV
+
+    - name: Cache SP-library v2.3.3
+      id: cache-sp-fortran
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/NCEPLIBS-sp
+        key: cache-sp-fortran-${{matrix.fortran-compiler}}-key
+
+    - name: Install SP-library v2.3.3
+      if: steps.cache-sp-fortran.outputs.cache-hit != 'true'
+      run: |
+        git clone --branch v2.3.3 https://github.com/NOAA-EMC/NCEPLIBS-sp.git NCEPLIBS-sp
+        cd NCEPLIBS-sp && mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=${sp_ROOT} ../
+        make -j2
+        make install
+        echo "sp_DIR=/home/runner/NCEPLIBS-sp/lib/cmake/sp" >> $GITHUB_ENV
+
+    - name: Cache w3emc library v2.9.2
+      id: cache-w3emc-fortran
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/myw3emc
+        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-key
+
+    - name: Install w3emc library v2.9.2
+      if: steps.cache-w3emc-fortran.outputs.cache-hit != 'true'
+      run: |
+        git clone --branch v2.9.2 https://github.com/NOAA-EMC/NCEPLIBS-w3emc.git NCEPLIBS-w3emc
+        cd NCEPLIBS-w3emc && mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=${w3emc_ROOT} ../
+        make -j2
+        make install
+        echo "w3emc_DIR=/home/runner/myw3emc/lib/cmake/w3emc" >> $GITHUB_ENV
+
+    - name: Install NetCDF C library
+      run: sudo apt-get install libnetcdf-dev
+
+    - name: Cache NetCDF Fortran library
+      id: cache-netcdf-fortran
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/netcdf-fortran
+        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-key
+
+    - name: Install NetCDF Fortran library
+      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
+      run: |
+        git clone --branch ${NFVERSION} https://github.com/Unidata/netcdf-fortran.git
+        cd netcdf-fortran
+        ./configure
+        make -j
+        sudo make install
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NFHOME}/lib
+
+    - name: Install open mpi
+      run: |
+        wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
+        tar -xvf v4.1.6.tar.gz
+        cd ompi-4.1.6
+        ./autogen.pl
+        ./configure --prefix=/home/runner/ompi-4.1.6
+        make -j4
+        make install
+        echo "LD_LIBRARY_PATH=/home/runner/ompi-4.1.6/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=/home/runner/ompi-4.1.6/bin:$PATH" >> $GITHUB_ENV
+
+    #######################################################################################
+    # Build SCM. Run regression tests.
+    #######################################################################################
+    - name: Download data for SCM
+      run: |
+        cd ${SCM_ROOT}
+        ./contrib/get_all_static_data.sh
+        ./contrib/get_thompson_tables.sh
+
+    - name: Configure build with CMake (Release)
+      if: contains(matrix.build-type, 'Release')
+      run: |
+        cd ${SCM_ROOT}/scm
+        mkdir bin && cd bin
+        cmake -DCCPP_SUITES=${suites},${suites_ps} ../src
+
+    - name: Configure build with CMake (Debug)
+      if: contains(matrix.build-type, 'Debug')
+      run: |
+        cd ${SCM_ROOT}/scm
+        mkdir bin && cd bin
+        cmake -DCCPP_SUITES=${suites},${suites_ps} -DCMAKE_BUILD_TYPE=Debug ../src
+
+    - name: Build SCM
+      run: |
+        cd ${SCM_ROOT}/scm/bin
+        make -j4
+
+    - name: Run SCM RTs
+      run: |
+        cd ${SCM_ROOT}/scm/bin
+        ./run_scm.py --file /home/runner/work/ccpp-scm/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1
+
+    - name: Gather SCM RT output
+      run: |
+        cd ${SCM_ROOT}/test
+        mkdir /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
+        ./ci_util.py -b ${{matrix.build-type}}
+
+    - name: Create directory for SCM RT baselines
+      run: mkdir ${dir_bl}
+
+    - name: Download SCM RT baselines
+      run: |
+        cd ${dir_bl}
+        wget ftp://ftp.rap.ucar.edu:/pub/ccpp-scm/rt-baselines-${{matrix.build-type}}.zip
+        unzip rt-baselines-${{matrix.build-type}}.zip
+
+    - name: Compare SCM RT output to baselines
+      run: |
+        cd ${SCM_ROOT}/test
+        ./cmp_rt2bl.py --build_type ${{matrix.build-type}} --dir_rt ${dir_rt} --dir_bl ${dir_bl}
+
+    - name: Upload SCM RTs as GitHub Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: rt-baselines-${{matrix.build-type}}
+        path: /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -47,7 +47,10 @@ jobs:
       run: git submodule update --init --recursive
 
     - name: Grab CCPP SCM code
-      run: git clone --recursive https://github.com/NCAR/ccpp-scm.git
+      run: |
+        git clone --recursive https://github.com/NCAR/ccpp-scm.git
+        pwd
+        ls
 
     - name: Update ccpp-framework hash in ccpp-scm
       run: |

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -67,7 +67,7 @@ jobs:
         echo ${{github.repository}}
         echo ${{ github.event.pull_request.head.sha }}
         echo $GITHUB_SHA
-        git remote add remote_local ${{ github.repository }}
+        git remote add remote_local ${{ github.event.pull_request.head.repo.clone_url }}
         git fetch remote_local ${{ github.head_ref }}
         git checkout remote_local/${{ github.head_ref }}
 

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -31,11 +31,35 @@ jobs:
     #######################################################################################
     # Initial
     #######################################################################################
-    - name: Checkout SCM code (into /home/runner/work/ccpp-scm/)
+    - name: Checkout current framework code (into /home/runner/work/ccpp-framework/)
       uses: actions/checkout@v3
+
+    - name: Store remote-URL for current ccpp-framework code
+      run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
+
+    - name: Store branch name for current ccpp-framework code
+      run: echo "GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD`" >> $GITHUB_ENV
+
+    - name: Store hash for HEAD of current ccpp-framework code
+      run: echo "GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
 
     - name: Initialize submodules
       run: git submodule update --init --recursive
+
+    - name: Grab CCPP SCM code
+      run: git clone --recursive https://github.com/NCAR/ccpp-scm.git
+
+    - name: Update ccpp-framework hash in ccpp-scm
+      run: |
+        cd /home/runner/work/ccpp-scm/ccpp/framework
+        echo $GIT_REMOTE_URL
+        echo $GIT_REMOTE_BRANCH
+        echo ${{github.repository}}
+        echo ${{ github.event.pull_request.head.sha }}
+        echo $GITHUB_SHA
+        git remote add remote_local $GIT_REMOTE_URL
+        git fetch remote_local $GIT_REMOTE_BRANCH
+        git checkout remote_local/$GIT_REMOTE_BRANCH
 
     #######################################################################################
     # Python setup

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -61,7 +61,7 @@ jobs:
         echo ${{ github.repository }}
         echo ${{ github.head_ref }}
         echo ${{ github.event.pull_request.head.repo.name }}
-        echo ${{ github.event.pull_request.head.repo.url }}
+        echo ${{ github.event.pull_request.head.repo.clone_url }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -33,6 +33,8 @@ jobs:
     #######################################################################################
     - name: Checkout current framework code (into /home/runner/work/ccpp-framework/)
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Store remote-URL for current ccpp-framework code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
@@ -49,14 +51,10 @@ jobs:
     - name: Grab CCPP SCM code
       run: |
         git clone --recursive https://github.com/NCAR/ccpp-scm.git
-        pwd
-        ls
 
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
-        ls ${SCM_ROOT}
         cd ${SCM_ROOT}/ccpp/framework
-        ls ${SCM_ROOT}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -1,6 +1,6 @@
 name: CI test to build and run the CCPP SCM regression tests
 
-on: [pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run_scm_rts:

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -20,11 +20,11 @@ jobs:
       bacio_ROOT: /home/runner/bacio
       sp_ROOT:    /home/runner/NCEPLIBS-sp
       w3emc_ROOT: /home/runner/myw3emc
-      SCM_ROOT:   /home/runner/work/ccpp-scm/ccpp-scm
+      SCM_ROOT:   /home/runner/work/ccpp-scm
       suites:     SCM_GFS_v15p2,SCM_GFS_v16,SCM_GFS_v17_p8,SCM_HRRR,SCM_RRFS_v1beta,SCM_RAP,SCM_WoFS_v0
       suites_ps:  SCM_GFS_v15p2_ps,SCM_GFS_v16_ps,SCM_GFS_v17_p8_ps,SCM_HRRR_ps,SCM_RRFS_v1beta_ps,SCM_RAP_ps,SCM_WoFS_v0_ps
-      dir_rt:     /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
-      dir_bl:     /home/runner/work/ccpp-scm/ccpp-scm/test/BL-${{matrix.build-type}}
+      dir_rt:     /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}
+      dir_bl:     /home/runner/work/ccpp-scm/test/BL-${{matrix.build-type}}
 
     # Workflow steps
     steps:
@@ -51,7 +51,7 @@ jobs:
 
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
-        cd /home/runner/work/ccpp-scm/ccpp/framework
+        cd ${SCM_ROOT}/ccpp/framework
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}
@@ -209,12 +209,12 @@ jobs:
     - name: Run SCM RTs
       run: |
         cd ${SCM_ROOT}/scm/bin
-        ./run_scm.py --file /home/runner/work/ccpp-scm/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1
+        ./run_scm.py --file /home/runner/work/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1
 
     - name: Gather SCM RT output
       run: |
         cd ${SCM_ROOT}/test
-        mkdir /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
+        mkdir /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}
         ./ci_util.py -b ${{matrix.build-type}}
 
     - name: Create directory for SCM RT baselines
@@ -223,7 +223,7 @@ jobs:
     - name: Download SCM RT baselines
       run: |
         cd ${dir_bl}
-        wget ftp://ftp.rap.ucar.edu:/pub/ccpp-scm/rt-baselines-${{matrix.build-type}}.zip
+        wget ftp://ftp.rap.ucar.edu:/pub/rt-baselines-${{matrix.build-type}}.zip
         unzip rt-baselines-${{matrix.build-type}}.zip
 
     - name: Compare SCM RT output to baselines
@@ -235,4 +235,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: rt-baselines-${{matrix.build-type}}
-        path: /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
+        path: /home/runner/work/ccpp-scm/test/artifact-${{matrix.build-type}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -20,7 +20,7 @@ jobs:
       bacio_ROOT: /home/runner/bacio
       sp_ROOT:    /home/runner/NCEPLIBS-sp
       w3emc_ROOT: /home/runner/myw3emc
-      SCM_ROOT:   /home/runner/ccpp-scm
+      SCM_ROOT:   /home/runner/work/ccpp-framework/ccpp-framework/ccpp-scm
       suites:     SCM_GFS_v15p2,SCM_GFS_v16,SCM_GFS_v17_p8,SCM_HRRR,SCM_RRFS_v1beta,SCM_RAP,SCM_WoFS_v0
       suites_ps:  SCM_GFS_v15p2_ps,SCM_GFS_v16_ps,SCM_GFS_v17_p8_ps,SCM_HRRR_ps,SCM_RRFS_v1beta_ps,SCM_RAP_ps,SCM_WoFS_v0_ps
       dir_rt:     /home/runner/ccpp-scm/test/artifact-${{matrix.build-type}}

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -58,14 +58,14 @@ jobs:
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
         cd ${SCM_ROOT}/ccpp/framework
-        echo ${{ github.repositoryUrl }}
+        echo ${{ github.repository }}
         echo ${{ github.head_ref }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}
         echo ${{ github.event.pull_request.head.sha }}
         echo $GITHUB_SHA
-        git remote add remote_local ${{ github.repositoryUrl }}
+        git remote add remote_local ${{ github.repository }}
         git fetch remote_local ${{ github.head_ref }}
         git checkout remote_local/${{ github.head_ref }}
 

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -58,6 +58,12 @@ jobs:
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
         cd ${SCM_ROOT}/ccpp/framework
+        echo "Slug URL variables"
+        echo " - ${{ env.GITHUB_REF_SLUG_URL }}"
+        echo " - ${{ env.GITHUB_HEAD_REF_SLUG_URL }}"
+        echo " - ${{ env.GITHUB_BASE_REF_SLUG_URL }}"
+        echo " - ${{ env.GITHUB_REPOSITORY_SLUG_URL }}"
+        echo " - "
         echo ${{ github.head_ref }}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -45,12 +45,14 @@ jobs:
     - name: Store hash for HEAD of current ccpp-framework code
       run: echo "GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
 
-    - name: Initialize submodules
-      run: git submodule update --init --recursive
-
-    - name: Grab CCPP SCM code
+    - name: Checkout latest CCPP SCM code.
       run: |
         git clone --recursive https://github.com/NCAR/ccpp-scm.git
+
+    - name: Initialize submodules
+      run: |
+        cd ${SCM_ROOT}
+        git submodule update --init --recursive
 
     - name: Update ccpp-framework hash in ccpp-scm
       run: |

--- a/.github/workflows/run_ccpp_scm.yaml
+++ b/.github/workflows/run_ccpp_scm.yaml
@@ -52,6 +52,7 @@ jobs:
     - name: Update ccpp-framework hash in ccpp-scm
       run: |
         cd ${SCM_ROOT}/ccpp/framework
+        ls ${SCM_ROOT}
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}


### PR DESCRIPTION
For discussion only.
This PR adds the CCPP SCM CI enabled regression tests.

*NOTE* This test is failing because the CCPP-SCM is not up-to-date wrt the Framework. When the CCPP-SCm updates it's ccpp-framework hash, this test will pass.
