### PR TITLE
Allow declaration of a scheme-dependent kind

### DIFF
--- a/cmake/ccpp_capgen.cmake
+++ b/cmake/ccpp_capgen.cmake
@@ -11,7 +11,7 @@
 # SUITES                    - CMake list of suite xml files
 function(ccpp_capgen)
   set(optionalArgs CAPGEN_DEBUG CAPGEN_EXPECT_THROW_ERROR)
-  set(oneValueArgs HOST_NAME OUTPUT_ROOT VERBOSITY)
+  set(oneValueArgs HOST_NAME OUTPUT_ROOT VERBOSITY KIND_SPECS)
   set(multi_value_keywords HOSTFILES SCHEMEFILES SUITES)
 
   cmake_parse_arguments(arg "${optionalArgs}" "${oneValueArgs}" "${multi_value_keywords}" ${ARGN})
@@ -50,6 +50,19 @@ function(ccpp_capgen)
     string(REPEAT "--verbose " ${arg_VERBOSITY} VERBOSE_PARAMS_SEPARATED)
     separate_arguments(VERBOSE_PARAMS UNIX_COMMAND "${VERBOSE_PARAMS_SEPARATED}")
     list(APPEND CCPP_CAPGEN_CMD_LIST ${VERBOSE_PARAMS})
+  endif()
+  if(DEFINED arg_KIND_SPECS)
+    string(REPLACE "," ";" KIND_SPEC_LIST "${arg_KIND_SPECS}")
+    set(KIND_ARGS "")               # start empty
+    foreach(pair IN LISTS KIND_SPEC_LIST)
+    # Append each pair prefixed with --kind-type and quoted.
+    # The surrounding double‑quotes are added explicitly so the
+    # resulting string contains them.
+    set(KIND_ARGS "${KIND_ARGS}--kind-type \"${pair}\"")
+    string(STRIP "${KIND_ARGS}" KIND_ARGS)
+  endforeach()
+
+    list(APPEND CCPP_CAPGEN_CMD_LIST ${KIND_SPEC_PARAMS})
   endif()
 
   message(STATUS "Running ccpp_capgen.py from ${CMAKE_CURRENT_SOURCE_DIR}")

--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -125,8 +125,8 @@ def create_kinds_file(run_env, output_dir):
     "Create the kinds.F90 file to be used by CCPP schemes and suites"
     kinds_filepath = os.path.join(output_dir, KINDS_FILENAME)
     if run_env.logger is not None:
