### PR TITLE
Detect invalid horizontal dimensions (loop variables) in metadata for host and schemes

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -47,14 +47,15 @@ jobs:
         export PYTHONPATH=$(pwd)/scripts:$(pwd)/scripts/parse_tools
         cd test_prebuild
         pytest
-    - name: ccpp-prebuild blocked data tests
-      run: |
-        cd test_prebuild/test_blocked_data
-        python3 ../../scripts/ccpp_prebuild.py --config=ccpp_prebuild_config.py --builddir=build
-        cd build
-        cmake ..
-        make
-        ./test_blocked_data.x
+    # No longer possible because of https://github.com/NCAR/ccpp-framework/pull/659
+    #- name: ccpp-prebuild blocked data tests
+    #  run: |
+    #    cd test_prebuild/test_blocked_data
+    #    python3 ../../scripts/ccpp_prebuild.py --config=ccpp_prebuild_config.py --builddir=build
+    #    cd build
+    #    cmake ..
+    #    make
+    #    ./test_blocked_data.x
     - name: ccpp-prebuild chunked data tests
       run: |
         cd test_prebuild/test_chunked_data

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -993,8 +993,26 @@ class MetadataSection(ParseSource):
                             pval = []
                             for dim in porig:
                                 if ':' in dim:
+                                    for dim2 in dim.split(':'):
+                                        dim_ok = VarDictionary.loop_var_okay(standard_name=dim2,
+                                            is_run_phase=self.__section_title.endswith("_run"))
+                                        if not dim_ok:
+                                            emsg = "horizontal dimension"
+                                            self.__pobj.add_syntax_err(emsg, token=dim2)
+                                            self.__section_valid = False
+                                            var_ok = False
+                                        # end if
+                                    # end for
                                     pval.append(dim)
                                 else:
+                                    dim_ok = VarDictionary.loop_var_okay(standard_name=dim,
+                                        is_run_phase=self.__section_title.endswith("_run"))
+                                    if not dim_ok:
+                                        emsg = "horizontal dimension"
+                                        self.__pobj.add_syntax_err(emsg, token=dim)
+                                        self.__section_valid = False
+                                        var_ok = False
+                                    # end if
                                     cone_str = 'ccpp_constant_one:{}'
                                     pval.append(cone_str.format(dim))
                                 # end if

--- a/test/capgen_test/make_ddt.meta
+++ b/test/capgen_test/make_ddt.meta
@@ -12,7 +12,7 @@
 [ vmr_array ]
   standard_name = array_of_volume_mixing_ratios
   units = ppmv
-  dimensions = (horizontal_loop_extent, number_of_chemical_species)
+  dimensions = (horizontal_dimension, number_of_chemical_species)
   type = real
   kind = kind_phys
 [ccpp-table-properties]

--- a/test/capgen_test/temp_set.meta
+++ b/test/capgen_test/temp_set.meta
@@ -86,7 +86,7 @@
   standard_name = array_variable_for_testing
   long_name = array variable for testing
   units = none
-  dimensions = (horizontal_dimension,2,4,6)
+  dimensions = (horizontal_loop_extent,2,4,6)
   type = real
   kind = kind_phys
   intent = inout

--- a/test/ddthost_test/make_ddt.meta
+++ b/test/ddthost_test/make_ddt.meta
@@ -12,7 +12,7 @@
 [ vmr_array ]
   standard_name = array_of_volume_mixing_ratios
   units = ppmv
-  dimensions = (horizontal_loop_extent, number_of_chemical_species)
+  dimensions = (horizontal_dimension, number_of_chemical_species)
   type = real
   kind = kind_phys
 [ccpp-table-properties]

--- a/test/unit_tests/sample_files/test_bad_var_property_name.meta
+++ b/test/unit_tests/sample_files/test_bad_var_property_name.meta
@@ -15,7 +15,7 @@
 [ vmr_array ]
   standard_name = array_of_volume_mixing_ratios
   units = ppmv
