### PR TITLE
Allow different ordering in Fortran scheme and associated metadata

### DIFF
--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -44,7 +44,7 @@ _FORTRAN_FILENAME_EXTENSIONS = ['F90', 'f90', 'F', 'f']
 _EXTRA_VARIABLE_TABLE_TYPES = ['module', 'host', 'ddt']
 
 ## Metadata table types where order is significant
-_ORDERED_TABLE_TYPES = [SCHEME_HEADER_TYPE]
+_ORDERED_TABLE_TYPES = []
 
 ## CCPP Framework supported DDT types
 _CCPP_FRAMEWORK_DDT_TYPES = ["ccpp_hash_table_t",
@@ -309,6 +309,17 @@ def compare_fheader_to_mheader(meta_header, fort_header, logger):
         if not list_match:
             errmsg = 'Variable mismatch in {}, variables missing from {}.'
             errors_found = add_error(errors_found, errmsg.format(title, etype))
+            if etype == "metadata header":
+                # Look for missing metadata variables
+                for fvar in flist:
+                    lname = fvar.get_prop_value('local_name')
+                    _, find = find_var_in_list(lname, mlist)
+                    if (find < 0) and (not fvar.get_prop_value('optional')):
+                        errmsg = f"Fortran variable, {lname}, not in metadata"
+                        errors_found = add_error(errors_found, errmsg)
+                    # end if
+                # end for
+            # end if
         # end if
         for mind, mvar in enumerate(mlist):
             lname = mvar.get_prop_value('local_name')

--- a/test/unit_tests/sample_scheme_files/temp_adjust.F90
+++ b/test/unit_tests/sample_scheme_files/temp_adjust.F90
@@ -17,7 +17,7 @@ CONTAINS
   !> \section arg_table_temp_adjust_register  Argument Table
   !! \htmlinclude arg_table_temp_adjust_register.html
   !!
-  subroutine temp_adjust_register(config_var, dyn_const, errmsg, errflg)
+  subroutine temp_adjust_register(config_var, dyn_const, errflg, errmsg)
      logical,          intent(in)     :: config_var
      type(ccpp_constituent_properties_t), allocatable, intent(out) :: dyn_const
      character(len=512), intent(out)   :: errmsg

--- a/test/unit_tests/test_metadata_scheme_file.py
+++ b/test/unit_tests/test_metadata_scheme_file.py
@@ -215,15 +215,13 @@ class MetadataHeaderTestCase(unittest.TestCase):
         # Exercise
         with self.assertRaises(CCPPError) as context:
             parse_scheme_files(scheme_files, self._run_env)
-        # Verify 3 correct error messages returned
+        # Verify 2 correct error messages returned
         emsg = "Variable mismatch in CCPPnotset_var_missing_in_meta_run, " +  \
             "variables missing from metadata header."
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errmsg in CCPPnotset_var_missing_in_meta_run"
+        emsg = "Fortran variable, bar, not in metadata"
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errflg in CCPPnotset_var_missing_in_meta_run"
-        self.assertTrue(emsg in str(context.exception))
-        self.assertTrue("3 errors found comparing" in str(context.exception))
+        self.assertTrue("2 errors found comparing" in str(context.exception))
 
     def test_ccpp_eq1_var_missing_in_fort(self):
         """Test for correct detection of a variable that IS REMOVED the
@@ -236,16 +234,14 @@ class MetadataHeaderTestCase(unittest.TestCase):
         # Exercise
         with self.assertRaises(CCPPError) as context:
             parse_scheme_files(scheme_files, self._run_env_ccpp)
-        # Verify 3 correct error messages returned
+        # Verify 2 correct error messages returned
         emsg = "Variable mismatch in CCPPeq1_var_missing_in_fort_run, " +     \
             "variables missing from Fortran scheme."
         self.assertTrue(emsg in str(context.exception))
         emsg = "Variable mismatch in CCPPeq1_var_missing_in_fort_run, " +     \
             "no Fortran variable bar."
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errmsg in CCPPeq1_var_missing_in_fort_run"
-        self.assertTrue(emsg in str(context.exception))
-        self.assertTrue("3 errors found comparing" in str(context.exception))
+        self.assertTrue("2 errors found comparing" in str(context.exception))
 
     def test_ccpp_eq1_var_in_fort_meta(self):
         """Test positive case of a variable that IS PRESENT the
@@ -305,16 +301,14 @@ class MetadataHeaderTestCase(unittest.TestCase):
         # Exercise
         with self.assertRaises(CCPPError) as context:
             _, _ = parse_scheme_files(scheme_files, self._run_env_ccpp)
-        # Verify 3 correct error messages returned
+        # Verify 2 correct error messages returned
         emsg = "Variable mismatch in CCPPgt1_var_in_fort_meta_init, " +       \
             "variables missing from Fortran scheme."
         self.assertTrue(emsg in str(context.exception))
         emsg = "Variable mismatch in CCPPgt1_var_in_fort_meta_init, " +       \
             "no Fortran variable bar."
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errmsg in CCPPgt1_var_in_fort_meta_init"
-        self.assertTrue(emsg in str(context.exception))
-        self.assertTrue("3 errors found comparing" in str(context.exception))
+        self.assertTrue("2 errors found comparing" in str(context.exception))
 
     def test_ccpp_eq1_var_missing_in_meta(self):
         """Test correct detection of a variable that
@@ -327,15 +321,13 @@ class MetadataHeaderTestCase(unittest.TestCase):
         # Exercise
         with self.assertRaises(CCPPError) as context:
              _, _ = parse_scheme_files(scheme_files, self._run_env_ccpp)
-        # Verify 3 correct error messages returned
+        # Verify 2 correct error messages returned
         emsg = "Variable mismatch in CCPPeq1_var_missing_in_meta_finalize, "+ \
             "variables missing from metadata header."
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errmsg in CCPPeq1_var_missing_in_meta_finalize"
+        emsg = "Fortran variable, bar, not in metadata"
         self.assertTrue(emsg in str(context.exception))
-        emsg = "Out of order argument, errflg in CCPPeq1_var_missing_in_meta_finalize"
-        self.assertTrue(emsg in str(context.exception))
-        self.assertTrue("3 errors found comparing" in str(context.exception))
+        self.assertTrue("2 errors found comparing" in str(context.exception))
 
     def test_scheme_ddt_only(self):
         """Test correct detection of a "scheme" file which contains only
@@ -363,4 +355,3 @@ class MetadataHeaderTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
Allow flexible Fortran scheme argument ordering

In checking compatibility between Fortran and metadata, schemes were required to have
arguments in the same order. This PR removes that restriction.

User interface changes?: No

Fixes: #665 

Testing:
  unit tests: Modified one test Fortran file to use a different argument ordering in the Fortran scheme.
  system tests:
  manual testing: manually ran unit tests