### PR TITLE
Change CODEOWNERS to use teams rather than individuals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @climbfuji @gold2718 @dustinswales @peverwhee @grantfirl @mkavulich
+*       @ccpp-framework-noaa-contingent @ccpp-framework-ncar-contingent @ccpp-framework-navy-contingent
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @NCAR/ccpp-framework-noaa-contingent @NCAR/ccpp-framework-ncar-contingent @NCAR/ccpp-framework-navy-contingent
+*       @NCAR/ccpp-framework-noaa-contingent @NCAR/ccpp-framework-ncar-contingent @NCAR/ccpp-framework-navy-contingent @gold2718
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @ccpp-framework-noaa-contingent @ccpp-framework-ncar-contingent @ccpp-framework-navy-contingent
+*       @NCAR/ccpp-framework-noaa-contingent @NCAR/ccpp-framework-ncar-contingent @NCAR/ccpp-framework-navy-contingent
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
Because our development workflow requires approvals representing each host model rather than individuals, we are setting up teams to allow for pings/reviews/approvals to be tied to these teams rather than individuals

User interface changes?: No

Testing: None, Github interface changes only
