### PR TITLE
DRAFT: Skip variable parse checks during fortran parsing

### DIFF
--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -262,7 +262,7 @@ class Var:
     # All constituent props are optional so no check
 
     def __init__(self, prop_dict, source, run_env, context=None,
-                 clone_source=None):
+                 clone_source=None, skip_checks=False):
         """Initialize a new Var object.
         If <prop_dict> is really a Var object, use that object's prop_dict.
         If this Var object is a clone, record the original Var object
@@ -360,19 +360,21 @@ class Var:
 #            # end if
 #        # end for
 # XXgoldyXX: ^ don't fill in default properties?
-        # Make sure all the variable values are valid
-        try:
-            for prop_name, prop_val in self.var_properties():
-                prop = Var.get_prop(prop_name)
-                _ = prop.valid_value(prop_val,
-                                     prop_dict=self._prop_dict, error=True)
-            # end for
-        except CCPPError as cperr:
-            lname = self._prop_dict['local_name']
-            emsg = "{}: {}"
-            raise ParseSyntaxError(emsg.format(lname, cperr),
-                                   context=self.context) from cperr
-        # end try
+        # Make sure all the variable values are validi
+        if not skip_checks:
+            try:
+                for prop_name, prop_val in self.var_properties():
+                    prop = Var.get_prop(prop_name)
+                    _ = prop.valid_value(prop_val,
+                                         prop_dict=self._prop_dict, error=True)
+                # end for
+            except CCPPError as cperr:
+                lname = self._prop_dict['local_name']
+                emsg = "{}: {}"
+                raise ParseSyntaxError(emsg.format(lname, cperr),
+                                        context=self.context) from cperr
+            # end try
+        # end if
 
     def compatible(self, other, run_env, is_tend=False):
         """Return a VarCompatObj object which describes the equivalence,
@@ -1209,9 +1211,10 @@ class FortranVar(Var):
                 del prop_dict[prop.name]
             # end if
         # end for
-        # Initialize Var
+        # Initialize Var; skip the parse checkers on the Fortran side since the
+        #  checks are already done during metadata parsing
         super().__init__(prop_dict, source, run_env, context=context,
-                         clone_source=clone_source)
+                         clone_source=clone_source, skip_checks=True)
         # Now, restore the saved properties
         for prop in save_dict:
             self._prop_dict[prop] = save_dict[prop]

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -360,7 +360,7 @@ class Var:
 #            # end if
 #        # end for
 # XXgoldyXX: ^ don't fill in default properties?
-        # Make sure all the variable values are validi
+        # Make sure all the variable values are valid
         if not skip_checks:
             try:
                 for prop_name, prop_val in self.var_properties():
@@ -1212,7 +1212,7 @@ class FortranVar(Var):
             # end if
         # end for
         # Initialize Var; skip the parse checkers on the Fortran side since the
-        #  checks are already done during metadata parsing
+        # checks are already done during metadata parsing
         super().__init__(prop_dict, source, run_env, context=context,
                          clone_source=clone_source, skip_checks=True)
         # Now, restore the saved properties

--- a/test/ddthost_test/CMakeLists.txt
+++ b/test/ddthost_test/CMakeLists.txt
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 set(SCHEME_FILES       "setup_coeffs" "temp_set" "temp_adjust" "temp_calc_adjust")
 set(SUITE_SCHEME_FILES "make_ddt" "environ_conditions")
-set(HOST_FILES         "test_host_data" "test_host_mod" "host_ccpp_ddt")
+set(HOST_FILES         "test_host_data" "test_host_mod" "host_ccpp_ddt" "wrapped_ddt")
 set(SUITE_FILES        "ddt_suite.xml" "temp_suite.xml")
 # HOST is the name of the executable we will build.
 # We assume there are files ${HOST}.meta and ${HOST}.F90 in CMAKE_SOURCE_DIR
@@ -46,8 +46,18 @@ add_library(DDT_TESTLIB OBJECT ${SCHEME_FORTRAN_FILES}
                                ${CCPP_CAPS_LIST})
 
 # Setup test executable with needed dependencies
+#  Dependencies for this test are the test_utils directory and the external_module.F90 file
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules)
 add_executable(ddt_host_integration test_ddt_host_integration.F90 ${HOST}.F90)
