### PR TITLE
fix errflg variable name in cap

### DIFF
--- a/scripts/host_cap.py
+++ b/scripts/host_cap.py
@@ -696,7 +696,7 @@ def write_host_cap(host_model, api, module_name, output_dir, run_env):
                     call_str = suite_part_call_list(host_model, const_dict, spart, False,
                                                                        dyn_const=True)
                     cap.write(f"call {suite.name}_{stage}({call_str})", 3)
-                    cap.write("if (errflg /= 0) then", 3)
+                    cap.write(f"if ({errflg_name} /= 0) then", 3)
                     cap.write("return", 4)
                     cap.write("end if", 3)
                     # Allocate the suite's dynamic constituents array


### PR DESCRIPTION
Fixes bug introduced by me in #608. Use variable errflg name instead of "errflg" explicitly

User interface changes?: No

Testing:
  test removed: none
  unit tests: all pass
  system tests: all pass
  manual testing:

