### PR TITLE
Update src/CMakeLists.txt: use modern cmake features to install Fortran modules in the correct place

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 #------------------------------------------------------------------------------
 # Set the sources
 set(SOURCES_F90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,26 +4,7 @@ set(SOURCES_F90
     ccpp_types.F90
 )
 
-# Generate list of Fortran modules from defined sources
-foreach(source_f90 ${SOURCES_F90})
-    string(REGEX REPLACE ".F90" ".mod" module_f90 ${source_f90})
-    list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/${module_f90})
-endforeach()
-
-#------------------------------------------------------------------------------
-# Add the toplevel source directory to our include directoies (for .h)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-# Add the toplevel binary directory to our include directoies (for .mod)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-# Set a cached variable containing the includes, so schemes can use them
-set(${PACKAGE}_INCLUDE_DIRS
-    "${CMAKE_CURRENT_SOURCE_DIR}$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}"
-     CACHE FILEPATH "${PACKAGE} include directories")
-set(${PACKAGE}_LIB_DIRS
-    "${CMAKE_CURRENT_BINARY_DIR}"
-     CACHE FILEPATH "${PACKAGE} library directories")
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
 
 #------------------------------------------------------------------------------
 # Define the executable and what to link
@@ -37,16 +18,17 @@ set_target_properties(ccpp_framework PROPERTIES VERSION ${PROJECT_VERSION}
 # Installation
 #
 target_include_directories(ccpp_framework PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
 
 # Define where to install the library
 install(TARGETS ccpp_framework
         EXPORT ccpp_framework-targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
-        RUNTIME DESTINATION lib
+        RUNTIME DESTINATION bin
 )
 
 # Export our configuration
@@ -55,5 +37,4 @@ install(EXPORT ccpp_framework-targets
         DESTINATION lib/cmake
 )
 
-# Define where to install the Fortran modules
-install(FILES ${MODULES_F90} DESTINATION include)
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
**Update src/CMakeLists.txt: use modern cmake features to install Fortran modules in the correct place**

Update CMakeLists.txt to modern cmake version 3 and support NEPTUNE cmake build while retaining compatibility with UFS/SCM

User interface changes?: No

Fixes: [Github issue #s] n/a

Testing: all CI tests pass, ran `capgen` and `prebuild` tests locally on my laptop - all pass
  test removed:
  unit tests:
  system tests:
  manual testing:

Associated PRs:
- ccpp-physics: https://github.com/ufs-community/ccpp-physics/pull/259
- FV3: https://github.com/NOAA-EMC/fv3atm/pull/940
- ufs-weather-model: https://github.com/ufs-community/ufs-weather-model/pull/2659