-  dimensions = (horizontal_loop_extent, number_of_chemical_species)
+  dimensions = (horizontal_dimension, number_of_chemical_species)
   type = real
   kind = kind_phys
 

--- a/test/unit_tests/sample_files/test_multi_ccpp_arg_tables.meta
+++ b/test/unit_tests/sample_files/test_multi_ccpp_arg_tables.meta
@@ -14,7 +14,7 @@
 [ vmr_array ]
   standard_name = array_of_volume_mixing_ratios
   units = ppmv
-  dimensions = (horizontal_loop_extent, number_of_chemical_species)
+  dimensions = (horizontal_dimension, number_of_chemical_species)
   type = real
   kind = kind_phys
 

--- a/test/unit_tests/sample_host_files/mismatch_hdim_mod.F90
+++ b/test/unit_tests/sample_host_files/mismatch_hdim_mod.F90
@@ -1,0 +1,11 @@
+module mismatch_hdim_mod
+
+   use ccpp_kinds, only: kind_phys
+
+   !> \section arg_table_mismatch_hdim_mod  Argument Table
+   !! \htmlinclude arg_table_mismatch_hdim_mod.html
+   real(kind_phys)              :: ps1
+   real(kind_phys), allocatable :: xbox(:,:)
+   real(kind_phys), allocatable :: switch(:,:)
+
+end module mismatch_hdim_mod

--- a/test/unit_tests/sample_host_files/mismatch_hdim_mod.meta
+++ b/test/unit_tests/sample_host_files/mismatch_hdim_mod.meta
@@ -1,0 +1,25 @@
+[ccpp-table-properties]
+  name = mismatch_hdim_mod
+  type = module
+[ccpp-arg-table]
+  name = mismatch_hdim_mod
+  type = module
+[ ps1 ]
+  standard_name = play_station
+  state_variable = true
+  type = real | kind = kind_phys
+  units = Pa
+  dimensions = ()
+[ xbox ]
+  standard_name = xbox
+  state_variable = true
+  type = real | kind = kind_phys
+  units = m s-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+[ switch ]
+  standard_name = nintendo_switch
+  long_name = Incompatible junk
+  state_variable = true
+  type = real | kind = kind_phys
+  units = m s-1
+  dimensions = (horizontal_loop_being:horizontal_loop_end, vertical_layer_dimension)

--- a/test/unit_tests/sample_scheme_files/mismatch_hdim.F90
+++ b/test/unit_tests/sample_scheme_files/mismatch_hdim.F90
@@ -1,0 +1,48 @@
+! Test parameterization with no vertical level
+!
+
+MODULE mismatch_hdim
+
+  USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: mismatch_hdim_init
+  PUBLIC :: mismatch_hdim_run
+
+CONTAINS
+
+  !> \section arg_table_mismatch_hdim_run  Argument Table
+  !! \htmlinclude arg_table_mismatch_hdim_run.html
+  !!
+  subroutine mismatch_hdim_run(tsfc, errmsg, errflg)
+
+    real(kind_phys),    intent(inout) :: tsfc(:)
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    errmsg = ''
+    errflg = 0
+
+    tsfc = tsfc-1.0_kind_phys
+
+  END SUBROUTINE mismatch_hdim_run
+
+  !> \section arg_table_mismatch_hdim_init  Argument Table
+  !! \htmlinclude arg_table_mismatch_hdim_init.html
+  !!
+  subroutine mismatch_hdim_init (tsfc, errmsg, errflg)
+
+    real(kind_phys),    intent(inout) :: tsfc(:)
+    character(len=512), intent(out)   :: errmsg
+    integer,            intent(out)   :: errflg
+
+    tsfc = tsfc+1.0_kind_phys
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine mismatch_hdim_init
+
+END MODULE mismatch_hdim

