### PR TITLE
Capgen in SCM: Bug fix for scheme ordering in non-run phases

### DIFF
--- a/scripts/ccpp_suite.py
+++ b/scripts/ccpp_suite.py
@@ -426,14 +426,14 @@ character(len=16) :: {css_var_name} = '{state}'
         self.__ddt_library = ddt_library
         # Collect all relevant schemes
         # For all groups, find associated init and final methods
-        scheme_set = list()
+        scheme_list = list()
         for group in self.groups:
             for scheme in group.schemes():
-                scheme_set.append(scheme.name)
+                scheme_list.append(scheme.name)
             # end for
         # end for
         no_scheme_entries = {} # Skip schemes that are not in this suite
-        for module in scheme_set:
+        for module in scheme_list:
             if scheme_library[module]:
                 scheme_entries = scheme_library[module]
             else:

--- a/scripts/ccpp_suite.py
+++ b/scripts/ccpp_suite.py
@@ -426,15 +426,15 @@ character(len=16) :: {css_var_name} = '{state}'
         self.__ddt_library = ddt_library
         # Collect all relevant schemes
         # For all groups, find associated init and final methods
-        scheme_set = set()
+        scheme_set = list()
         for group in self.groups:
             for scheme in group.schemes():
-                scheme_set.add(scheme.name)
+                scheme_set.append(scheme.name)
             # end for
         # end for
         no_scheme_entries = {} # Skip schemes that are not in this suite
-        for module in scheme_library:
-            if module in scheme_set:
+        for module in scheme_set:
+            if scheme_library[module]:
                 scheme_entries = scheme_library[module]
             else:
                 scheme_entries = no_scheme_entries

--- a/test/var_compatibility_test/effr_calc.F90
+++ b/test/var_compatibility_test/effr_calc.F90
@@ -14,12 +14,21 @@ module effr_calc
    !> \section arg_table_effr_calc_init Argument Table
    !! \htmlinclude arg_table_effr_calc_init.html
    !!
-   subroutine effr_calc_init(errmsg, errflg)
+   subroutine effr_calc_init(scheme_order, errmsg, errflg)
      character(len=512), intent(out)   :: errmsg
      integer,            intent(out)   :: errflg
-     
+     integer,            intent(inout) :: scheme_order
+
      errmsg = ''
      errflg = 0
+
+     if (scheme_order .ne. 2) then
+        errflg = 1
+        errmsg = 'ERROR: effr_calc_init() needs to be called second'
+        return
+     else
+        scheme_order = scheme_order + 1
+     endif
 
    end subroutine effr_calc_init
   

--- a/test/var_compatibility_test/effr_calc.F90
+++ b/test/var_compatibility_test/effr_calc.F90
@@ -8,10 +8,21 @@ module effr_calc
    implicit none
    private
 
-   public :: effr_calc_run
+   public :: effr_calc_run, effr_calc_init
 
-contains
+ contains
+   !> \section arg_table_effr_calc_init Argument Table
+   !! \htmlinclude arg_table_effr_calc_init.html
+   !!
+   subroutine effr_calc_init(errmsg, errflg)
+     character(len=512), intent(out)   :: errmsg
+     integer,            intent(out)   :: errflg
+     
+     errmsg = ''
+     errflg = 0
 
+   end subroutine effr_calc_init
+  
    !> \section arg_table_effr_calc_run  Argument Table
    !! \htmlinclude arg_table_effr_calc_run.html
    !!

--- a/test/var_compatibility_test/effr_calc.meta
+++ b/test/var_compatibility_test/effr_calc.meta
@@ -2,6 +2,26 @@
   name = effr_calc
   type = scheme
   dependencies =
+########################################################################
+[ccpp-arg-table]
+  name = effr_calc_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+########################################################################
 [ccpp-arg-table]
   name = effr_calc_run
   type = scheme

--- a/test/var_compatibility_test/effr_calc.meta
+++ b/test/var_compatibility_test/effr_calc.meta
@@ -6,6 +6,13 @@
 [ccpp-arg-table]
   name = effr_calc_init
   type = scheme
+[ scheme_order ]
+  standard_name = scheme_order_in_suite
+  long_name = scheme order in suite definition file
+  units = None
+  dimensions = ()
+  type = integer
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP

--- a/test/var_compatibility_test/effr_diag.F90
+++ b/test/var_compatibility_test/effr_diag.F90
@@ -15,12 +15,21 @@ contains
   !> \section arg_table_effr_diag_init Argument Table
   !! \htmlinclude arg_table_effr_diag_init.html
   !!
-  subroutine effr_diag_init(errmsg, errflg)
+  subroutine effr_diag_init(scheme_order, errmsg, errflg)
     character(len=512), intent(out)   :: errmsg
     integer,            intent(out)   :: errflg
