### PR TITLE
ccpp_prebuild.py: remove execute function from common.py, clean files the Python way

### DIFF
--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 # CCPP framework imports
-from common import encode_container, decode_container, decode_container_as_dict, execute
+from common import encode_container, decode_container, decode_container_as_dict
 from common import CCPP_STAGES, CCPP_INTERNAL_VARIABLES, CCPP_STATIC_API_MODULE, CCPP_INTERNAL_VARIABLE_DEFINITON_FILE
 from common import STANDARD_VARIABLE_TYPES, STANDARD_INTEGER_TYPE, CCPP_TYPE
 from common import SUITE_DEFINITION_FILENAME_PATTERN
@@ -157,9 +157,14 @@ def clean_files(config, namespace):
         os.path.join(config['static_api_dir'], static_api_file),
         config['static_api_sourcefile'],
         ]
-    # Not very pythonic, but the easiest way w/o importing another Python module
-    cmd = 'rm -vf {0}'.format(' '.join(files_to_remove))
-    execute(cmd)
+    for f in files_to_remove:
+        try:
+            os.remove(f)
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logging.error(f"Error removing {f}: {e}")
+            success = False
     return success
 
 def get_all_suites(suites_dir):

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -78,35 +78,6 @@ SUITE_DEFINITION_FILENAME_PATTERN = re.compile('^(.*)\.xml$')
 # Maximum number of concurrent CCPP instances per MPI task
 CCPP_NUM_INSTANCES = 200
 
-def execute(cmd, abort = True):
-    """Runs a local command in a shell. Waits for completion and
-    returns status, stdout and stderr. If abort = True, abort in
-    case an error occurs during the execution of the command."""
-
-    # Set debug to true if logging level is debug
-    debug = logging.getLogger().getEffectiveLevel() == logging.DEBUG
-
-    logging.debug('Executing "{0}"'.format(cmd))
-    p = subprocess.Popen(cmd, stdout = subprocess.PIPE,
-                         stderr = subprocess.PIPE, shell = True)
-    (stdout, stderr) = p.communicate()
-    status = p.returncode
-    if debug:
-        message = 'Execution of "{0}" returned with exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
-        logging.debug(message)
-    if not status == 0:
-        message = 'Execution of command {0} failed, exit code {1}\n'.format(cmd, status)
-        message += '    stdout: "{0}"\n'.format(stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'))
-        message += '    stderr: "{0}"'.format(stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
-        if abort:
-            raise Exception(message)
-        else:
-            logging.error(message)
-    return (status, stdout.decode(encoding='ascii', errors='ignore').rstrip('\n'),
-                    stderr.decode(encoding='ascii', errors='ignore').rstrip('\n'))
-
 def split_var_name_and_array_reference(var_name):
     """Split an expression like foo(:,a,1:ddt%ngas)
     into components foo and (:,a,1:ddt%ngas)."""

--- a/test/unit_tests/test_common.py
+++ b/test/unit_tests/test_common.py
@@ -34,18 +34,6 @@ class CommonTestCase(unittest.TestCase):
 
     """Tests functionality of functions in common.py"""
 
-    def test_execute(self):
-        """Test execute() function"""
-
-        # Input for successful test: ls command on this file
-        self.assertEqual(common.execute(f"ls {TEST_FILE}"),(0,f"{TEST_FILE}",""))
-
-        # Input for failing test (no exception): exit 1 from a subshell
-        self.assertEqual(common.execute(f"(exit 1)",abort=False),(1,"",f""))
-
-        # Input for failing test (raise exception): exit 1 from a subshell
-        self.assertRaises(Exception,common.execute,f"(exit 1)",abort=True)
-
     def test_split_var_name_and_array_reference(self):
         """Test split_var_name_and_array_reference() function"""
 


### PR DESCRIPTION
All in the title.

User interface changes?: No

Closes https://github.com/NCAR/ccpp-framework/issues/641

Testing:
  test removed: removed `test_execute` from `test/unit_tests/test_common.py`
  unit tests: CI tests all pass
  system tests: CI tests all pass
  manual testing:
    - tested with NEPTUNE
    - ran `test_prebuild/run_all_tests.sh`

