### PR TITLE
Fix offline tool when relative path is supplied

### DIFF
--- a/.github/workflows/capgen_unit_tests.yaml
+++ b/.github/workflows/capgen_unit_tests.yaml
@@ -54,3 +54,6 @@ jobs:
 
     - name: Run Fortran to metadata test
       run: cd test && ./test_fortran_to_metadata.sh
+
+    - name: Run offline metadata parser test
+      run: cd test && ./test_offline_metadata_checker.sh

--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -540,7 +540,7 @@ def parse_host_model_files(host_filenames, host_name, run_env,
 
 ###############################################################################
 def parse_scheme_files(scheme_filenames, run_env, skip_ddt_check=False,
-                       known_ddts=list()):
+                       known_ddts=list(), relative_source_path=False):
 ###############################################################################
     """
     Gather information from scheme files (e.g., init, run, and finalize
@@ -553,7 +553,8 @@ def parse_scheme_files(scheme_filenames, run_env, skip_ddt_check=False,
         logger.info('Reading CCPP schemes from {}'.format(filename))
         # parse metadata file
         mtables = parse_metadata_file(filename, known_ddts, run_env,
-                                      skip_ddt_check=skip_ddt_check)
+                                      skip_ddt_check=skip_ddt_check,
+                                      relative_source_path=relative_source_path)
         fortran_source_path = mtables[0].fortran_source_path
         fort_file = find_associated_fortran_file(filename, fortran_source_path)
         ftables, additional_routines = parse_fortran_file(fort_file, run_env)

--- a/scripts/fortran_tools/offline_check_fortran_vs_metadata.py
+++ b/scripts/fortran_tools/offline_check_fortran_vs_metadata.py
@@ -42,7 +42,7 @@ def compare_fortran_and_metadata(scheme_directory, run_env):
     ## Check for files
     metadata_files = find_files_to_compare(scheme_directory)
     # Perform checks
-    parse_scheme_files(metadata_files, run_env, skip_ddt_check=True)
+    parse_scheme_files(metadata_files, run_env, skip_ddt_check=True, relative_source_path=True)
 
 def parse_command_line(arguments, description):
     """Parse command-line arguments"""

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -182,7 +182,7 @@ def _parse_config_line(line, context):
 
 ########################################################################
 
-def parse_metadata_file(filename, known_ddts, run_env, skip_ddt_check=False):
+def parse_metadata_file(filename, known_ddts, run_env, skip_ddt_check=False, relative_source_path=False):
     """Parse <filename> and return list of parsed metadata tables"""
     # Read all lines of the file at once
     meta_tables = []
@@ -200,7 +200,8 @@ def parse_metadata_file(filename, known_ddts, run_env, skip_ddt_check=False):
         if MetadataTable.table_start(curr_line):
             new_table = MetadataTable(run_env, parse_object=parse_obj,
                                       known_ddts=known_ddts,
-                                      skip_ddt_check=skip_ddt_check)
+                                      skip_ddt_check=skip_ddt_check,
+                                      relative_source_path=relative_source_path)
             ntitle = new_table.table_name
             if ntitle not in table_titles:
                 meta_tables.append(new_table)
@@ -360,7 +361,7 @@ class MetadataTable():
     def __init__(self, run_env, table_name_in=None, table_type_in=None,
                  dependencies=None, dependencies_path=None, source_path=None,
                  known_ddts=None, var_dict=None, module=None, parse_object=None,
-                 skip_ddt_check=False):
+                 skip_ddt_check=False, relative_source_path=False):
         """Initialize a MetadataTable, either with a name, <table_name_in>, and
         type, <table_type_in>, or with information from a file (<parse_object>).
         if <parse_object> is None, <dependencies>, <dependencies_path>, and
@@ -448,7 +449,9 @@ class MetadataTable():
                 self.__dependencies[ind] = os.path.abspath(os.path.join(path, dep))
             # end for
             if self.__fortran_src_path:
-                self.__fortran_src_path = os.path.join(path, self.__fortran_src_path)
+                if not relative_source_path:
+                    self.__fortran_src_path = os.path.join(path, self.__fortran_src_path)
+                # end if
             # end if
         # end if
 

--- a/test/test_offline_metadata_checker.sh
+++ b/test/test_offline_metadata_checker.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+## Relevant directories and file paths
+root_dir="$(cd $(dirname ${0}); pwd -P)"
+script_dir="$(dirname ${root_dir})/scripts/fortran_tools"
+test_root_dir="$(dirname ${root_dir})/test"
+test_dir="$(dirname ${root_dir})/test/advection_test"
+offline_script="${script_dir}/offline_check_fortran_vs_metadata.py"
+relative_path="capgen_test"
+
+# Run the script
+${offline_script} --directory ${test_dir}
+res=$?
+
+retval=0
+if [ ${res} -ne 0 ]; then
+    echo "FAIL: offline_check_fortran_vs_metadata.py exited with error ${res} while checking ${test_dir}"
+    retval=${res}
+    exit ${retval}
+else
+    echo "PASS"
+fi
+
+# Run the script again with a relative path
+cd ${test_root_dir}
+${offline_script} --directory ${relative_path}
+res=$?
+
+retval=0
+if [ ${res} -ne 0 ]; then
+    echo "FAIL: offline_check_fortran_vs_metadata.py exited with error ${res} while checking ${relative_path}"
+    retval=${res}
+else
+    echo "PASS"
+fi
+exit ${retval}

--- a/test/test_offline_metadata_checker.sh
+++ b/test/test_offline_metadata_checker.sh
@@ -3,7 +3,6 @@
 ## Relevant directories and file paths
 root_dir="$(cd $(dirname ${0}); pwd -P)"
 script_dir="$(dirname ${root_dir})/scripts/fortran_tools"
-test_root_dir="$(dirname ${root_dir})/test"
 test_dir="$(dirname ${root_dir})/test/advection_test"
 offline_script="${script_dir}/offline_check_fortran_vs_metadata.py"
 relative_path="capgen_test"
@@ -22,7 +21,7 @@ else
 fi
 
 # Run the script again with a relative path
-cd ${test_root_dir}
+cd ${root_dir}
 ${offline_script} --directory ${relative_path}
 res=$?
 


### PR DESCRIPTION
Tiny fix to allow the offline metadata parser to work with a relative path. Also includes a new test for the offline tool.

User interface changes?: No

fixes #709