-target_link_libraries(ddt_host_integration PRIVATE DDT_TESTLIB test_utils)
+add_library(external_module STATIC external_module.F90)
+set_target_properties(external_module PROPERTIES
+    Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules)
+target_compile_options(external_module PRIVATE "-J${CMAKE_BINARY_DIR}/fortran_modules")
+target_include_directories(external_module PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
+target_link_libraries(ddt_host_integration PRIVATE DDT_TESTLIB test_utils external_module)
+target_include_directories(ddt_host_integration PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
+target_link_libraries(DDT_TESTLIB PRIVATE external_module)
+target_include_directories(DDT_TESTLIB PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
 target_include_directories(ddt_host_integration PRIVATE "$<TARGET_PROPERTY:test_utils,BINARY_DIR>")
 
 # Add executable to be called with ctest

--- a/test/ddthost_test/CMakeLists.txt
+++ b/test/ddthost_test/CMakeLists.txt
@@ -39,7 +39,7 @@ ccpp_capgen(CAPGEN_DEBUG ON
 ccpp_datafile(DATATABLE "${CCPP_CAP_FILES}/datatable.xml"
               REPORT_NAME "--ccpp-files")
 
-# Create dependenct libraries to mimic possibly pre-built external dependencies
+# Create dependent library to mimic possibly pre-built external dependencies
 add_library(external_module STATIC external_module.F90)
 
 # Create test host library

--- a/test/ddthost_test/CMakeLists.txt
+++ b/test/ddthost_test/CMakeLists.txt
@@ -39,24 +39,21 @@ ccpp_capgen(CAPGEN_DEBUG ON
 ccpp_datafile(DATATABLE "${CCPP_CAP_FILES}/datatable.xml"
               REPORT_NAME "--ccpp-files")
 
+# Create dependenct libraries to mimic possibly pre-built external dependencies
+add_library(external_module STATIC external_module.F90)
+
 # Create test host library
 add_library(DDT_TESTLIB OBJECT ${SCHEME_FORTRAN_FILES}
                                ${SUITE_SCHEME_FORTRAN_FILES}
                                ${DDT_HOST_FORTRAN_FILES}
                                ${CCPP_CAPS_LIST})
 
+# Add the external as a dependency of the DDT library.
+add_dependencies(DDT_TESTLIB external_module)
+
 # Setup test executable with needed dependencies
-#  Dependencies for this test are the test_utils directory and the external_module.F90 file
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules)
 add_executable(ddt_host_integration test_ddt_host_integration.F90 ${HOST}.F90)
-add_library(external_module STATIC external_module.F90)
-set_target_properties(external_module PROPERTIES
-    Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules)
-target_include_directories(external_module PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
-target_link_libraries(ddt_host_integration PRIVATE DDT_TESTLIB test_utils external_module)
-target_include_directories(ddt_host_integration PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
-target_link_libraries(DDT_TESTLIB PRIVATE external_module)
-target_include_directories(DDT_TESTLIB PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
+target_link_libraries(ddt_host_integration PRIVATE DDT_TESTLIB test_utils)
 target_include_directories(ddt_host_integration PRIVATE "$<TARGET_PROPERTY:test_utils,BINARY_DIR>")
 
 # Add executable to be called with ctest

--- a/test/ddthost_test/CMakeLists.txt
+++ b/test/ddthost_test/CMakeLists.txt
@@ -52,7 +52,6 @@ add_executable(ddt_host_integration test_ddt_host_integration.F90 ${HOST}.F90)
 add_library(external_module STATIC external_module.F90)
 set_target_properties(external_module PROPERTIES
     Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules)
-target_compile_options(external_module PRIVATE "-J${CMAKE_BINARY_DIR}/fortran_modules")
 target_include_directories(external_module PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)
 target_link_libraries(ddt_host_integration PRIVATE DDT_TESTLIB test_utils external_module)
 target_include_directories(ddt_host_integration PRIVATE ${CMAKE_BINARY_DIR}/fortran_modules)

--- a/test/ddthost_test/README.md
+++ b/test/ddthost_test/README.md
@@ -3,6 +3,8 @@
 Contains tests to exercise more DDT functionality:
 - Passing around and modifying a DDT
 - Making DDT in host model & using it in CCPP-ized physics code
+- Providiing metadata for only the top-level DDT
+  - Ensures framework allows unknown DDT in Fortran as long as there's no metadata for it
 
 ## Building/Running
 

--- a/test/ddthost_test/external_module.F90
+++ b/test/ddthost_test/external_module.F90
@@ -1,0 +1,7 @@
+module external_module
+
+ type, public :: unknown_external_ddt
+    integer :: var
+ end type
+
+end module external_module

--- a/test/ddthost_test/temp_adjust.F90
+++ b/test/ddthost_test/temp_adjust.F90
@@ -17,11 +17,13 @@ contains
   !> \section arg_table_temp_adjust_run  Argument Table
   !! \htmlinclude arg_table_temp_adjust_run.html
   !!
-  subroutine temp_adjust_run(foo, timestep, temp_prev, temp_layer, qv, ps,    &
+  subroutine temp_adjust_run(foo, timestep, wrapped_ext_ddt, temp_prev, temp_layer, qv, ps,    &
        to_promote, promote_pcnst, errmsg, errflg, innie, outie, optsie)
+    use wrapped_ddt, only: wrapped_ddt_t
 
     integer,                   intent(in)    :: foo
     real(kind_phys),           intent(in)    :: timestep
+    type(wrapped_ddt_t),       intent(out)   :: wrapped_ext_ddt
     real(kind_phys),           intent(inout),optional :: qv(:)
     real(kind_phys),           intent(inout) :: ps(:)
     real(kind_phys),           intent(in)    :: temp_prev(:)
@@ -39,6 +41,8 @@ contains
 
     errmsg = ''
     errflg = 0
+
+    wrapped_ext_ddt%ext_ddt%var = 1
 
     do col_index = 1, foo
        temp_layer(col_index) = temp_layer(col_index) + temp_prev(col_index)

--- a/test/ddthost_test/temp_adjust.meta
+++ b/test/ddthost_test/temp_adjust.meta
@@ -20,6 +20,12 @@
   type = real
   kind = kind_phys
   intent = in
+[ wrapped_ext_ddt ]
+  standard_name = wrapped_ddt_for_physics
+  units = none
+  dimensions = ()
+  type = wrapped_ddt_t
+  intent = out
 [ temp_prev ]
   standard_name = potential_temperature_at_previous_timestep
   units = K

--- a/test/ddthost_test/wrapped_ddt.F90
+++ b/test/ddthost_test/wrapped_ddt.F90
@@ -1,0 +1,11 @@
+module wrapped_ddt
+   ! CCPP wrapper for external ddt
+   use external_module, only: unknown_external_ddt
+
+   !> \section arg_table_wrapped_ddt_t Argument Table
+   !! \htmlinclude wrapped_ddt_t.html
+   type, public :: wrapped_ddt_t
+      type(unknown_external_ddt) :: ext_ddt
+   end type
+
+end module wrapped_ddt

--- a/test/ddthost_test/wrapped_ddt.meta
+++ b/test/ddthost_test/wrapped_ddt.meta
@@ -1,0 +1,7 @@
+[ccpp-table-properties]
+  name = wrapped_ddt_t
+  type = ddt
+
+[ccpp-arg-table]
+  name  = wrapped_ddt_t
+  type  = ddt


### PR DESCRIPTION
### Summary
Since the variables are checked during the metadata parsing stage and the metadata is validated against the Fortran, there's no need to also check the variables during the Fortran parsing stage.

### Context
For some external packages, we need to wrap DDTs to provide metadata, which means the underlying DDT is unknown to the framework and that should be OK (the metadata is only provided for the top-level DDT). Because the Fortran parsing parses all variables even if there's no metadata provided, these wrapped DDTs result in "unknown DDT" errors.

Example from RRTMGP:
```
module ccpp_fluxes
   ! CCPP wrapper for ty_fluxes_broadband DDT from RRTMGP
   use mo_fluxes, only: ty_fluxes_broadband

   !> \section arg_table_ty_fluxes_broadband_ccpp Argument Table
   !! \htmlinclude ty_fluxes_broadband_ccpp.html
   type, public :: ty_fluxes_broadband_ccpp
      type(ty_fluxes_broadband) :: fluxes
   end type

end module ccpp_fluxes
```
Corresponding metadata:
```
[ccpp-table-properties]
  name = ty_fluxes_broadband_ccpp
  type = ddt
  dependencies = ../ext/rte-frontend/mo_fluxes.F90

[ccpp-arg-table]
  name = ty_fluxes_broadband_ccpp
  type = ddt

```
These changes add a flag to the Var class `__init__` to conditionally not perform the parse checks on the parsed variables (this flag is then triggered for Fortran-parsed variables). As a result, there are no errors about "unknown DDT ty_fluxes_broadband" in the above example.

User interface changes?: No

