### PR TITLE
Fix for "none" units edge case

### DIFF
--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -936,6 +936,13 @@ class VarCompatObj:
             # end if
         # end if
         if self.__compat:
+            # Only "none" units are case-insensitive
+            if var1_units.lower() == 'none':
+                var1_units = 'none'
+            # end if
+            if var2_units.lower() == 'none':
+                var2_units = 'none'
+            # end if
             # Check units argument
             if var1_units != var2_units:
                 self.__equiv = False

--- a/test/var_compatibility_test/test_host.meta
+++ b/test/var_compatibility_test/test_host.meta
@@ -26,7 +26,7 @@
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP
-  units = none
+  units = None
   dimensions = ()
   type = character
   kind = len=512


### PR DESCRIPTION
Tiny bugfix for unit conversion edge case that was trying to convert "None" to "none"

## Description
Convert "none" units to lowercase before comparing.

User interface changes?: No

Fixes: 
closes #567

Testing:
- Updated var_compatability_test to include a "None" to "none" comparison