### PR TITLE
Add capgen automated testing on PRs to "develop"

### DIFF
--- a/.github/workflows/capgen_unit_tests.yaml
+++ b/.github/workflows/capgen_unit_tests.yaml
@@ -3,7 +3,7 @@ name: Capgen Unit Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [feature/capgen, main]
+    branches: [develop, main]
 
 jobs:
   unit_tests:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,7 +3,7 @@ name: Python package
 on:
   workflow_dispatch:
   pull_request:
-    branches: [feature/capgen, main]
+    branches: [develop, main]
 
 jobs:
   build:


### PR DESCRIPTION
Updates the github workflows so capgen tests run when a PR is opened into the "develop" branch (in addition to the "main" branch)

User interface changes?: No