+    integer,            intent(inout) :: scheme_order
  
     errmsg = ''
     errflg = 0
+
+    if (scheme_order .ne. 4) then
+        errflg = 1
+        errmsg = 'ERROR: effr_diag_init() needs to be called fourth'
+        return
+     else
+        scheme_order = scheme_order + 1
+     endif
 
   end subroutine effr_diag_init
 

--- a/test/var_compatibility_test/effr_diag.F90
+++ b/test/var_compatibility_test/effr_diag.F90
@@ -8,9 +8,21 @@ module effr_diag
    implicit none
    private
 
-   public :: effr_diag_run
+   public :: effr_diag_run, effr_diag_init
 
 contains
+
+  !> \section arg_table_effr_diag_init Argument Table
+  !! \htmlinclude arg_table_effr_diag_init.html
+  !!
+  subroutine effr_diag_init(errmsg, errflg)
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+ 
+    errmsg = ''
+    errflg = 0
+
+  end subroutine effr_diag_init
 
    !> \section arg_table_effr_diag_run  Argument Table
    !! \htmlinclude arg_table_effr_diag_run.html

--- a/test/var_compatibility_test/effr_diag.meta
+++ b/test/var_compatibility_test/effr_diag.meta
@@ -2,6 +2,26 @@
   name = effr_diag
   type = scheme
   dependencies =
+########################################################################
+[ccpp-arg-table]
+  name = effr_diag_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+########################################################################
 [ccpp-arg-table]
   name = effr_diag_run
   type = scheme

--- a/test/var_compatibility_test/effr_diag.meta
+++ b/test/var_compatibility_test/effr_diag.meta
@@ -6,6 +6,13 @@
 [ccpp-arg-table]
   name = effr_diag_init
   type = scheme
+[ scheme_order ]
+  standard_name = scheme_order_in_suite
+  long_name = scheme order in suite definition file
+  units = None
+  dimensions = ()
+  type = integer
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP

--- a/test/var_compatibility_test/effr_post.F90
+++ b/test/var_compatibility_test/effr_post.F90
@@ -15,12 +15,21 @@ contains
    !> \section arg_table_effr_post_init Argument Table
    !! \htmlinclude arg_table_effr_post_init.html
    !!
-   subroutine effr_post_init(errmsg, errflg)
+   subroutine effr_post_init(scheme_order, errmsg, errflg)
      character(len=512), intent(out)   :: errmsg
      integer,            intent(out)   :: errflg
+     integer,            intent(inout) :: scheme_order
 
      errmsg = ''
      errflg = 0
+
+     if (scheme_order .ne. 3) then
+        errflg = 1
+        errmsg = 'ERROR: effr_post_init() needs to be called third'
+        return
+     else
+        scheme_order = scheme_order + 1
+     endif
 
    end subroutine effr_post_init
 

--- a/test/var_compatibility_test/effr_post.F90
+++ b/test/var_compatibility_test/effr_post.F90
@@ -8,9 +8,21 @@ module effr_post
    implicit none
    private
 
-   public :: effr_post_run
+   public :: effr_post_run, effr_post_init
 
 contains
+
+   !> \section arg_table_effr_post_init Argument Table
+   !! \htmlinclude arg_table_effr_post_init.html
+   !!
+   subroutine effr_post_init(errmsg, errflg)
+     character(len=512), intent(out)   :: errmsg
+     integer,            intent(out)   :: errflg
+
+     errmsg = ''
+     errflg = 0
+
+   end subroutine effr_post_init
 
    !> \section arg_table_effr_post_run  Argument Table
    !! \htmlinclude arg_table_effr_post_run.html

--- a/test/var_compatibility_test/effr_post.meta
+++ b/test/var_compatibility_test/effr_post.meta
@@ -6,6 +6,13 @@
 [ccpp-arg-table]
   name = effr_post_init
   type = scheme
+[ scheme_order ]
+  standard_name = scheme_order_in_suite
+  long_name = scheme order in suite definition file
+  units = None
+  dimensions = ()
+  type = integer
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP

--- a/test/var_compatibility_test/effr_post.meta
+++ b/test/var_compatibility_test/effr_post.meta
@@ -2,6 +2,26 @@
   name = effr_post
   type = scheme
   dependencies =
+########################################################################
+[ccpp-arg-table]
+  name = effr_post_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+########################################################################
 [ccpp-arg-table]
   name = effr_post_run
   type = scheme

--- a/test/var_compatibility_test/effr_pre.F90
+++ b/test/var_compatibility_test/effr_pre.F90
@@ -14,12 +14,21 @@ contains
    !> \section arg_table_effr_pre_init Argument Table
    !! \htmlinclude arg_table_effr_pre_init.html
    !!