--- a/test/unit_tests/sample_scheme_files/mismatch_hdim.meta
+++ b/test/unit_tests/sample_scheme_files/mismatch_hdim.meta
@@ -1,0 +1,55 @@
+[ccpp-table-properties]
+  name = mismatch_hdim
+  type = scheme
+  
+########################################################################
+[ccpp-arg-table]
+  name = mismatch_hdim_run
+  type = scheme
+[ tsfc ]
+  standard_name = temperature_at_surface
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+[ccpp-arg-table]
+  name = mismatch_hdim_init
+  type = scheme
+[ tsfc ]
+  standard_name = temperature_at_surface
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out

--- a/test/unit_tests/test_metadata_host_file.py
+++ b/test/unit_tests/test_metadata_host_file.py
@@ -25,6 +25,8 @@
                        two DDT definitions
                   - Correctly parse and match a simple module file with
                        two DDT definitions and a data block
+                  - "Test correct use of loop variables (horizontal
+                       dimensions) in host metadata
 
  Assumptions:
 
@@ -249,9 +251,26 @@ class MetadataHeaderTestCase(unittest.TestCase):
         # Check error messages
         except_str = str(context.exception)
         emsgs = ["Variable mismatch in ddt2_t, variables missing from Fortran ddt.",
-
                  "No Fortran variable for bogus in ddt2_t",
                  "2 errors found comparing"]
+        for emsg in emsgs:
+            self.assertTrue(emsg in except_str)
+        # end for
+
+    def test_mismatch_hdim(self):
+        """Test correct use of loop variables (horizontal dimensions)
+           in host metadata."""
+        # Setup
+        module_files = [os.path.join(self._sample_files_dir, "mismatch_hdim_mod.meta")]
+        # Exercise
+        hname = 'host_name_mismatch_hdim'
+        with self.assertRaises(CCPPError) as context:
+            _ = parse_host_model_files(module_files, hname, self._run_env)
+        # end with
+        # Check error messages
+        except_str = str(context.exception)
+        emsgs = ["Invalid horizontal dimension, 'horizontal_loop_extent'",
+                 "Invalid horizontal dimension, 'horizontal_loop_end'"]
         for emsg in emsgs:
             self.assertTrue(emsg in except_str)
         # end for

--- a/test/unit_tests/test_metadata_scheme_file.py
+++ b/test/unit_tests/test_metadata_scheme_file.py
@@ -51,8 +51,6 @@ import os
 import logging
 import unittest
 
-logging.basicConfig(level=logging.DEBUG)
-
 _TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 _SCRIPTS_DIR = os.path.abspath(os.path.join(_TEST_DIR, os.pardir,
                                             os.pardir, "scripts"))
@@ -75,7 +73,6 @@ class MetadataHeaderTestCase(unittest.TestCase):
         self._sample_files_dir = os.path.join(_TEST_DIR, "sample_scheme_files")
         self._host_files_dir = os.path.join(_TEST_DIR, "sample_host_files")
         logger = logging.getLogger(self.__class__.__name__)
-        logger.setLevel(logging.DEBUG)
         self._run_env = CCPPFrameworkEnv(logger, ndict={'host_files':'',
                                                         'scheme_files':'',
                                                         'suites':''})

--- a/test_prebuild/run_all_tests.sh
+++ b/test_prebuild/run_all_tests.sh
@@ -4,7 +4,8 @@ set -e
 
 echo "" && echo "Running unit_tests       " && cd unit_tests        && ./run_tests.sh && cd ..
 echo "" && echo "Running test_opt_arg     " && cd test_opt_arg      && ./run_test.sh  && cd ..
-echo "" && echo "Running test_blocked_data" && cd test_blocked_data && ./run_test.sh  && cd ..
+# No longer possible because of https://github.com/NCAR/ccpp-framework/pull/659 
+#echo "" && echo "Running test_blocked_data" && cd test_blocked_data && ./run_test.sh  && cd ..
 echo "" && echo "Running test_chunked_data" && cd test_chunked_data && ./run_test.sh  && cd ..
 echo "" && echo "Running test_unit_conv"    && cd test_unit_conv    && ./run_test.sh  && cd ..
 