-        msg = f'Writing {KINDS_FILENAME} to {output_dir}'
-        run_env.logger.info(msg)
+        msg = 'Writing {} to {}'
+        run_env.logger.info(msg.format(KINDS_FILENAME, output_dir))
     # end if
     kind_types = run_env.kind_types()
     with FortranWriter(kinds_filepath, "w",

--- a/scripts/ccpp_capgen.py
+++ b/scripts/ccpp_capgen.py
@@ -125,16 +125,21 @@ def create_kinds_file(run_env, output_dir):
     "Create the kinds.F90 file to be used by CCPP schemes and suites"
     kinds_filepath = os.path.join(output_dir, KINDS_FILENAME)
     if run_env.logger is not None:
-        msg = 'Writing {} to {}'
-        run_env.logger.info(msg.format(KINDS_FILENAME, output_dir))
+        msg = f'Writing {KINDS_FILENAME} to {output_dir}'
+        run_env.logger.info(msg)
     # end if
     kind_types = run_env.kind_types()
     with FortranWriter(kinds_filepath, "w",
                        "kinds for CCPP", KINDS_MODULE) as kindf:
         for kind_type in kind_types:
-            use_stmt = "use ISO_FORTRAN_ENV, only: {} => {}"
-            kindf.write(use_stmt.format(kind_type,
-                                        run_env.kind_spec(kind_type)), 1)
+            kind_spec = run_env.kind_spec(kind_type)
+            use_stmt = f"use {run_env.kind_module(kind_type)},"
+            if kind_spec == kind_type:
+                use_stmt += f" only: {kind_type}"
+            else:
+                use_stmt += f" only: {kind_type} => {kind_spec}"
+            # end if
+            kindf.write(use_stmt, 1)
         # end for
         kindf.write_preamble()
         for kind_type in kind_types:

--- a/scripts/framework_env.py
+++ b/scripts/framework_env.py
@@ -11,9 +11,13 @@ Framework runtime information and parameter values.
 import argparse
 import os
 from parse_tools import verbose
-
 _EPILOG = '''
 '''
+
+## List of kinds in ISO_FORTRAN_ENV (that are useful in CCPP)
+## Note: this is defined here instead of in fortran_tools to prevent a
+##       circular dependency
+ISO_FORTRAN_KINDS = ['int8', 'int16', 'int32', 'int64', 'real32', 'real64', 'real128']
 
 ###############################################################################
 class CCPPFrameworkEnv:
@@ -31,6 +35,19 @@ class CCPPFrameworkEnv:
         <ndict> is a dict with the parsed command-line arguments (or a
            dictionary created with the necessary arguments).
         <logger> is a logger to be used by users of this object.
+        <kind_types> is a list defining the Fortran kind types which will be
+           public in ccpp_kinds.F90.
+           It has entries of the form:
+           kind_type=kind_specification[:kind_module]
+           where <kind_type> is a string defining the kind type name,
+           <kind_specification> is the Fortran kind parameter name
+           (e.g., 'REAL64'), and <kind_module> is the (optional) Fortran
+           module that contains <kind_specification>. If <kind_module> is
+           not specified, then <kind_specification> must be a type defined in
+           ISO_FORTRAN_ENV.
+           It is allowed to have a duplicate entry for <kind_type> as long as
+           it does not specify a different type or module.
+           <kind_type> will be made available as a kind in ccpp_kinds.F90
         """
         emsg = ''
         esep = ''
@@ -143,30 +160,44 @@ class CCPPFrameworkEnv:
         # end if
         self.__generate_host_cap = self.host_name != ''
         self.__kind_dict = {}
-        if ndict and ("kind_type" in ndict):
-            kind_list = ndict["kind_type"]
-            del ndict["kind_type"]
+        if ndict and ("kind_types" in ndict):
+            kind_list = ndict["kind_types"]
+            del ndict["kind_types"]
         else:
             kind_list = kind_types
         # end if
         # Note that the command line uses repeated calls to 'kind_type'
         for kind in kind_list:
             kargs = [x.strip() for x in kind.strip().split('=')]
+            errstr = ""
             if len(kargs) != 2:
-                emsg += esep
-                emsg += "Error: '{}' is not a valid kind specification "
-                emsg += "(should be of the form <kind_name>=<kind_spec>)"
-                emsg = emsg.format(kind)
+                emsg += (f"{esep}Error: '{kind}' is not a valid kind specification "
+                         "(should be of the form <kind_name>=<kind_spec>)")
                 esep = '\n'
             else:
                 kind_name, kind_spec = kargs
-                # Do not worry about duplicates, just use last value
-                self.__kind_dict[kind_name] = kind_spec
+                kind_specs = kind_spec.split(':')
+                if len(kind_specs) == 1:
+                    errstr = self.add_kind_type(kind_name, kind_specs[0])
+                elif len(kind_specs) > 2:
+                    emsg += (f"{esep}Error: Invalid format for '{kind_name}' "
+                             "should be [<kind_spec>] or [<kind_spec>, <module name>]")
+                    esep = '\n'
+                else:
+                    errstr = self.add_kind_type(kind_name, kind_specs[0], kind_specs[1])
+                # end if
+                if errstr:
+                    emsg += f"{esep}{errstr}"
+                    esep = '\n'
+                # end if
             # end if
         # end for
+
         # We always need a kind_phys so add a default if necessary
         if "kind_phys" not in self.__kind_dict:
-            self.__kind_dict["kind_phys"] = "REAL64"
+            # Use ISO-Fortran 64-bit real
+            # definition for default physics kind:
+            self.__kind_dict['kind_phys'] = ['REAL64', 'ISO_FORTRAN_ENV']
         # end if
         if ndict and ('use_error_obj' in ndict):
             self.__use_error_obj = ndict['use_error_obj']
@@ -269,15 +300,67 @@ class CCPPFrameworkEnv:
         CCPPFrameworkEnv object."""
         return self.__generate_host_cap
 
+    def kind_module(self, kind_type):
+        """Return the Fortran module that
+        contains the kind specification
+        for kind type, <kind_type>,
+        for this CCPPFrameworkEnv object.
+        If there is no entry for <kind_type>,
+        return None."""
+        kind_mod = None
+        if kind_type in self.__kind_dict:
+            # The kind module should always be
+            # the second element in the list:
+            kind_mod = self.__kind_dict[kind_type][1]
+        # end if
+        return kind_mod
+
     def kind_spec(self, kind_type):
         """Return the kind specification for kind type, <kind_type>
         for this CCPPFrameworkEnv object.
         If there is no entry for <kind_type>, return None."""
         kind_spec = None
         if kind_type in self.__kind_dict:
-            kind_spec = self.__kind_dict[kind_type]
+            # The kind specification should always be
+            # the first element in the list:
+            kind_spec = self.__kind_dict[kind_type][0]
         # end if
         return kind_spec
+
+    def add_kind_type(self, new_ccpp_kind, new_kind, new_module=None):
+        """Add <new_kind> to our kind dictionary.
+        <new_module> is the name of the Fortran module that defined <new_kind>
+        <new_ccpp_kind> is the kind name as published in ccpp_kinds.f90
+        This method assumes the inputs have been parsed.
+        Returns None or an error string if <new_kind> is already in the
+        kinds dictionary.
+        """
+        emsg = ""
+        esep = ""
+        # Make sure we have a valid module
+        if new_module == None:
+            if new_kind.lower() in ISO_FORTRAN_KINDS:
+                new_module = 'ISO_FORTRAN_ENV'
+            else:
+                emsg += (f"{esep}Error: unknown kind, '{new_kind}' "
+                         "and no Fortran module name specified")
+                esep = '\n'
+            # end if
+        # end if
+        # Check for incompatible duplicates
+        if ((new_ccpp_kind in self.__kind_dict) and
+            ((self.kind_spec(new_ccpp_kind) != new_kind) or
+             (self.kind_module(new_ccpp_kind) != new_module))):
+            emsg += (f"{esep}Error: '{new_ccpp_kind} = [{new_kind}, {new_module}]'"
+                     f"is an invalid duplicate. {new_ccpp_kind} "
+                     f"is already '{str(self.__kind_dict[new_ccpp_kind])}")
+            esep = '\n'
+        else:
+            if new_module:
+                self.__kind_dict[new_ccpp_kind] = [new_kind, new_module]
+            # end if
+        # end if
+        return emsg
 
     def kind_types(self):
         """Return a list of all kind types defined in this
@@ -381,12 +464,12 @@ If this option is passed, a host model cap is generated''')
                         help='Remove files created by this script, then exit')
 
     parser.add_argument("--kind-type", type=str, action='append',
-                        metavar="kind_type", default=list(),
-                        help="""Data size for real(<kind_type>) data.
+                        metavar="kind_spec", dest="kind_types", default=list(),
+                        help="""Data size for <kind_type> data (e.g., real(<kind_type>)).
 Entry in the form of <kind_type>=<kind_val>
 e.g., --kind-type "kind_phys=REAL64"
 Enter more than one --kind-type entry to define multiple CCPP kinds.
-<kind_val> SHOULD be a valid ISO_FORTRAN_ENV type""")
+<kind_val> MUST be a valid ISO_FORTRAN_ENV type""")
 
     parser.add_argument("--generate-docfiles",
                         metavar='HTML | Latex | HTML,Latex', type=str,

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -15,21 +15,42 @@ Metadata headers are in config file format.
 
 A 'ccpp-table-properties' section entries are:
 name = <name> : the name of the following ccpp-arg-table entries (required).
-                It is one of the following possibilities:
+          It is one of the following possibilities:
    - SchemeName: the name of a scheme (i.e., the name of
-                  a scheme interface (related to SubroutineName below).
+          a scheme interface (related to SubroutineName below).
    - DerivedTypeName: a derived type name for a type which will be used
-                      somewhere in the CCPP interface.
+          somewhere in the CCPP interface.
    - ModuleName: the name of the module whose module variables will be
-                 used somewhere in the CCPP interface
+          used somewhere in the CCPP interface
    - HostName: the name of the host model. Variables in this section become
-                 part of the CCPP UI, the CCPP routines called by the
-                 host model (e.g., <HostName>_ccpp_physics_run).
+          part of the CCPP UI, the CCPP routines called by the
+          host model (e.g., <HostName>_ccpp_physics_run).
 type = <type> : The type of header (required), one of:
     - scheme: A CCPP subroutine
     - ddt: A header for a derived data type
     - module: A header on some module data
     - host: A header on data which will be part of the CCPP UI
+dependencies = <dependencies> : Comma-separated list of module dependencies
+          Each item should appear in one or more use statements in the
+          corresponding Fortran module
+dependencies_path = <relative path> : A path, relative to the location of
+          metadata table file, where dependencies can be found.
+module_name = <module name> : only needed if module name differs from filename
+source_path = <relative source directory of Fortran source (if different)>
+dynamic_constituent_routine = ??? : @peverwhee?
+kind_spec = <kind_spec> : One or more optional Fortran kinds defined
+          in the corresponding Fortran file.
+          The format is <kind_name>:<fortran_module>[:<ccpp_kind_name>]
+          - <kind_name> is defined in the corresponding Fortran module
+          - <fortran_module> is the module name of the corresponding Fortran module
+          - <ccpp_kind_name> is optional and describes the kind name
+          used in CCPP metadata tables and Fortran files.
+          These entries are added to the framework_env object and
+          thus to ccpp_kinds.F90
+          The entries in ccpp_kinds.F90 are:
+          use <module name>, only <kind_name>
+          use <module name>, only <ccpp_kind_name> => <kind_name>
+          where the first form is used if <ccpp_kind_name> is omitted.
 
 The ccpp-arg-table section entries in this section are:
 name = <name> : the name of the file object which immediately follows the
@@ -63,7 +84,7 @@ An example argument table is shown below.
   type = scheme
   dependencies_path = <relative path>
   dependencies = <dependencies>
-  module = <module name> # only needed if module name differs from filename
+  module_name = <module name> # only needed if module name differs from filename
   source_path = <relative source directory of Fortran source (if different)>
   dynamic_constituent_routine = <routine name>
 
@@ -512,6 +533,42 @@ class MetadataTable():
                         self.__dependencies_path = value
                     elif key == 'source_path':
                         self.__fortran_src_path = os.path.join(my_dirname, value)
+                    elif key == 'kind_spec':
+                        # Add spec to the runtime environment's kinds dict
+                        spec_list = [x.strip() for x in value.split(':', maxsplit=2)]
+                        new_kind = spec_list[0]
+                        if len(spec_list) < 2:
+                            emsg = f"A fortran module name is required for '{new_kind}'"
+                            self.__pobj.add_syntax_err(emsg)
+                            continue
+                        # end if
+                        fort_module = spec_list[1]
+                        if len(spec_list) > 2:
+                            new_ccpp_kind = spec_list[2]
+                        else:
+                            new_ccpp_kind = new_kind
+                        # end if
+                        try:
+                            check_fortran_id(new_kind, {}, True)
+                        except CCPPError as err:
+                            self.__pobj.add_syntax_err(f"{err}")
+                            new_kind = None
+                        # end try
+                        if new_kind and (new_ccpp_kind != new_kind):
+                            try:
+                                check_fortran_id(new_ccpp_kind, {}, True)
+                            except CCPPError as err:
+                                self.__pobj.add_syntax_err(f"{err}")
+                                new_ccpp_kind = None
+                            # end try
+                        # end if
+                        if new_kind:
+                            emsg = run_env.add_kind_type(new_ccpp_kind,
+                                                         new_kind, fort_module)
+                            if emsg:
+                                self.__pobj.add_syntax_err(emsg)
+                            # end if
+                        # end if
                     else:
                         tok_type = "metadata table start property"
                         self.__pobj.add_syntax_err(tok_type, token=key)

--- a/scripts/metadata_table.py
+++ b/scripts/metadata_table.py
@@ -40,11 +40,12 @@ source_path = <relative source directory of Fortran source (if different)>
 dynamic_constituent_routine = ??? : @peverwhee?
 kind_spec = <kind_spec> : One or more optional Fortran kinds defined
           in the corresponding Fortran file.
-          The format is <kind_name>:<fortran_module>[:<ccpp_kind_name>]
-          - <kind_name> is defined in the corresponding Fortran module
+          The format is fortran_module:ccpp_kind_name=>kind_name or
+            fortran_module:kind_name
           - <fortran_module> is the module name of the corresponding Fortran module
-          - <ccpp_kind_name> is optional and describes the kind name
-          used in CCPP metadata tables and Fortran files.
+          - <kind_name> is defined in the corresponding Fortran module
+          - <ccpp_kind_name> is optional and describes the kind name used in CCPP
+            metadata tables and Fortran files.
           These entries are added to the framework_env object and
           thus to ccpp_kinds.F90
           The entries in ccpp_kinds.F90 are:
@@ -536,17 +537,19 @@ class MetadataTable():
                     elif key == 'kind_spec':
                         # Add spec to the runtime environment's kinds dict
                         spec_list = [x.strip() for x in value.split(':', maxsplit=2)]
-                        new_kind = spec_list[0]
+                        fort_module = spec_list[0]
                         if len(spec_list) < 2:
-                            emsg = f"A fortran module name is required for '{new_kind}'"
+                            emsg = f"A Fortran kind name is required for '{value}'"
                             self.__pobj.add_syntax_err(emsg)
                             continue
                         # end if
-                        fort_module = spec_list[1]
-                        if len(spec_list) > 2:
-                            new_ccpp_kind = spec_list[2]
+                        new_ccpp_kind = spec_list[1]
+                        spec_list = [x.strip() for x in new_ccpp_kind.split('=>', maxsplit=1)]
+                        if len(spec_list) > 1:
+                            new_kind = spec_list[1]
+                            new_ccpp_kind = spec_list[0]
                         else:
-                            new_ccpp_kind = new_kind
+                            new_kind = new_ccpp_kind
                         # end if
                         try:
                             check_fortran_id(new_kind, {}, True)

--- a/scripts/parse_tools/fortran_conditional.py
+++ b/scripts/parse_tools/fortran_conditional.py
@@ -10,4 +10,4 @@ import re
 FORTRAN_CONDITIONAL_REGEX_WORDS = [' ', '(', ')', '==', '/=', '<=', '>=', '<', '>', '.eqv.', '.neqv.',
                                    '.true.', '.false.', '.lt.', '.le.', '.eq.', '.ge.', '.gt.', '.ne.',
                                    '.not.', '.and.', '.or.', '.xor.']
-FORTRAN_CONDITIONAL_REGEX = re.compile(r"[\w']+|" + "|".join([word.replace('(','\(').replace(')', '\)') for word in FORTRAN_CONDITIONAL_REGEX_WORDS]))
+FORTRAN_CONDITIONAL_REGEX = re.compile(r"[\w']+|" + "|".join([word.replace('(',r'\(').replace(')', r'\)') for word in FORTRAN_CONDITIONAL_REGEX_WORDS]))

--- a/scripts/parse_tools/parse_checkers.py
+++ b/scripts/parse_tools/parse_checkers.py
@@ -13,13 +13,13 @@ from parse_source import CCPPError, ParseInternalError
 ########################################################################
 
 _UNITLESS_REGEX                = "1"
-_NON_LEADING_ZERO_NUM          = "[1-9]\d*"
+_NON_LEADING_ZERO_NUM          = r"[1-9]\d*"
 _CHAR_WITH_UNDERSCORE          = "([a-zA-Z]+_[a-zA-Z]+)+"
 _NEGATIVE_NON_LEADING_ZERO_NUM = f"[-]{_NON_LEADING_ZERO_NUM}"
 _POSITIVE_NON_LEADING_ZERO_NUM = f"[+]{_NON_LEADING_ZERO_NUM}"
 _UNIT_EXPONENT                 = f"({_NEGATIVE_NON_LEADING_ZERO_NUM}|{_POSITIVE_NON_LEADING_ZERO_NUM}|{_NON_LEADING_ZERO_NUM})"
 _UNIT_REGEX                    = f"[a-zA-Z]+{_UNIT_EXPONENT}?"
-_UNITS_REGEX                   = f"^({_CHAR_WITH_UNDERSCORE}|{_UNIT_REGEX}(\s{_UNIT_REGEX})*|{_UNITLESS_REGEX})$"
+_UNITS_REGEX                   = rf"^({_CHAR_WITH_UNDERSCORE}|{_UNIT_REGEX}(\s{_UNIT_REGEX})*|{_UNITLESS_REGEX})$"
 _UNITS_RE                      = re.compile(_UNITS_REGEX)
 _MAX_MOLAR_MASS                = 10000.0
 

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -835,7 +835,7 @@ class VarCompatObj:
                                               'scheme_files':'', \
                                               'suites':''}, \
                                        kind_types=["kind_phys=REAL64", \
-                                                   "kind_dyn=REAL32", \
+                                                   "kind_dyn=REAL32",  \
                                                    "kind_host=REAL64"])
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", [], "var1_lname", False,\
                      "var_stdname", "real", "kind_phys", "m", [], "var2_lname", False,\
@@ -1172,7 +1172,7 @@ class VarCompatObj:
                                                       'scheme_files':'', \
                                                       'suites':''}, \
                                                kind_types=["kind_phys=REAL64", \
-                                                           "kind_dyn=REAL32", \
+                                                           "kind_dyn=REAL32",  \
                                                            "kind_host=REAL64"])
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')
@@ -1227,7 +1227,7 @@ class VarCompatObj:
                                                       'scheme_files':'', \
                                                       'suites':''}, \
                                                kind_types=["kind_phys=REAL64", \
-                                                           "kind_dyn=REAL32", \
+                                                           "kind_dyn=REAL32",  \
                                                            "kind_host=REAL64"])
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')
@@ -1318,7 +1318,7 @@ class VarCompatObj:
                                               'scheme_files':'', \
                                               'suites':''}, \
                                        kind_types=["kind_phys=REAL64", \
-                                                   "kind_dyn=REAL32", \
+                                                   "kind_dyn=REAL32",  \
                                                    "kind_host=REAL64"])
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -835,7 +835,7 @@ class VarCompatObj:
                                               'scheme_files':'', \
                                               'suites':''}, \
                                        kind_types=["kind_phys=REAL64", \
-                                                   "kind_dyn=REAL32",  \
+                                                   "kind_dyn=REAL32", \
                                                    "kind_host=REAL64"])
     >>> VarCompatObj("var_stdname", "real", "kind_phys", "m", [], "var1_lname", False,\
                      "var_stdname", "real", "kind_phys", "m", [], "var2_lname", False,\

--- a/scripts/var_props.py
+++ b/scripts/var_props.py
@@ -1227,7 +1227,7 @@ class VarCompatObj:
                                                       'scheme_files':'', \
                                                       'suites':''}, \
                                                kind_types=["kind_phys=REAL64", \
-                                                           "kind_dyn=REAL32",  \
+                                                           "kind_dyn=REAL32", \
                                                            "kind_host=REAL64"])
         >>> _DOCTEST_CONTEXT1 = ParseContext(linenum=3, filename='foo.F90')
         >>> _DOCTEST_CONTEXT2 = ParseContext(linenum=5, filename='bar.F90')

--- a/test/capgen_test/CMakeLists.txt
+++ b/test/capgen_test/CMakeLists.txt
@@ -6,9 +6,10 @@
 #
 #------------------------------------------------------------------------------
 set(SCHEME_FILES       "setup_coeffs" "temp_set" "temp_adjust" "temp_calc_adjust")
-set(SUITE_SCHEME_FILES "make_ddt" "environ_conditions")
+set(SUITE_SCHEME_FILES "make_ddt" "environ_conditions" "temp_kinds")
 set(HOST_FILES         "test_host_data" "test_host_mod")
 set(SUITE_FILES        "ddt_suite.xml" "temp_suite.xml")
+set(KIND_TYPE          "kind_phys=REAL64")
 
 # HOST is the name of the executable we will build.
 # We assume there are files ${HOST}.meta and ${HOST}.F90 in CMAKE_SOURCE_DIR
@@ -38,10 +39,12 @@ foreach(sfile ${SUITE_SCHEME_FILES})
   find_file(fort_file "${sfile}.F90" NO_CACHE
             HINTS ${CMAKE_CURRENT_SOURCE_DIR}
             HINTS ${CMAKE_CURRENT_SOURCE_DIR}/source_dir1
-            HINTS ${CMAKE_CURRENT_SOURCE_DIR}/source_dir2)
+            HINTS ${CMAKE_CURRENT_SOURCE_DIR}/source_dir2
+            HINTS ${CMAKE_CURRENT_SOURCE_DIR}/adjust)
   list(APPEND SUITE_SCHEME_FORTRAN_FILES ${fort_file})
   unset(fort_file)
 endforeach()
+
 list(TRANSFORM SUITE_SCHEME_FILES APPEND ".meta" OUTPUT_VARIABLE SUITE_SCHEME_META_FILES)
 list(TRANSFORM HOST_FILES         APPEND ".F90"  OUTPUT_VARIABLE CAPGEN_HOST_FORTRAN_FILES)
 list(TRANSFORM HOST_FILES         APPEND ".meta" OUTPUT_VARIABLE CAPGEN_HOST_METADATA_FILES)
@@ -54,6 +57,7 @@ ccpp_capgen(CAPGEN_DEBUG ON
             SCHEMEFILES ${SCHEME_META_FILES} ${SUITE_SCHEME_META_FILES}
             SUITES ${SUITE_FILES}
             HOST_NAME ${HOST}
+            KIND_TYPES ${KIND_TYPES}
             OUTPUT_ROOT "${CCPP_CAP_FILES}")
 
 # Retrieve the list of Fortran files required for test host from datatable.xml and set to CCPP_CAPS_LIST

--- a/test/capgen_test/adjust/temp_kinds.F90
+++ b/test/capgen_test/adjust/temp_kinds.F90
@@ -1,0 +1,12 @@
+! Define a new Fortran kind for use within
+! various temp_* test files.
+
+module temp_kinds
+
+   implicit none
+   private
+
+   integer, public, parameter :: temp_r8 = selected_real_kind(12) !8-byte real
+   integer, public, parameter :: temp_i8 = selected_int_kind (13) !8-byte integer
+
+end module temp_kinds

--- a/test/capgen_test/capgen_test_reports.py
+++ b/test/capgen_test/capgen_test_reports.py
@@ -37,6 +37,7 @@ _CCPP_FILES = _UTILITY_FILES + \
                os.path.join(_BUILD_DIR, "ccpp", "ccpp_ddt_suite_cap.F90"),
                os.path.join(_BUILD_DIR, "ccpp", "ccpp_temp_suite_cap.F90")]
 _DEPENDENCIES = [os.path.join(_TEST_DIR, "adjust", "qux.F90"),
+                 os.path.join(_TEST_DIR, "adjust", "temp_kinds.F90"),
                  os.path.join(_TEST_DIR, "ddt2"),
                  os.path.join(_TEST_DIR, "bar.F90"),
                  os.path.join(_TEST_DIR, "foo.F90")]

--- a/test/capgen_test/source_dir2/temp_set.F90
+++ b/test/capgen_test/source_dir2/temp_set.F90
@@ -3,7 +3,7 @@
 
 MODULE temp_set
 
-  USE ccpp_kinds, ONLY: kind_phys
+  USE ccpp_kinds, ONLY: kind_phys, kind_temp
 
   IMPLICIT NONE
   PRIVATE
@@ -32,7 +32,7 @@ CONTAINS
    real(kind_phys),    intent(inout) :: temp_diag(:,:)
    real(kind_phys),    intent(inout) :: soil_levs(slev_lbound:)
    real(kind_phys),    intent(inout) :: var_array(:,:,:,:)
-   real(kind_phys),    intent(out)   :: to_promote(:, :)
+   real(kind_temp),    intent(out)   :: to_promote(:, :)
    real(kind_phys),    intent(out)   :: promote_pcnst(:)
    character(len=512), intent(out)   :: errmsg
    integer,            intent(out)   :: errflg
@@ -62,7 +62,7 @@ CONTAINS
 
     var_array(:,:,:,:) = 1._kind_phys
 
-    ! 
+    !
     internal_scalar_var = soil_levs(slev_lbound)
     internal_scalar_var = soil_levs(0)
 

--- a/test/capgen_test/temp_adjust.F90
+++ b/test/capgen_test/temp_adjust.F90
@@ -3,7 +3,7 @@
 
 MODULE temp_adjust
 
-  USE ccpp_kinds, ONLY: kind_phys
+  USE ccpp_kinds, ONLY: kind_phys, kind_temp
 
   IMPLICIT NONE
   PRIVATE
@@ -43,7 +43,7 @@ CONTAINS
     real(kind_phys),           intent(inout) :: ps(:)
     REAL(kind_phys),           intent(in)    :: temp_prev(:)
     REAL(kind_phys),           intent(inout) :: temp_layer(foo)
-    real(kind_phys),           intent(in)    :: to_promote(:)
+    real(kind_temp),           intent(in)    :: to_promote(:)
     real(kind_phys),           intent(in)    :: promote_pcnst(:)
     integer,                   intent(out)   :: interstitial_var(:)
     character(len=512),        intent(out)   :: errmsg

--- a/test/capgen_test/temp_adjust.meta
+++ b/test/capgen_test/temp_adjust.meta
@@ -1,7 +1,8 @@
 [ccpp-table-properties]
   name = temp_adjust
   type = scheme
-  dependencies = qux.F90
+  kind_spec = temp_r8:temp_kinds:kind_temp
+  dependencies = qux.F90, temp_kinds.F90
   dependencies_path = adjust
 [ccpp-arg-table]
   name = temp_adjust_register
@@ -87,7 +88,7 @@
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
-  kind = kind_phys
+  kind = kind_temp
   intent = in
 [ promote_pcnst ]
   standard_name = promote_this_variable_with_no_horizontal_dimension

--- a/test/capgen_test/temp_adjust.meta
+++ b/test/capgen_test/temp_adjust.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = temp_adjust
   type = scheme
-  kind_spec = temp_r8:temp_kinds:kind_temp
+  kind_spec = temp_kinds:kind_temp=>temp_r8
   dependencies = qux.F90, temp_kinds.F90
   dependencies_path = adjust
 [ccpp-arg-table]

--- a/test/capgen_test/temp_set.meta
+++ b/test/capgen_test/temp_set.meta
@@ -2,7 +2,7 @@
   name = temp_set
   type = scheme
   source_path = source_dir2
-  kind_spec = temp_r8:temp_kinds:kind_temp
+  kind_spec = temp_kinds:kind_temp=>temp_r8
   dependencies = temp_kinds.F90
   dependencies_path = adjust
 [ccpp-arg-table]

--- a/test/capgen_test/temp_set.meta
+++ b/test/capgen_test/temp_set.meta
@@ -2,6 +2,9 @@
   name = temp_set
   type = scheme
   source_path = source_dir2
+  kind_spec = temp_r8:temp_kinds:kind_temp
+  dependencies = temp_kinds.F90
+  dependencies_path = adjust
 [ccpp-arg-table]
   name = temp_set_run
   type = scheme
@@ -60,7 +63,7 @@
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = kind_temp
   intent = out
 [ promote_pcnst ]
   standard_name = promote_this_variable_with_no_horizontal_dimension

--- a/test/unit_tests/sample_files/bad_kind_spec_table_properties.meta
+++ b/test/unit_tests/sample_files/bad_kind_spec_table_properties.meta
@@ -1,0 +1,5 @@
+[ccpp-table-properties]
+  name = bad_scheme
+  type = scheme
+  dependencies =
+  kind_spec = temp_r8

--- a/test/unit_tests/sample_files/duplicate_kind_spec_table_properties.meta
+++ b/test/unit_tests/sample_files/duplicate_kind_spec_table_properties.meta
@@ -2,5 +2,5 @@
   name = scheme_scheme
   type = scheme
   dependencies = fmodule.F90
-  kind_spec = temp_r8:fmodule:kind_temp
-  kind_spec = kind_temp:fmodule
+  kind_spec = fmodule:kind_temp=>temp_r8
+  kind_spec = fmodule:kind_temp

--- a/test/unit_tests/sample_files/duplicate_kind_spec_table_properties.meta
+++ b/test/unit_tests/sample_files/duplicate_kind_spec_table_properties.meta
@@ -1,0 +1,6 @@
+[ccpp-table-properties]
+  name = scheme_scheme
+  type = scheme
+  dependencies = fmodule.F90
+  kind_spec = temp_r8:fmodule:kind_temp
+  kind_spec = kind_temp:fmodule

--- a/test/unit_tests/sample_files/good_kind_spec_table_properties.meta
+++ b/test/unit_tests/sample_files/good_kind_spec_table_properties.meta
@@ -2,5 +2,5 @@
   name = good_scheme
   type = scheme
   dependencies = fmodule.F90
-  kind_spec = temp_r8:fmodule:kind_temp
-  kind_spec = temp_i8:fmodule
+  kind_spec = fmodule:kind_temp=>temp_r8
+  kind_spec = fmodule:temp_i8

--- a/test/unit_tests/sample_files/good_kind_spec_table_properties.meta
+++ b/test/unit_tests/sample_files/good_kind_spec_table_properties.meta
@@ -1,0 +1,6 @@
+[ccpp-table-properties]
+  name = good_scheme
+  type = scheme
+  dependencies = fmodule.F90
+  kind_spec = temp_r8:fmodule:kind_temp
+  kind_spec = temp_i8:fmodule

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -399,5 +399,47 @@ class MetadataTableTestCase(unittest.TestCase):
         emsg = "Invalid metadata table type, 'banana', at "
         self.assertTrue(emsg in str(context.exception))
 
+    def test_added_kind_spec(self):
+        """Test that adding a kind_spec to a Metadata table works as expected"""
+        known_ddts = list()
+        filename = os.path.join(SAMPLE_FILES_DIR,
+                                "good_kind_spec_table_properties.meta")
+
+        # Test that we can parse the table with no error
+        _ = parse_metadata_file(filename, known_ddts, self._DUMMY_RUN_ENV)
+        # Test that the expected names are in the table
+        kind_types = self._DUMMY_RUN_ENV.kind_types()
+        self.assertEqual(len(kind_types), 3)
+        self.assertIn("kind_temp", kind_types)
+        self.assertEqual(self._DUMMY_RUN_ENV.kind_module("kind_temp"), "fmodule")
+        self.assertEqual(self._DUMMY_RUN_ENV.kind_spec("kind_temp"), "temp_r8")
+        self.assertIn("temp_i8", kind_types)
+        self.assertIn("kind_phys", kind_types)
+
+    def test_bad_kind_spec(self):
+        """Test that adding a bad kind_spec to a Metadata table returns expected error"""
+        known_ddts = list()
+        filename = os.path.join(SAMPLE_FILES_DIR,
+                                "bad_kind_spec_table_properties.meta")
+
+        with self.assertRaises(Exception) as context:
+            _ = parse_metadata_file(filename, known_ddts, self._DUMMY_RUN_ENV)
+
+        emsg = "A fortran module name is required for 'temp_r8'"
+        self.assertTrue(emsg in str(context.exception), msg=str(context.exception))
+
+    def test_duplicate_kind_spec(self):
+        """Test that adding a duplicate kind_spec to a Metadata table returns expected error"""
+        known_ddts = list()
+        filename = os.path.join(SAMPLE_FILES_DIR,
+                                "duplicate_kind_spec_table_properties.meta")
+
+        with self.assertRaises(Exception) as context:
+            _ = parse_metadata_file(filename, known_ddts, self._DUMMY_RUN_ENV)
+
+        emsg = ("'kind_temp = [kind_temp, fmodule]'is an invalid duplicate. "
+                "kind_temp is already '['temp_r8', 'fmodule'],")
+        self.assertTrue(emsg in str(context.exception), msg=str(context.exception))
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit_tests/test_metadata_table.py
+++ b/test/unit_tests/test_metadata_table.py
@@ -425,7 +425,7 @@ class MetadataTableTestCase(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             _ = parse_metadata_file(filename, known_ddts, self._DUMMY_RUN_ENV)
 
-        emsg = "A fortran module name is required for 'temp_r8'"
+        emsg = "A Fortran kind name is required for 'temp_r8'"
         self.assertTrue(emsg in str(context.exception), msg=str(context.exception))
 
     def test_duplicate_kind_spec(self):

--- a/test/unit_tests/test_var_transforms.py
+++ b/test/unit_tests/test_var_transforms.py
@@ -473,4 +473,3 @@ class VarCompatTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
- kind declaration now available in a metadata_table header.
- Add test to the capgen system test (test/capgen_test)

There are two ways to use the new keyword:
```kind_spec = temp_kinds:kind_temp=>temp_r8```
Results in an entry in ccpp_kinds.F90:
```use temp_kinds, only: kind_temp => temp_r8```

```kind_spec = temp_kinds:temp_r8```
Results in an entry in ccpp_kinds.F90:
```use temp_kinds, only: temp_r8```

In both cases, the Fortran module file (temp_kinds.F90) SHOULD be added as a dependency in the
same metadata table header.

User interface changes?: Yes
A new metadata keyword

Fixes: #712 

Testing:
  unit tests: all PASS
  system tests: all PASS