### PR TITLE
Merge two workarounds for ccpp-prebuild for handling optional arguments

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -490,9 +490,12 @@ def compare_metadata(metadata_define, metadata_request):
         if not metadata_define[var_name][0].active == 'T':
             for var in metadata_request[var_name]:
                 if var.optional == 'F':
-                    logging.error("Conditionally allocated host-model variable {0} is not optional in {1}".format(
+                    # DH 20241022 - change logging.error to logging.warn, because it is known
+                    # that this strict check is not correct and will be reverted soon
+                    #logging.error(
+                    logging.warn("Conditionally allocated host-model variable {0} is not optional in {1}".format(
                                   var_name, var.container))
-                    success = False
+                    #success = False
         # TEMPORARY CHECK - IF THE VARIABLE IS ALWAYS ALLOCATED, THE SCHEME VARIABLE SHOULDN'T BE OPTIONAL
         else:
             for var in metadata_request[var_name]:

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -355,12 +355,16 @@ class Var(object):
                         str = "type({s.type}), pointer :: p => null()"
             return str.format(s=self)
         else:
-            # If the host variable is potentially unallocated, the active attribute is
-            # also set accordingly for the local variable; add target to variable declaration
-            if self.optional == 'T':
-                target = ', target'
-            else:
-                target = ''
+            # DH* 20241022 WORKAROUND TO ACCOUNT FOR MISSING UPDATES TO CCPP PHYSICS
+            # W.R.T. DECLARING OPTIONAL VARIABLES IN METADATA AND CODE. ALWAYS USE TARGET
+            ## If the host variable is potentially unallocated, the active attribute is
+            ## also set accordingly for the local variable; add target to variable declaration
+            #if self.optional == 'T':
+            #    target = ', target'
+            #else:
+            #    target = ''
+            target = ', target'
+            # *DH
             if self.type in STANDARD_VARIABLE_TYPES:
                 if self.kind:
                     if self.rank:


### PR DESCRIPTION
**This PR affects ccpp-prebuild only. It can be merged into develop (or main), but it must come to main as soon as possible for use in UFS/SCM.**

This PR adds workarounds for handling optional arguments the right way (finally!) in `scripts/ccpp_prebuild.py` and `scripts/mkcap.py`. This update is already in use in NEPTUNE and is required for @dustinswales' work to update/revert the optional arguments in ccpp-physics in the UFS and the SCM.

The workaround for `ccpp-prebuild` allows us to treat only those arguments as optional that are truly optional for a CCPP scheme. In the past, any argument that was conditionally allocated by any of the host models had to be declared as optional, even if it was required by the physics.

User interface changes?: Yes and No. This can be merged without making any changes (it won't break the previous functionality where any conditionally allocated variable had to be declared as optional in the physics). But it will allow to declare many CCPP physics variables as non-optional if they aren't really optional.

This finally resolves https://github.com/NCAR/ccpp-framework/issues/566 (by making ccpp-prebuild behave the same as capgen, which is the correct way to handle optional arguments).

Testing:
  test removed: none
  unit tests: all pass
  system tests: all pass
  manual testing: implemented and tested thoroughly in NEPTUNE

