### PR TITLE
Add capability to add new kind definitions to capgen

### DIFF
--- a/cmake/ccpp_capgen.cmake
+++ b/cmake/ccpp_capgen.cmake
@@ -11,7 +11,7 @@
 # SUITES                    - CMake list of suite xml files
 function(ccpp_capgen)
   set(optionalArgs CAPGEN_DEBUG CAPGEN_EXPECT_THROW_ERROR)
-  set(oneValueArgs HOST_NAME OUTPUT_ROOT VERBOSITY)
+  set(oneValueArgs HOST_NAME KIND_TYPES OUTPUT_ROOT VERBOSITY)
   set(multi_value_keywords HOSTFILES SCHEMEFILES SUITES)
 
   cmake_parse_arguments(arg "${optionalArgs}" "${oneValueArgs}" "${multi_value_keywords}" ${ARGN})
@@ -45,6 +45,9 @@ function(ccpp_capgen)
     message(STATUS "Creating output directory: ${arg_OUTPUT_ROOT}")
     file(MAKE_DIRECTORY "${arg_OUTPUT_ROOT}")
     list(APPEND CCPP_CAPGEN_CMD_LIST "--output-root" "${arg_OUTPUT_ROOT}")
+  endif()
+  if(DEFINED arg_KIND_TYPES)
+    list(APPEND CCPP_CAPGEN_CMD_LIST "--kind-types" "${arg_KIND_TYPES}")
   endif()
   if(DEFINED arg_VERBOSITY)
     string(REPEAT "--verbose " ${arg_VERBOSITY} VERBOSE_PARAMS_SEPARATED)

--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -125,16 +125,16 @@ def create_kinds_file(run_env, output_dir):
     "Create the kinds.F90 file to be used by CCPP schemes and suites"
     kinds_filepath = os.path.join(output_dir, KINDS_FILENAME)
     if run_env.logger is not None:
-        msg = 'Writing {} to {}'
-        run_env.logger.info(msg.format(KINDS_FILENAME, output_dir))
+        msg = f'Writing {KINDS_FILENAME} to {output_dir}'
+        run_env.logger.info(msg)
     # end if
     kind_types = run_env.kind_types()
     with FortranWriter(kinds_filepath, "w",
                        "kinds for CCPP", KINDS_MODULE) as kindf:
         for kind_type in kind_types:
-            use_stmt = "use ISO_FORTRAN_ENV, only: {} => {}"
-            kindf.write(use_stmt.format(kind_type,
-                                        run_env.kind_spec(kind_type)), 1)
+            use_stmt = f"use {run_env.kind_module(kind_type)},"
+            use_stmt += f" only: {kind_type} => {run_env.kind_spec(kind_type)}"
+            kindf.write(use_stmt, 1)
         # end for
         kindf.write_preamble()
         for kind_type in kind_types:

--- a/scripts/framework_env.py
+++ b/scripts/framework_env.py
@@ -31,6 +31,13 @@ class CCPPFrameworkEnv:
         <ndict> is a dict with the parsed command-line arguments (or a
            dictionary created with the necessary arguments).
         <logger> is a logger to be used by users of this object.
