### PR TITLE
Bugfix for unpromoted ddt-type scalar variables

### DIFF
--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -2485,9 +2485,9 @@ class Group(SuiteObject):
         call_vars = self.call_list.variable_list()
         self._ddt_library.write_ddt_use_statements(call_vars, outfile,
                                                    indent+1, pad=modmax)
-        decl_vars = [x[0] for x in subpart_allocate_vars.values()] + \
-                    [x[0] for x in subpart_scalar_vars.values()] + \
-                    [x[0] for x in subpart_optional_vars.values()]
+        decl_vars = ([x[0] for x in subpart_allocate_vars.values()] +
+                     [x[0] for x in subpart_scalar_vars.values()] +
+                     [x[0] for x in subpart_optional_vars.values()])
         self._ddt_library.write_ddt_use_statements(decl_vars, outfile,
                                                    indent+1, pad=modmax)
         outfile.write('', 0)

--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -2485,7 +2485,9 @@ class Group(SuiteObject):
         call_vars = self.call_list.variable_list()
         self._ddt_library.write_ddt_use_statements(call_vars, outfile,
                                                    indent+1, pad=modmax)
-        decl_vars = [x[0] for x in subpart_allocate_vars.values()]
+        decl_vars = [x[0] for x in subpart_allocate_vars.values()] + \
+                    [x[0] for x in subpart_scalar_vars.values()] + \
+                    [x[0] for x in subpart_optional_vars.values()]
         self._ddt_library.write_ddt_use_statements(decl_vars, outfile,
                                                    indent+1, pad=modmax)
         outfile.write('', 0)


### PR DESCRIPTION
Fixes a bug where a ddt used in only one phase (thereby not promoted to the group level) does not get the necessary "use" statement added at the subroutine level in the suite cap.

**Updates**
M   scripts/suite_objects.py
- Modifications to add necessary ddt use statements for scalar and optional variables

User interface changes?: No

Testing:
  test removed: n/a
  unit tests: all pass
  system tests: all pass
  manual testing: ran w/ scalar ddt in CAM-SIMA

