### PR TITLE
Return full error message from xmllint

### DIFF
--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -68,7 +68,13 @@ def call_command(commands, logger, silent=False):
             cmd = ' '.join(commands)
             emsg = "Execution of '{}' failed with code:\n"
             outstr = emsg.format(cmd, err.returncode)
-            outstr += "{}".format(err.output)
+            outstr += f"{err.output.decode('utf-8', errors='replace').strip()}"
+            if hasattr(err, 'stderr') and err.stderr:
+                stderr_str = err.stderr.decode('utf-8', errors='replace').strip()
+                if stderr_str:
+                    outstr += f"Error output: {stderr_str}"
+                # end if
+            # end if
             raise CCPPError(outstr) from err
         # end if
     # end of try

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -85,12 +85,11 @@ def call_command(commands, logger, silent=False):
             outstr += f"{err.output.decode('utf-8', errors='replace').strip()}"
             if hasattr(err, 'stderr') and err.stderr:
                 stderr_str = err.stderr.decode('utf-8', errors='replace').strip()
-                if err.output:
-                    outstr += os.linesep
-                # end if
-                outstr += f"Error output: {stderr_str}"
-#                if stderr_str:
-#                    outstr += f"Error output: {stderr_str}"
+                if stderr_str:
+                    if err.output:
+                        outstr += os.linesep
+                    # end if
+                    outstr += f"Error output: {stderr_str}"
                 # end if
             # end if
             raise CCPPError(outstr) from err

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -55,9 +55,17 @@ def call_command(commands, logger, silent=False):
     ...    call_command(['ls','--invalid-option'], _LOGGER)
     ... except CCPPError as e:
     ...    print(str(e))
-    Execution of 'ls --invalid-option' failed with code:
+    Execution of 'ls --invalid-option' failed with code: 2
     Error output: ls: unrecognized option '--invalid-option'
     Try 'ls --help' for more information.
+    >>> try:
+    ...    os.chdir(os.path.dirname(__file__))
+    ...    call_command(['ls', os.path.basename(__file__), 'foo.bar.baz'], _LOGGER)
+    ... except CCPPError as e:
+    ...    print(str(e))
+    Execution of 'ls xml_tools.py foo.bar.baz' failed with code: 2
+    xml_tools.py
+    Error output: ls: cannot access 'foo.bar.baz': No such file or directory
     """
     result = False
     outstr = ''
@@ -73,13 +81,16 @@ def call_command(commands, logger, silent=False):
             result = False
         else:
             cmd = ' '.join(commands)
-            emsg = "Execution of '{}' failed with code:\n"
-            outstr = emsg.format(cmd, err.returncode)
+            outstr = f"Execution of '{cmd}' failed with code: {err.returncode}\n"
             outstr += f"{err.output.decode('utf-8', errors='replace').strip()}"
             if hasattr(err, 'stderr') and err.stderr:
                 stderr_str = err.stderr.decode('utf-8', errors='replace').strip()
-                if stderr_str:
-                    outstr += f"Error output: {stderr_str}"
+                if err.output:
+                    outstr += os.linesep
+                # end if
+                outstr += f"Error output: {stderr_str}"
+#                if stderr_str:
+#                    outstr += f"Error output: {stderr_str}"
                 # end if
             # end if
             raise CCPPError(outstr) from err

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -51,6 +51,13 @@ def call_command(commands, logger, silent=False):
     False
     >>> call_command(['ls'], _LOGGER)
     True
+    >>> try:
+    ...    call_command(['ls','--invalid-option'], _LOGGER)
+    ... except CCPPError as e:
+    ...    print(str(e))
+    Execution of 'ls --invalid-option' failed with code:
+    Error output: ls: unrecognized option '--invalid-option'
+    Try 'ls --help' for more information.
     """
     result = False
     outstr = ''


### PR DESCRIPTION
Update `call_command` function to include stderr output in CCPPError message.

Right now, when xmllint-ing is done via `xml_tools.py` (`validate_xml_file`),
the output of the linter is not returned. This PR adds the stderr output 
(if any) to the returned error message.

PR also decodes error messages for cleaner output.

User interface changes?: No

Testing:
  test removed: N/A
  unit tests: Added new doctest to test error message
  system tests: N/A
  manual testing: Ran with/parsed new error messages within CAM-SIMA