--- a/test_prebuild/test_track_variables/scheme_3.meta
+++ b/test_prebuild/test_track_variables/scheme_3.meta
@@ -107,7 +107,7 @@
   standard_name = air_pressure
   long_name = mean layer pressure
   units = Pa
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
@@ -115,7 +115,7 @@
   standard_name = surface_air_pressure
   long_name = surface pressure
   units = Pa
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
   intent = inout
@@ -128,7 +128,7 @@
   standard_name = air_pressure
   long_name = mean layer pressure
   units = Pa
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
@@ -136,7 +136,7 @@
   standard_name = surface_air_pressure
   long_name = surface pressure
   units = Pa
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
   intent = out

--- a/test_prebuild/test_unit_conv/data.F90
+++ b/test_prebuild/test_unit_conv/data.F90
@@ -10,10 +10,11 @@ module data
 
     private
 
-    public ncols, nspecies
+    public ncols, ncolsrun, nspecies
     public cdata, data_array, data_array2, opt_array_flag
 
     integer, parameter :: ncols = 4
+    integer, parameter :: ncolsrun = ncols
     integer, parameter :: nspecies = 2
     type(ccpp_t), target :: cdata
     real(kind_phys), dimension(1:ncols,1:nspecies) :: data_array

--- a/test_prebuild/test_unit_conv/data.meta
+++ b/test_prebuild/test_unit_conv/data.meta
@@ -12,6 +12,12 @@
   dimensions = ()
   type = ccpp_t
 [ncols]
+  standard_name = horizontal_dimension
+  long_name = horizontal dimension
+  units = count
+  dimensions = ()
+  type = integer
+[ncolsrun]
   standard_name = horizontal_loop_extent
   long_name = horizontal loop extent
   units = count
@@ -27,21 +33,21 @@
   standard_name = data_array_all_species
   long_name = data array in module
   units = m
-  dimensions = (horizontal_loop_extent, number_of_species)
+  dimensions = (horizontal_dimension, number_of_species)
   type = real
   kind = kind_phys
 [data_array(:,2)]
   standard_name = data_array
   long_name = data array in module
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
 [data_array2]
   standard_name = data_array2
   long_name = data array 2 in module
   units = m2 s-2
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
 [opt_array_flag]
@@ -54,7 +60,7 @@
   standard_name = data_array_opt
   long_name = optional data array in km
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_opt_array)


### PR DESCRIPTION
Detect invalid horizontal dimensions (loop variables) in metadata for host and schemes

Detect invalid horizontal dimensions (loop variables) in metadata for host and schemes. For schemes, `horizontal_dimension` is invalid in the `run` phase, all other options (`horizontal_loop_extent`, `horizontal_loop_begin`, `horizontal_loop_end`) are only valid in the `run` phase. For host models, only `horizontal_dimension` is valid.

Tests are added for both scheme and host metadata, and existing tests are fixed, namely bad horizontal dimensions in:
- `test/unit_tests/sample_files/test_bad_var_property_name.meta`
- `test/unit_tests/sample_files/test_multi_ccpp_arg_tables.meta`
- `test/capgen_test/make_ddt.meta`
- `test/capgen_test/temp_set.meta`
- `test/ddthost_test/make_ddt.meta`
- `test_prebuild/test_tracked_data/scheme3.meta`
- `test_prebuild/test_unit_conv/data.*`

Further: I commented out test for blocked data structures in `test_prebuild/run_all_tests.sh`; this test can no longer be run, since blocked data structures required the host model to define the horizontal dimension for blocked data as `horizontal_loop_extent`. This test and all code related to supporting blocked data structures in `ccpp_prebuild.py` will be removed in a follow-up PR (out of scope of this PR).

User interface changes?: No

Fixes https://github.com/NCAR/ccpp-framework/issues/521

Testing: **all tests pass**
  tests **added**: test that invalid horizontal dimensions are detected correctly for host and scheme metadata
  tests **removed**: commented out blocked data tests for `ccpp_prebuild`
  unit tests:
  system tests:
  manual testing:

