### PR TITLE
[DRAFT] Feature/standard name checker

### DIFF
--- a/scripts/check_standard_names.py
+++ b/scripts/check_standard_names.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import argparse
+import glob
+import os
+import requests
+import xml.etree.ElementTree as ET
+import sys
+
+from ccpp_track_variables import setup_logging
+from metadata_table import parse_metadata_file
+from parse_checkers import registered_fortran_ddt_names
+from framework_env import CCPPFrameworkEnv
+
+def fetch_xml(branch):
+    url = f"https://raw.githubusercontent.com/ESCOMP/ESMStandardNames/{branch}/standard_names.xml"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        sys.exit(f"Failed to fetch XML: {e}")
+    return response.text
+
+def parse_standard_names(xml_text):
+    root = ET.fromstring(xml_text)
+
+    std_names = {}
+    for entry in root.findall(".//standard_name"):
+        std_id = entry.attrib.get("name")
+        description = entry.attrib.get("long_name")
+        if std_id:
+            std_names[std_id] = description
+    return std_names
+
+def main(branch,metafiles,debug):
+
+    files = []
+    if os.path.isfile(metafiles):
+        files = [metafiles]
+    else:
+        files = glob.glob(os.path.join(metafiles, "*.meta"), recursive=True)
+    if not files:
+        raise FileNotFoundError(f"Could not find any metadata files in {metafiles}")
+    logger = setup_logging(debug)
+    print(f"Fetching XML from branch: {branch}")
+    xml_text = fetch_xml(branch)
+    std_dict = parse_standard_names(xml_text)
+
+    print(f"Retrieved {len(std_dict)} standard names from XML")
+
+    meta_names = []
+    for metafile in files:
+        print(f"Retrieving metadata from {metafile}")
+        run_env = CCPPFrameworkEnv(logger, host_files="", scheme_files="", suites="")
+        metadict = parse_metadata_file(metafile,known_ddts=registered_fortran_ddt_names(),
+                                       run_env=run_env)
+        print(f"Retrieved {len(metadict)} metadata entries.")
+    
+#        print(metadict)
+        # Print a sample
+    #    for i, (key, val) in enumerate(metadict.items()):
+    #        print(f"{key}: {val}")
+        for i, table in enumerate(metadict):
+    #        print(f"{table=}")
+            for j, item in enumerate(table.sections()):
+    #            print(f"{item.has_variables.prop_list('standard_name')=}")
+                meta_names += item.has_variables.prop_list('standard_name')
+#        print(f"Found {len(meta_names)} standard names in {metafile}:\n{meta_names}")
+
+    bad_names = []
+    for name in meta_names:
+        if name in bad_names:
+            continue
+        if not std_dict.__contains__(name):
+            bad_names.append(name)
+
+    if bad_names:
+        print(f"The following {len(bad_names)} standard names in {metafiles} were not found in provided XML:")
+        for name in sorted(bad_names):
+            print(name)
+    else:
+        print(f"All standard names in {metafile} are valid!")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch and parse standard_names.xml from ESMStandardNames GitHub, and output any metadata entries with standard_names not found in that dictionary.")
+    parser.add_argument("--branch", "-b", type=str, default="main",
+                        help="GitHub branch, tag, or hash to fetch from (default: main)")
+    parser.add_argument("--metafiles", "-m", type=str, required=True,
+                        help="Metadata file or directory containing metadata files to check for valid standard names")
+    parser.add_argument('--debug', action='store_true', help='enable debugging output')
+
+    args = parser.parse_args()
+
+    main(args.branch,args.metafiles,args.debug)

--- a/scripts/check_standard_names.py
+++ b/scripts/check_standard_names.py
@@ -31,7 +31,7 @@ def parse_standard_names(xml_text):
             std_names[std_id] = description
     return std_names
 
-def main(branch,metafiles,debug):
+def main(branch,xml,metafiles,debug):
 
     files = []
     if os.path.isfile(metafiles):
@@ -41,8 +41,15 @@ def main(branch,metafiles,debug):
     if not files:
         raise FileNotFoundError(f"Could not find any metadata files in {metafiles}")
     logger = setup_logging(debug)
-    print(f"Fetching XML from branch: {branch}")
-    xml_text = fetch_xml(branch)
+
+    if xml:
+        print(f"Using local XML: {xml}")
+        with open(xml, "r", encoding="utf-8") as f:
+            xml_text = f.read()
+    else:
+        print(f"Fetching XML from branch: {branch}")
+        xml_text = fetch_xml(branch)
+
     std_dict = parse_standard_names(xml_text)
 
     print(f"Retrieved {len(std_dict)} standard names from XML")