-   subroutine effr_pre_init(errmsg, errflg)
+   subroutine effr_pre_init(scheme_order, errmsg, errflg)
      character(len=512), intent(out)   :: errmsg
      integer,            intent(out)   :: errflg
+     integer,            intent(inout) :: scheme_order
 
      errmsg = ''
      errflg = 0
+
+     if (scheme_order .ne. 1) then
+        errflg = 1
+        errmsg = 'ERROR: effr_pre_init() needs to be called first'
+        return
+     else
+        scheme_order = scheme_order + 1
+     endif
 
    end subroutine effr_pre_init
 

--- a/test/var_compatibility_test/effr_pre.F90
+++ b/test/var_compatibility_test/effr_pre.F90
@@ -8,9 +8,20 @@ module effr_pre
    implicit none
    private
 
-   public :: effr_pre_run
+   public :: effr_pre_run, effr_pre_init
 
 contains
+   !> \section arg_table_effr_pre_init Argument Table
+   !! \htmlinclude arg_table_effr_pre_init.html
+   !!
+   subroutine effr_pre_init(errmsg, errflg)
+     character(len=512), intent(out)   :: errmsg
+     integer,            intent(out)   :: errflg
+
+     errmsg = ''
+     errflg = 0
+
+   end subroutine effr_pre_init
 
    !> \section arg_table_effr_pre_run  Argument Table
    !! \htmlinclude arg_table_effr_pre_run.html

--- a/test/var_compatibility_test/effr_pre.meta
+++ b/test/var_compatibility_test/effr_pre.meta
@@ -2,6 +2,26 @@
   name = effr_pre
   type = scheme
   dependencies =
+########################################################################
+[ccpp-arg-table]
+  name = effr_pre_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+########################################################################
 [ccpp-arg-table]
   name = effr_pre_run
   type = scheme

--- a/test/var_compatibility_test/effr_pre.meta
+++ b/test/var_compatibility_test/effr_pre.meta
@@ -6,6 +6,13 @@
 [ccpp-arg-table]
   name = effr_pre_init
   type = scheme
+[ scheme_order ]
+  standard_name = scheme_order_in_suite
+  long_name = scheme order in suite definition file
+  units = None
+  dimensions = ()
+  type = integer
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP

--- a/test/var_compatibility_test/run_test
+++ b/test/var_compatibility_test/run_test
@@ -144,6 +144,7 @@ required_vars_var_compatibility="${required_vars_var_compatibility},horizontal_d
 required_vars_var_compatibility="${required_vars_var_compatibility},horizontal_loop_begin"
 required_vars_var_compatibility="${required_vars_var_compatibility},horizontal_loop_end"
 required_vars_var_compatibility="${required_vars_var_compatibility},scalar_variable_for_testing"
+required_vars_var_compatibility="${required_vars_var_compatibility},scheme_order_in_suite"
 required_vars_var_compatibility="${required_vars_var_compatibility},vertical_layer_dimension"
 input_vars_var_compatibility="cloud_graupel_number_concentration"
 #input_vars_var_compatibility="${input_vars_var_compatibility},cloud_ice_number_concentration"
@@ -157,6 +158,7 @@ input_vars_var_compatibility="${input_vars_var_compatibility},horizontal_dimensi
 input_vars_var_compatibility="${input_vars_var_compatibility},horizontal_loop_begin"
 input_vars_var_compatibility="${input_vars_var_compatibility},horizontal_loop_end"
 input_vars_var_compatibility="${input_vars_var_compatibility},scalar_variable_for_testing"
+input_vars_var_compatibility="${input_vars_var_compatibility},scheme_order_in_suite"
 input_vars_var_compatibility="${input_vars_var_compatibility},vertical_layer_dimension"
 output_vars_var_compatibility="ccpp_error_code,ccpp_error_message"
 output_vars_var_compatibility="${output_vars_var_compatibility},cloud_ice_number_concentration"
@@ -165,6 +167,7 @@ output_vars_var_compatibility="${output_vars_var_compatibility},effective_radius
 output_vars_var_compatibility="${output_vars_var_compatibility},effective_radius_of_stratiform_cloud_rain_particle"
 output_vars_var_compatibility="${output_vars_var_compatibility},effective_radius_of_stratiform_cloud_snow_particle"
 output_vars_var_compatibility="${output_vars_var_compatibility},scalar_variable_for_testing"
+output_vars_var_compatibility="${output_vars_var_compatibility},scheme_order_in_suite"
 
 ##
 ## Run a database report and check the return string

--- a/test/var_compatibility_test/test_host.F90
+++ b/test/var_compatibility_test/test_host.F90
@@ -351,17 +351,18 @@ CONTAINS
 
    character(len=cs), target :: test_parts1(1) = (/ 'radiation       ' /)
 
