### PR TITLE
Fix TypeError when reporting ParseSyntaxError in parse_fortran_var_decl

### DIFF
--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -814,7 +814,7 @@ def parse_fortran_var_decl(line, source, run_env, imports=None):
                                  fortran_imports=imports)
                 newvars.append(var)
             except ParseSyntaxError as perr:
-                errors.append(perr)
+                errors.append(str(perr))
             # end try
         # end for
     # No else (not a variable declaration)

--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -701,6 +701,8 @@ def parse_fortran_var_decl(line, source, run_env, imports=None):
     ['8']
     >>> parse_fortran_var_decl("character(len=*), intent(out) :: errmsg", ParseSource('foo.F90', 'module', ParseContext()), _DUMMY_RUN_ENV)[1][0]
     'Syntax error: Invalid variable declaration, character(len=*), intent(out) :: errmsg, intent not allowed in module variable, in <standard input>'
+    >>> parse_fortran_var_decl("type(banana_t) :: bananas(0:N_FRUITS)", ParseSource('foo.F90', 'module', ParseContext()), _DUMMY_RUN_ENV)[1][0]
+    "bananas: '0:N_FRUITS' is an invalid dimension name; integer dimension indices not supported, in <standard input>"
 
     ## NB: Expressions (including function calls) not currently supported here
     #>>> parse_fortran_var_decl("real(kind_phys), intent(out) :: foo(size(bar))", ParseSource('foo.F90', 'scheme', ParseContext()), _DUMMY_RUN_ENV)[0].get_prop_value('dimensions')


### PR DESCRIPTION
[ 50 character, one line summary ]
Fix TypeError from ParseSyntaxError in parse_fortran_var_decl

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]
In `parse_fortran_var_decl()`, when `FortranVar()` raises a
  `ParseSyntaxError`, the exception object was appended directly
  to the errors list. `parse_module` expects string elements and calls
  `'\n'.join(errors)`, which crashes with a `TypeError`. Convert
  the exception to a string before appending.

From the context above `errmsg` is already being appended to
  `errors` array so I think this is a safe change to make that is
  consistent with the intended type of `errors[]`.

User interface changes?: No

Fixes: closes #725 

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: see minimal reproducible example in issue #725 

