### PR TITLE
Remove case sensitivity for variable dimensions

### DIFF
--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -921,7 +921,7 @@ class MetadataSection(ParseSource):
                       (not MetadataTable.table_start(curr_line)))
         if valid_line:
              # variable_start handles exception
-            local_name = MetadataSection.variable_start(curr_line, self.__pobj)
+            local_name = MetadataSection.variable_start(curr_line, self.__pobj).lower()
         else:
             local_name = None
         # end if

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -1003,7 +1003,7 @@ class MetadataSection(ParseSource):
                                             var_ok = False
                                         # end if
                                     # end for
-                                    pval.append(dim)
+                                    pval.append(dim.lower())
                                 else:
                                     dim_ok = VarDictionary.loop_var_okay(standard_name=dim,
                                         is_run_phase=self.__section_title.endswith("_run"))
@@ -1014,9 +1014,13 @@ class MetadataSection(ParseSource):
                                         var_ok = False
                                     # end if
                                     cone_str = 'ccpp_constant_one:{}'
-                                    pval.append(cone_str.format(dim))
+                                    pval.append(cone_str.format(dim.lower()))
                                 # end if
                             # end for
+                        # end if
+                        # Special handling for standard_names (convert to lowercase)
+                        if pname == 'standard_name':
+                            pval = pval.lower()
                         # end if
                         # Add the property to our Var dictionary
                         var_props[pname] = pval

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -708,7 +708,7 @@ class Var:
                     lname = ""
                     for item in dim.split(':'):
                         if item:
-                            dvar = var_dict.find_variable(standard_name=item.lower(),
+                            dvar = var_dict.find_variable(standard_name=item,
                                                           any_scope=False)
                             if dvar is None:
                                 try:

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -948,7 +948,7 @@ class Var:
                 except ValueError:
                     # Not an integer, maybe add it
                     if include_constants or (not name in CCPP_CONSTANT_VARS):
-                        dimset.add(name.lower())
+                        dimset.add(name)
                     # end if
                 # end try
             # end for

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -948,7 +948,7 @@ class Var:
                 except ValueError:
                     # Not an integer, maybe add it
                     if include_constants or (not name in CCPP_CONSTANT_VARS):
-                        dimset.add(name)
+                        dimset.add(name.lower())
                     # end if
                 # end try
             # end for

--- a/test/advection_test/cld_liq.meta
+++ b/test/advection_test/cld_liq.meta
@@ -52,7 +52,7 @@
 [ temp ]
   standard_name = temperature
   units = K
-  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_LAYER_dimension)
   type = real
   kind = kind_phys
   intent = inout


### PR DESCRIPTION
Updates metadata_table.py parsing to lowercase the following fields:
* local name
* standard name
* dimensions

Context: I ran into an issue where dimension variable standard names were not being found if they contain >=1 upper case letter.

To reproduce, modify any dimension in any of the capgen tests to be mixed case. The test run will fail with this message: `Could not find dimension...`

User interface changes?: No