+        <kind_types> is a dictionary defining the Fortran kind types.
+           It has entries of the form:
+           kind_type : [kind_module, kind_specification]
+           where <kind_type> is a string defining the kind type name,
+           <kind_module> is the Fortran module that contains the kind
+           specification, and <kind_specification> is the Fortran kind
+           parameter name (e.g., 'REAL64').    
         """
         emsg = ''
         esep = ''
@@ -143,9 +150,9 @@ class CCPPFrameworkEnv:
         # end if
         self.__generate_host_cap = self.host_name != ''
         self.__kind_dict = {}
-        if ndict and ('kind_type' in ndict):
-            self.__kind_dict = ndict['kind_type']
-            del ndict['kind_type']
+        if ndict and ('kind_types' in ndict):
+            self.__kind_dict = ndict['kind_types']
+            del ndict['kind_types']
         else:
             self.__kind_dict = kind_types
         # end if
@@ -386,20 +393,24 @@ If this option is passed, a host model cap is generated''')
                         help='Remove files created by this script, then exit')
 
     # Define parser for kind dictionary input
-    def parse_dict(arg_str):
-        """Parse a 'key=value' string
-           into a dictionary"""
+    def parse_kind_dict(arg_str):
+        """Parse a 'key1=value1:key2=value2' string
+           into a dictionary, where each value is a
+           list of comma-separated entries."""
         result = {}
-        key, value = arg_str.split('=')
-        result[key.strip()] = value.split(',')
+        dict_entries = arg_str.split(':')
+        for entry in dict_entries:
+            key, value = entry.split('=')
+            result[key.strip()] = value.split(',')
         return result
 
-    parser.add_argument("--kind-type", type=parse_dict, action='update',
-                        metavar="kind_type", default=dict(),
-                        help="""Data size for real(<kind_type>) data.
+    parser.add_argument("--kind-types", type=parse_kind_dict,
+                        metavar="kind_types", default=dict(),
+                        help="""Data size for real(<kind_types>) data.
 Entry in the form of <kind_type>=<kind_module>,<kind_val>
 e.g., --kind-type "kind_phys=ISO_FORTRAN_ENV,REAL64"
-Enter more than one --kind-type entry to define multiple CCPP kinds.""")
+Additional entries are separated by colons to define multiple CCPP kinds,
+e.g., --kind-type "kind_phys=ISO_FORTRAN_ENV,REAL64:kind_host=host_kinds,coupler_kind""")
 
     parser.add_argument("--generate-docfiles",
                         metavar='HTML | Latex | HTML,Latex', type=str,

--- a/scripts/framework_env.py
+++ b/scripts/framework_env.py
@@ -24,7 +24,7 @@ class CCPPFrameworkEnv:
     def __init__(self, logger, ndict=None, verbose=0, clean=False,
                  host_files=None, scheme_files=None, suites=None,
                  preproc_directives=[], generate_docfiles=False, host_name='',
-                 kind_types=[], use_error_obj=False, force_overwrite=False,
+                 kind_types={}, use_error_obj=False, force_overwrite=False,
                  output_root=os.getcwd(), ccpp_datafile="datatable.xml",
                  debug=False):
         """Initialize a new CCPPFrameworkEnv object from the input arguments.
@@ -143,30 +143,18 @@ class CCPPFrameworkEnv:
         # end if
         self.__generate_host_cap = self.host_name != ''
         self.__kind_dict = {}
-        if ndict and ("kind_type" in ndict):
-            kind_list = ndict["kind_type"]
-            del ndict["kind_type"]
+        if ndict and ('kind_type' in ndict):
+            self.__kind_dict = ndict['kind_type']
+            del ndict['kind_type']
         else:
-            kind_list = kind_types
+            self.__kind_dict = kind_types
         # end if
-        # Note that the command line uses repeated calls to 'kind_type'
-        for kind in kind_list:
-            kargs = [x.strip() for x in kind.strip().split('=')]
-            if len(kargs) != 2:
-                emsg += esep
-                emsg += "Error: '{}' is not a valid kind specification "
-                emsg += "(should be of the form <kind_name>=<kind_spec>)"
-                emsg = emsg.format(kind)
-                esep = '\n'
-            else:
-                kind_name, kind_spec = kargs
-                # Do not worry about duplicates, just use last value
-                self.__kind_dict[kind_name] = kind_spec
-            # end if
-        # end for
+
         # We always need a kind_phys so add a default if necessary
         if "kind_phys" not in self.__kind_dict:
-            self.__kind_dict["kind_phys"] = "REAL64"
+            # Use ISO-Fortran double-precision real
+            # definition for default physics kind:
+            self.__kind_dict['kind_phys'] = ['ISO_FORTRAN_ENV', 'REAL64']
         # end if
         if ndict and ('use_error_obj' in ndict):
             self.__use_error_obj = ndict['use_error_obj']
@@ -269,13 +257,30 @@ class CCPPFrameworkEnv:
         CCPPFrameworkEnv object."""
         return self.__generate_host_cap
 
+    def kind_module(self, kind_type):
+        """Return the Fortran module that
+        contains the kind specification
+        for kind type, <kind_type>,
+        for this CCPPFrameworkEnv object.
+        If there is no entry for <kind_type>,
+        return None."""
+        kind_mod = None
+        if kind_type in self.__kind_dict:
+            # The kind module should always be
+            # the first element in the list:
+            kind_mod = self.__kind_dict[kind_type][0]
+        # end if
+        return kind_mod
+
     def kind_spec(self, kind_type):
         """Return the kind specification for kind type, <kind_type>
         for this CCPPFrameworkEnv object.
         If there is no entry for <kind_type>, return None."""
         kind_spec = None
         if kind_type in self.__kind_dict:
-            kind_spec = self.__kind_dict[kind_type]
+            # The kind specification should always be
+            # the second element in the list:
+            kind_spec = self.__kind_dict[kind_type][1]
         # end if
         return kind_spec
 
@@ -380,13 +385,21 @@ If this option is passed, a host model cap is generated''')
     parser.add_argument("--clean", action='store_true', default=False,
                         help='Remove files created by this script, then exit')
 
-    parser.add_argument("--kind-type", type=str, action='append',
-                        metavar="kind_type", default=list(),
+    # Define parser for kind dictionary input
+    def parse_dict(arg_str):
+        """Parse a 'key=value' string
+           into a dictionary"""
+        result = {}
+        key, value = arg_str.split('=')
+        result[key.strip()] = value.split(',')
+        return result
+
+    parser.add_argument("--kind-type", type=parse_dict, action='update',
+                        metavar="kind_type", default=dict(),
                         help="""Data size for real(<kind_type>) data.
-Entry in the form of <kind_type>=<kind_val>
-e.g., --kind-type "kind_phys=REAL64"
-Enter more than one --kind-type entry to define multiple CCPP kinds.
-<kind_val> SHOULD be a valid ISO_FORTRAN_ENV type""")
+Entry in the form of <kind_type>=<kind_module>,<kind_val>
+e.g., --kind-type "kind_phys=ISO_FORTRAN_ENV,REAL64"
+Enter more than one --kind-type entry to define multiple CCPP kinds.""")
 
     parser.add_argument("--generate-docfiles",
                         metavar='HTML | Latex | HTML,Latex', type=str,

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -834,9 +834,9 @@ class VarCompatObj:
                                        ndict={'host_files':'', \
                                               'scheme_files':'', \
                                               'suites':''}, \
-                                       kind_types=["kind_phys=REAL64", \
-                                                   "kind_dyn=REAL32", \
-                                                   "kind_host=REAL64"])
+                                       kind_types={"kind_phys": ["ISO_FORTRAN_ENV", "REAL64"], \
+                                                   "kind_dyn": ["ISO_FORTRAN_ENV", "REAL32"], \
+                                                   "kind_host": ["ISO_FORTRAN_ENV", "REAL64"]})
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", [], "var1_lname", False,\
                      "var_stdname", "real", "kind_phys", "m", [], "var2_lname", False,\
                      _DOCTEST_RUNENV) #doctest: +ELLIPSIS
@@ -1171,9 +1171,9 @@ class VarCompatObj:
                                                ndict={'host_files':'', \
                                                       'scheme_files':'', \
                                                       'suites':''}, \
-                                               kind_types=["kind_phys=REAL64", \
-                                                           "kind_dyn=REAL32", \
-                                                           "kind_host=REAL64"])
+                                               kind_types={"kind_phys": ["ISO_FORTRAN_ENV", "REAL64"], \
+                                                           "kind_dyn": ["ISO_FORTRAN_ENV", "REAL32"], \
+                                                           "kind_host": ["ISO_FORTRAN_ENV", "REAL64"]})
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')
         >>> _DOCTEST_VCOMPAT = VarCompatObj("var_stdname", "real", "kind_phys", \
@@ -1226,9 +1226,9 @@ class VarCompatObj:
                                                ndict={'host_files':'', \
                                                       'scheme_files':'', \
                                                       'suites':''}, \
-                                               kind_types=["kind_phys=REAL64", \
-                                                           "kind_dyn=REAL32", \
-                                                           "kind_host=REAL64"])
+                                               kind_types={"kind_phys": ["ISO_FORTRAN_ENV", "REAL64"], \
+                                                           "kind_dyn": ["ISO_FORTRAN_ENV", "REAL32"], \
+                                                           "kind_host": ["ISO_FORTRAN_ENV", "REAL64"]})
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')
         >>> _DOCTEST_VCOMPAT = VarCompatObj("var_stdname", "real", "kind_phys", \
@@ -1317,9 +1317,9 @@ class VarCompatObj:
                                        ndict={'host_files':'', \
                                               'scheme_files':'', \
                                               'suites':''}, \
-                                       kind_types=["kind_phys=REAL64", \
-                                                   "kind_dyn=REAL32", \
-                                                   "kind_host=REAL64"])
+                                       kind_types={"kind_phys": ["ISO_FORTRAN_ENV", "REAL64"], \
+                                                   "kind_dyn": ["ISO_FORTRAN_ENV", "REAL32"], \
+                                                   "kind_host": ["ISO_FORTRAN_ENV", "REAL64"]})
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')
         >>> _DOCTEST_VCOMPAT = VarCompatObj("var_stdname", "real", "kind_phys", \

--- a/test/capgen_test/CMakeLists.txt
+++ b/test/capgen_test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SCHEME_FILES       "setup_coeffs" "temp_set" "temp_adjust" "temp_calc_adjust
 set(SUITE_SCHEME_FILES "make_ddt" "environ_conditions")
 set(HOST_FILES         "test_host_data" "test_host_mod")
 set(SUITE_FILES        "ddt_suite.xml" "temp_suite.xml")
+set(KIND_TYPES         "kind_phys=ISO_FORTRAN_ENV,REAL64:kind_temp=temp_kinds,temp_r8")
 
 # HOST is the name of the executable we will build.
 # We assume there are files ${HOST}.meta and ${HOST}.F90 in CMAKE_SOURCE_DIR
@@ -42,6 +43,10 @@ foreach(sfile ${SUITE_SCHEME_FILES})
   list(APPEND SUITE_SCHEME_FORTRAN_FILES ${fort_file})
   unset(fort_file)
 endforeach()
+
+# Append Fortran files that define kinds to scheme Fortran files list
+list(APPEND SCHEME_FORTRAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/temp_kinds.F90")
+
 list(TRANSFORM SUITE_SCHEME_FILES APPEND ".meta" OUTPUT_VARIABLE SUITE_SCHEME_META_FILES)
 list(TRANSFORM HOST_FILES         APPEND ".F90"  OUTPUT_VARIABLE CAPGEN_HOST_FORTRAN_FILES)
 list(TRANSFORM HOST_FILES         APPEND ".meta" OUTPUT_VARIABLE CAPGEN_HOST_METADATA_FILES)
@@ -54,6 +59,7 @@ ccpp_capgen(CAPGEN_DEBUG ON
             SCHEMEFILES ${SCHEME_META_FILES} ${SUITE_SCHEME_META_FILES}
             SUITES ${SUITE_FILES}
             HOST_NAME ${HOST}
+            KIND_TYPES ${KIND_TYPES}
             OUTPUT_ROOT "${CCPP_CAP_FILES}")
 
 # Retrieve the list of Fortran files required for test host from datatable.xml and set to CCPP_CAPS_LIST

--- a/test/capgen_test/source_dir2/temp_set.F90
+++ b/test/capgen_test/source_dir2/temp_set.F90
@@ -3,7 +3,7 @@
 
 MODULE temp_set
 
-  USE ccpp_kinds, ONLY: kind_phys
+  USE ccpp_kinds, ONLY: kind_phys, kind_temp
 
   IMPLICIT NONE
   PRIVATE
@@ -32,7 +32,7 @@ CONTAINS
    real(kind_phys),    intent(inout) :: temp_diag(:,:)
    real(kind_phys),    intent(inout) :: soil_levs(slev_lbound:)
    real(kind_phys),    intent(inout) :: var_array(:,:,:,:)
-   real(kind_phys),    intent(out)   :: to_promote(:, :)
+   real(kind_temp),    intent(out)   :: to_promote(:, :)
    real(kind_phys),    intent(out)   :: promote_pcnst(:)
    character(len=512), intent(out)   :: errmsg
    integer,            intent(out)   :: errflg
@@ -62,7 +62,7 @@ CONTAINS
 
     var_array(:,:,:,:) = 1._kind_phys
 
-    ! 
+    !
     internal_scalar_var = soil_levs(slev_lbound)
     internal_scalar_var = soil_levs(0)
 

--- a/test/capgen_test/temp_adjust.F90
+++ b/test/capgen_test/temp_adjust.F90
@@ -3,7 +3,7 @@
 
 MODULE temp_adjust
 
-  USE ccpp_kinds, ONLY: kind_phys
+  USE ccpp_kinds, ONLY: kind_phys, kind_temp
 
   IMPLICIT NONE
   PRIVATE
@@ -43,7 +43,7 @@ CONTAINS
     real(kind_phys),           intent(inout) :: ps(:)
     REAL(kind_phys),           intent(in)    :: temp_prev(:)
     REAL(kind_phys),           intent(inout) :: temp_layer(foo)
-    real(kind_phys),           intent(in)    :: to_promote(:)
+    real(kind_temp),           intent(in)    :: to_promote(:)
     real(kind_phys),           intent(in)    :: promote_pcnst(:)
     integer,                   intent(out)   :: interstitial_var(:)
     character(len=512),        intent(out)   :: errmsg

--- a/test/capgen_test/temp_adjust.meta
+++ b/test/capgen_test/temp_adjust.meta
@@ -87,7 +87,7 @@
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
-  kind = kind_phys
+  kind = kind_temp
   intent = in
 [ promote_pcnst ]
   standard_name = promote_this_variable_with_no_horizontal_dimension

--- a/test/capgen_test/temp_kinds.F90
+++ b/test/capgen_test/temp_kinds.F90
@@ -1,8 +1,5 @@
-!Define Fortran kinds for use specifically
-!within PUMAS.  This allows PUMAS to control
-!the precision in its internal routines without
-!having to depend on a specific host model
-!implemention.
+! Define a new Fortran kind for use within
+! various temp_* test files.
 
 module temp_kinds
 

--- a/test/capgen_test/temp_kinds.F90
+++ b/test/capgen_test/temp_kinds.F90
@@ -1,0 +1,14 @@
+!Define Fortran kinds for use specifically
+!within PUMAS.  This allows PUMAS to control
+!the precision in its internal routines without
+!having to depend on a specific host model
+!implemention.
+
+module temp_kinds
+
+   implicit none
+   private
+
+   integer, public, parameter :: temp_r8 = selected_real_kind(12) !8-byte real
+
+end module temp_kinds

--- a/test/capgen_test/temp_set.meta
+++ b/test/capgen_test/temp_set.meta
@@ -60,7 +60,7 @@
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = kind_temp
   intent = out
 [ promote_pcnst ]
   standard_name = promote_this_variable_with_no_horizontal_dimension

--- a/test/unit_tests/test_var_transforms.py
+++ b/test/unit_tests/test_var_transforms.py
@@ -52,9 +52,9 @@ class VarCompatTestCase(unittest.TestCase):
         self.__run_env = CCPPFrameworkEnv(None, ndict={'host_files':'',
                                                        'scheme_files':'foo.meta',
                                                        'suites':''},
-                                          kind_types=["kind_phys=REAL64",
-                                                      "kind_dyn=REAL32",
-                                                      "kind_host=REAL64"])
+                                          kind_types={"kind_phys": ["ISO_FORTRAN_ENV", "REAL64"],
+                                                      "kind_dyn": ["ISO_FORTRAN_ENV", "REAL32"],
+                                                      "kind_host": ["ISO_FORTRAN_ENV", "REAL64"]})
         # For making variables unique
         self.__linenum = 2
         # For assert messages


### PR DESCRIPTION
Adds the ability for the host model to provide additional kind definitions to the auto-generated `ccpp_kinds.F90` file.

This PR provides the ability for a host model, during the creation of the cap in capgen, to provide a dictionary of kind types (the kind type name, module, and specification/name within the module), which then add the kind to `ccpp_kinds.F90`, and thus make it accessible throughout the CCPP cap.  An example of this dictionary being used in practice can be found in a branch of CAM-SIMA here:

https://github.com/nusbaume/CAM-SIMA/blob/pumas_round3/cime_config/cam_autogen.py#L497-L504

Additional info about what this PR is specifically trying to fix can also be found in issue #712 

User interface changes?: Yes

The `kind_types` argument for `CCPPFrameworkEnv` has been changed from a string to a dictionary.  If one is using command-line arguments then it the `kind_types` argument has changed from `kind_type=kind_spec` to `kind_type=kind_module,kind_spec`, with a colon-delimiter for multiple definitions.  Examples should be findable in the comments/testing code provided in this PR.

Fixes:

Fixes #712 - Need ability to expose scheme-defined kind to cap in capgen

Testing:
  test removed:  N/A
  unit tests:  Updated python tests to properly use the new `kind_types` dictionary structure.
  system tests:  Added new kind to `capgen_test` to ensure this fucntionality works as expected.
  manual testing:  Tested this functionality in CAM-SIMA with the PUMAS cloud microphysics scheme (which has its own kind definition).

