### PR TITLE
Add missing MPI target in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ set(${PACKAGE}_LIB_DIRS
 #------------------------------------------------------------------------------
 # Define the executable and what to link
 add_library(ccpp_framework STATIC ${SOURCES_F90})
-target_link_libraries(ccpp_framework LINK_PUBLIC ${LIBS} ${CMAKE_DL_LIBS})
+target_link_libraries(ccpp_framework PUBLIC MPI::MPI_Fortran)
 set_target_properties(ccpp_framework PROPERTIES VERSION ${PROJECT_VERSION}
                                       SOVERSION ${PROJECT_VERSION_MAJOR}
                                       LINK_FLAGS ${CMAKE_Fortran_FLAGS})


### PR DESCRIPTION
Add missing MPI target in `src/CMakeLists.txt`

Not sure why this is not causing any errors currently because it should be there! The line that gets replaced is old and should have been removed in the past (neither `LIBS` nor `CMAKE_DL_LIBS` is defined).

User interface changes?: No

Fixes: [Github issue #s] n/a

Testing:
  test removed: n/a
  unit tests: n/a
  system tests: n/a
  manual testing: on my macOS with ufs-weather-model