-   character(len=cm), target :: test_invars1(8) = (/                          &
+   character(len=cm), target :: test_invars1(9) = (/                          &
         'effective_radius_of_stratiform_cloud_rain_particle        ',         &
         'effective_radius_of_stratiform_cloud_liquid_water_particle',         &
         'effective_radius_of_stratiform_cloud_snow_particle        ',         &
         'effective_radius_of_stratiform_cloud_graupel              ',         &
         'cloud_graupel_number_concentration                        ',         &
         'scalar_variable_for_testing                               ',         &
+        'scheme_order_in_suite                                     ',         &
         'flag_indicating_cloud_microphysics_has_graupel            ',         &
         'flag_indicating_cloud_microphysics_has_ice                '/)
 
-   character(len=cm), target :: test_outvars1(8) = (/                         &
+   character(len=cm), target :: test_outvars1(9) = (/                         &
         'ccpp_error_code                                           ',         &
         'ccpp_error_message                                        ',         &
         'effective_radius_of_stratiform_cloud_ice_particle         ',         &
@@ -369,9 +370,11 @@ CONTAINS
         'effective_radius_of_stratiform_cloud_rain_particle        ',         &
         'effective_radius_of_stratiform_cloud_snow_particle        ',         &
         'cloud_ice_number_concentration                            ',         &
-        'scalar_variable_for_testing                               ' /)
+        'scalar_variable_for_testing                               ',         &
+        'scheme_order_in_suite                                     '/)
+   
 
-   character(len=cm), target :: test_reqvars1(12) = (/                        &
+   character(len=cm), target :: test_reqvars1(13) = (/                        &
         'ccpp_error_code                                           ',         &
         'ccpp_error_message                                        ',         &
         'effective_radius_of_stratiform_cloud_rain_particle        ',         &
@@ -382,6 +385,7 @@ CONTAINS
         'cloud_graupel_number_concentration                        ',         &
         'cloud_ice_number_concentration                            ',         &
         'scalar_variable_for_testing                               ',         &
+        'scheme_order_in_suite                                     ', 	      &
         'flag_indicating_cloud_microphysics_has_graupel            ',         &
         'flag_indicating_cloud_microphysics_has_ice                '/)
 

--- a/test/var_compatibility_test/test_host_data.F90
+++ b/test/var_compatibility_test/test_host_data.F90
@@ -13,6 +13,7 @@ module test_host_data
           ncg,                                       & ! number concentration of cloud graupel
           nci                                          ! number concentration of cloud ice
      real(kind_phys) :: scalar_var
+     integer :: scheme_order
   end type physics_state
 
   public allocate_physics_state
@@ -61,6 +62,9 @@ contains
        end if
        allocate(state%nci(cols, levels))
     endif
+
+    ! Initialize scheme counter.
+    state%scheme_order = 1
 
   end subroutine allocate_physics_state
 

--- a/test/var_compatibility_test/test_host_data.meta
+++ b/test/var_compatibility_test/test_host_data.meta
@@ -59,3 +59,9 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[scheme_order]
+  standard_name = scheme_order_in_suite
+  long_name = scheme order in suite definition file
+  units = None
+  dimensions = ()
+  type = integer

--- a/test/var_compatibility_test/test_reports.py
+++ b/test/var_compatibility_test/test_reports.py
@@ -74,6 +74,7 @@ _INPUT_VARS_VAR_ACTION = ["horizontal_loop_begin", "horizontal_loop_end", "horiz
                           "effective_radius_of_stratiform_cloud_graupel",
                           "cloud_graupel_number_concentration",
                           "scalar_variable_for_testing",
+                          "scheme_order_in_suite",
                           "flag_indicating_cloud_microphysics_has_graupel",
                           "flag_indicating_cloud_microphysics_has_ice"]
 _OUTPUT_VARS_VAR_ACTION = ["ccpp_error_code", "ccpp_error_message",
@@ -82,7 +83,8 @@ _OUTPUT_VARS_VAR_ACTION = ["ccpp_error_code", "ccpp_error_message",
                            "effective_radius_of_stratiform_cloud_snow_particle",
                            "cloud_ice_number_concentration",
                            "effective_radius_of_stratiform_cloud_rain_particle",
-                           "scalar_variable_for_testing"]
+                           "scalar_variable_for_testing",
+                           "scheme_order_in_suite"]
 _REQUIRED_VARS_VAR_ACTION = _INPUT_VARS_VAR_ACTION + _OUTPUT_VARS_VAR_ACTION
 
 def fields_string(field_type, field_list, sep):


### PR DESCRIPTION
Description:
A python set is used to gather the schemes to call in the non CCPP run phases. However, python sets don't maintain the order, and hence the call order is wrong outside the run phase.

User interface changes?: No

Fixes: #628 

Testing:
Expanded var_compatibility_test to have initialization phases and illustrate bug. 
Not sure how to test that the order is unchanged?


