### PR TITLE
Make N m-2 equivalent to Pa

### DIFF
--- a/scripts/conversion_tools/unit_conversion.py
+++ b/scripts/conversion_tools/unit_conversion.py
@@ -196,3 +196,11 @@ def V_A__to__W():
 def W__to__V_A():
     """Equivalent units"""
     return '{var}'
+
+def N_m_minus_2__to__Pa():
+    """Equivalent units"""
+    return '{var}'
+
+def Pa__to__N_m_minus_2():
+    """Equivalent units"""
+    return '{var}'

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -1201,6 +1201,8 @@ class VarCompatObj:
         ('{var}+273.15{kind}', '{var}-273.15{kind}')
         >>> _DOCTEST_VCOMPAT._get_unit_convstrs('V A', 'W')
         (None, None)
+        >>> _DOCTEST_VCOMPAT._get_unit_convstrs('N m-2', 'Pa')
+        (None, None)
         >>> _DOCTEST_VCOMPAT._get_unit_convstrs('m2 s-2', 'J kg-1')
         (None, None)
         >>> _DOCTEST_VCOMPAT._get_unit_convstrs('m+2 s-2', 'J kg-1')


### PR DESCRIPTION
**Makes N m-2 equivalent to Pa.**

Simple change to `unit_conversion.py` to add N m-2 equivalent to Pa and vice-versa.

User interface changes?: No

Fixes: no separate issue but I am happy to create one.

Testing:
  test removed: none
  unit tests: unit and doctests all pass, added one doctest
  system tests:
  manual testing: manually ran unit tests; will test in CAM-SIMA code that this is added for

This is my first PR to this repository so please let me know if I missed any steps. Thanks!
