### PR TITLE
When allocating dyn_const_array pre-calculate size to avoid line length limits

### DIFF
--- a/scripts/host_cap.py
+++ b/scripts/host_cap.py
@@ -732,21 +732,25 @@ def write_host_cap(host_model, api, module_name, output_dir, run_env):
                     cap.write("return", 4)
                     cap.write("end if", 3)
                     # Allocate the suite's dynamic constituents array
-                    size_string = "0+"
-                    for var in host_local_vars.variable_list():
-                        vtype = var.get_prop_value('type')
-                        if vtype == 'ccpp_constituent_properties_t':
-                            local_name = var.get_prop_value('local_name')
-                            size_string += f"size({local_name})+"
-                        # end if
-                    # end for
                     if not has_dyn_consts:
                         cap.comment("Suite does not return dynamic constituents; allocate to zero", 3)
-                    # end if
-                    cap.write(f"allocate({dyn_const_array}({size_string[:-1]}))", 3)
-                    if has_dyn_consts:
+                        cap.write(f"allocate({dyn_const_array}(0))", 3)
+                    else:
+                        # This is calculated separately to avoid exceeding line length limits at
+                        # inconvenient places:
+                        cap.comment("Compute total number of dynamic constituents for allocation", 3)
+                        cap.write("num_dyn_consts = 0", 3)
+                        for var in host_local_vars.variable_list():
+                            vtype = var.get_prop_value('type')
+                            if vtype == 'ccpp_constituent_properties_t':
+                                local_name = var.get_prop_value('local_name')
+                                cap.write(f"num_dyn_consts = num_dyn_consts + size({local_name})", 3)
+                            # end if
+                        # end for
+                        cap.write(f"allocate({dyn_const_array}(num_dyn_consts))", 3)
                         cap.comment("Pack the suite-level dynamic, run-time constituents array", 3)
                         cap.write("num_dyn_consts = 0", 3)
+                    # end if
                     for var in host_local_vars.variable_list():
                         vtype = var.get_prop_value('type')
                         if vtype != 'ccpp_constituent_properties_t':


### PR DESCRIPTION
[ 50 character, one line summary ]

Avoid syntax error in long dyn_const_array alloc.

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]

When multiple schemes return dynamic constituents, the host cap generator
builds the allocate statement as a single long expression like:
```fortran
allocate(tracer_data_test_dynamic_constituents(0+size(ozone_constituents)+size(aerosol_constituents)+size(volcaero_consti&
     tuents)))
```

This got chopped off mid-identifier, producing a syntax error.

Fix: compute the total size incrementally into `num_dyn_consts`
before the allocate, so no single line is long enough (hopefully!)
to trigger continuation:

```fortran
num_dyn_consts = 0
num_dyn_consts = num_dyn_consts + size(ozone_constituents)
num_dyn_consts = num_dyn_consts + size(aerosol_constituents)
num_dyn_consts = num_dyn_consts + size(volcaero_constituents)
allocate(tracer_data_test_dynamic_constituents(num_dyn_consts))
```

I reset `num_dyn_consts` to 0 afterward for the packing loop so there is no logic
change downstream.

User interface changes?: No

Fixes: TBA

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: tested to work in CAM-SIMA where it previously was not