@@ -81,12 +88,20 @@ def main(branch,metafiles,debug):
         print(f"All standard names in {metafile} are valid!")
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fetch and parse standard_names.xml from ESMStandardNames GitHub, and output any metadata entries with standard_names not found in that dictionary.")
-    parser.add_argument("--branch", "-b", type=str, default="main",
+    parser.add_argument("--branch", "-b", type=str,
                         help="GitHub branch, tag, or hash to fetch from (default: main)")
+    parser.add_argument("--xml", "-x", type=str,
+                        help="Full path to xml file containing standard names (alternative to fetching from internet)")
     parser.add_argument("--metafiles", "-m", type=str, required=True,
                         help="Metadata file or directory containing metadata files to check for valid standard names")
     parser.add_argument('--debug', action='store_true', help='enable debugging output')
 
     args = parser.parse_args()
 
-    main(args.branch,args.metafiles,args.debug)
+    if args.branch and args.xml:
+        raise argparse.ArgumentError("Can not specify both --branch and --xml arguments")
+    if not (args.branch or args.xml):
+        #If neither specified, fall back to retrieving from main branch
+        args.branch="main"
+
+    main(args.branch,args.xml,args.metafiles,args.debug)


### PR DESCRIPTION
Adding a simple script to the framework that takes a metadata file or path containing metadata files, and a branch/tag/hash for the ESCOMP/ESMStandardNames repository (or path to local XML standard names dictionary), and checks the standard names in those metadata variable definitions against the standard names contained in the XML dictionary.

Creating this as a draft for now, as it currently fails when attempting to read metadata files with DDT types. I'm also not sure if this is the correct location for such a tool, or even the right repository. I also should probably add some unit tests.

As an example usage:

```
python3 check_standard_names.py -m  '../../physics/physics/SFC_Layer/MYJ/'
Fetching XML from branch: main
Retrieved 1106 standard names from XML
Retrieving metadata from ../../physics/physics/SFC_Layer/MYJ/myjsfc_wrapper.meta
Retrieved 1 metadata entries.
The following 48 standard names in ../../physics/physics/SFC_Layer/MYJ/ were not found in provided XML:
air_pressure_at_interface
bulk_richardson_number_at_lowest_model_level
bulk_richardson_number_at_lowest_model_level_over_ice
bulk_richardson_number_at_lowest_model_level_over_land
bulk_richardson_number_at_lowest_model_level_over_water
ccpp_loop_counter
flag_for_iteration
flag_for_mellor_yamada_janjic_surface_layer_scheme
flag_for_restart
flag_print
geopotential_at_interface
index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array
index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array
index_of_graupel_mixing_ratio_in_tracer_concentration_array
index_of_rain_mixing_ratio_in_tracer_concentration_array
index_of_snow_mixing_ratio_in_tracer_concentration_array
monin_obukhov_similarity_function_for_heat_at_2m
monin_obukhov_similarity_function_for_heat_at_2m_over_ice
monin_obukhov_similarity_function_for_heat_at_2m_over_land
monin_obukhov_similarity_function_for_heat_at_2m_over_water
monin_obukhov_similarity_function_for_heat_over_ice
monin_obukhov_similarity_function_for_heat_over_land
monin_obukhov_similarity_function_for_heat_over_water
monin_obukhov_similarity_function_for_momentum_at_10m
monin_obukhov_similarity_function_for_momentum_at_10m_over_ice
monin_obukhov_similarity_function_for_momentum_at_10m_over_land
monin_obukhov_similarity_function_for_momentum_at_10m_over_water
monin_obukhov_similarity_function_for_momentum_over_ice
monin_obukhov_similarity_function_for_momentum_over_land
monin_obukhov_similarity_function_for_momentum_over_water
surface_drag_coefficient_for_heat_and_moisture_in_air
surface_drag_coefficient_for_heat_and_moisture_in_air_over_ice
surface_drag_coefficient_for_heat_and_moisture_in_air_over_land
surface_drag_coefficient_for_heat_and_moisture_in_air_over_water
surface_drag_coefficient_for_momentum_in_air
surface_drag_coefficient_for_momentum_in_air_over_ice
surface_drag_coefficient_for_momentum_in_air_over_land
surface_drag_coefficient_for_momentum_in_air_over_water
surface_friction_velocity_over_ice
surface_friction_velocity_over_land
surface_friction_velocity_over_water
surface_skin_temperature
surface_wind_stress
surface_wind_stress_over_ice
surface_wind_stress_over_land
surface_wind_stress_over_water
weight_for_potental_temperature_at_top_of_viscous_sublayer
wind_speed_at_lowest_model_layer
```

And another example with truncated output:

```
python3.10 check_standard_names.py -m  '../../physics/physics/SFC_Models/**' -b release/v1
Fetching XML from branch: release/v1
Retrieved 1218 standard names from XML
Retrieving metadata from ../../physics/physics/SFC_Models/Lake/CLM/clm_lake.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Lake/Flake/flake_driver.meta
Retrieved 2 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/SeaIce/CICE/sfc_sice.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/SeaIce/CICE/sfc_cice.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Land/sfc_land.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Land/Noahmp/lnd_iau_mod.meta
Retrieved 4 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Land/RUC/lsm_ruc.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Land/Noah/lsm_noah.meta
Retrieved 1 metadata entries.
Retrieving metadata from ../../physics/physics/SFC_Models/Ocean/UFS/sfc_ocean.meta
Retrieved 1 metadata entries.
The following 269 standard names in ../../physics/physics/SFC_Models/** were not found in provided XML:
actual_snow_depth_in_clm_lake_model
aerodynamic_resistance_in_canopy
air_pressure_at_interface
bounded_surface_roughness_length_for_heat_over_land
bounded_vegetation_area_fraction
bulk_richardson_number_at_lowest_model_level_over_land
...
...
wind_speed_at_lowest_model_layer
x_ocean_current
y_ocean_current
```

User interface changes?: No

Fixes: #671 
Testing:
  test removed: none
  unit tests: None yet
  system tests: Still don't know what this means
  manual testing: Ran this script with several combinations of XMLs, branches, and metadata files

