### PR TITLE
Fix for ccpp_track_variables.py: Need "recursive=True" for glob on .meta files

### DIFF
--- a/scripts/ccpp_track_variables.py
+++ b/scripts/ccpp_track_variables.py
@@ -69,7 +69,7 @@ def create_metadata_filename_dict(metapath):
        with that scheme"""
 
     metadata_dict = {}
-    scheme_filenames = glob.glob(os.path.join(metapath, "*.meta"))
+    scheme_filenames = glob.glob(os.path.join(metapath, "*.meta"), recursive=True)
     if not scheme_filenames:
         raise Exception(f'No files found in {metapath} with ".meta" extension')
 


### PR DESCRIPTION
Because of the change in directory structure for CCPP physics (https://github.com/ufs-community/ccpp-physics/pull/99), there are now `.meta` files at different levels in the directory tree. The `ccpp_track_variables.py` script needs the location of these `.meta` files as an input argument to the script, but the call to `glob.glob` in the script does not use the `recursive=True` argument, so even if the user passes in the argument `-m './physics/physics/**/'` (which should include all subdirectories), the call to `glob.glob` only searches one level. Our simple test case only has `.meta` files at a single directory level, so we never caught this issue.

Simply adding the `recursive=True` argument fixes this issue.

User interface changes?: No

Fixes: #580 ccpp_track_variables.py is broken since CCPP physics directory structure was reorganized

Testing:
  test removed: none
  unit tests: Passing
  system tests: none
  manual testing: See Issue #580 

