### PR TITLE
Make constituent index lookup routines case insensitive

### DIFF
--- a/scripts/constituents.py
+++ b/scripts/constituents.py
@@ -741,7 +741,7 @@ class ConstituentVarDict(VarDictionary):
         substmt = f"subroutine {const_index_func}"
         cap.blank_line()
         cap.write(f"{substmt}(stdname, const_index, {err_dummy_str})", 1)
-        cap.write("use ccpp_scheme_utils, only: to_lower", 2)
+        cap.write("use ccpp_constituent_prop_mod, only: to_lower", 2)
         cap.comment("Set <const_index> to the constituent array index " +     \
                     "for <stdname>.", 2)
         cap.comment("If <stdname> is not found, set <const_index> to -1 " +   \

--- a/scripts/constituents.py
+++ b/scripts/constituents.py
@@ -741,6 +741,7 @@ class ConstituentVarDict(VarDictionary):
         substmt = f"subroutine {const_index_func}"
         cap.blank_line()
         cap.write(f"{substmt}(stdname, const_index, {err_dummy_str})", 1)
+        cap.write("use ccpp_scheme_utils, only: to_lower", 2)
         cap.comment("Set <const_index> to the constituent array index " +     \
                     "for <stdname>.", 2)
         cap.comment("If <stdname> is not found, set <const_index> to -1 " +   \
@@ -755,7 +756,7 @@ class ConstituentVarDict(VarDictionary):
         # end for
         cap.blank_line()
         cap.write(f"call {const_obj_name}%const_index(const_index, " +        \
-                  f"stdname, {obj_err_callstr})", 2)
+                  f"to_lower(stdname), {obj_err_callstr})", 2)
         cap.write(f"end {substmt}", 1)
 
     @staticmethod

--- a/scripts/host_cap.py
+++ b/scripts/host_cap.py
@@ -243,14 +243,6 @@ def constituent_model_const_props(host_model):
     return unique_local_name(hstr, host_model)
 
 ###############################################################################
-def constituent_model_const_index(host_model):
-###############################################################################
-    """Return the name of the interface that returns the array index of
-       a constituent array given its standard name"""
-    hstr = f"{host_model.name}_const_get_index"
-    return unique_local_name(hstr, host_model)
-
-###############################################################################
 def add_constituent_vars(cap, host_model, suite_list, run_env):
 ###############################################################################
     """Create a DDT library containing array reference variables

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -410,7 +410,7 @@ contains
     else
       errcode = 0
       errmsg = ''
-      this%var_std_name = trim(std_name)
+      this%var_std_name = trim(to_lower(std_name))
     end if
     if (errcode == 0) then
       this%var_long_name = trim(long_name)

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -2661,5 +2661,4 @@ contains
 
   end function to_lower
 
-
 end module ccpp_constituent_prop_mod

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -2641,7 +2641,7 @@ contains
   function to_lower(str)
 
     character(len=*), intent(in) :: str ! String to convert to lower case
-    character(len=len(str))      :: to_lower
+    character(len=len(str)) :: to_lower
 
     ! Local variables
     integer :: i ! Index
@@ -2654,8 +2654,8 @@ contains
     do i = 1, len(str)
       ctmp = str(i:i)
       aseq = iachar(ctmp)
-      if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
-           ctmp = achar(aseq + upper_to_lower)
+      if (aseq >= iachar("A") .and. aseq <= iachar("Z")) &
+          ctmp = achar(aseq + upper_to_lower)
       to_lower(i:i) = ctmp
     end do
 

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -202,6 +202,9 @@ module ccpp_constituent_prop_mod
     procedure :: constituent_props_ptr => ccp_constituent_props_ptr
   end type ccpp_model_constituents_t
 
+  ! Public interfaces
+  public to_lower
+
   ! Private interfaces
   private to_str
   private initialize_errvars
@@ -2632,5 +2635,38 @@ contains
     end if
 
   end subroutine ccpt_set_water_species
+
+  !#######################################################################
+
+  function to_lower(str)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+    character(len=*), intent(in) :: str      ! String to convert to lower case
+    character(len=len(str))      :: to_lower
+
+    !----- local -----
+    integer :: i              ! Index
+    integer :: aseq           ! ascii collating sequence
+    integer :: upper_to_lower ! integer to convert case
+    character(len=1) :: ctmp  ! Character temporary
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    upper_to_lower = iachar("a") - iachar("A")
+
+    do i = 1, len(str)
+       ctmp = str(i:i)
+       aseq = iachar(ctmp)
+       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
+            ctmp = achar(aseq + upper_to_lower)
+       to_lower(i:i) = ctmp
+    end do
+
+  end function to_lower
+
 
 end module ccpp_constituent_prop_mod

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -2640,30 +2640,23 @@ contains
 
   function to_lower(str)
 
-    implicit none
-
-    ! !INPUT/OUTPUT PARAMETERS:
-    character(len=*), intent(in) :: str      ! String to convert to lower case
+    character(len=*), intent(in) :: str ! String to convert to lower case
     character(len=len(str))      :: to_lower
 
-    !----- local -----
-    integer :: i              ! Index
-    integer :: aseq           ! ascii collating sequence
+    ! Local variables
+    integer :: i ! Index
+    integer :: aseq ! ascii collating sequence
     integer :: upper_to_lower ! integer to convert case
-    character(len=1) :: ctmp  ! Character temporary
-
-    !-------------------------------------------------------------------------------
-    !
-    !-------------------------------------------------------------------------------
+    character(len=1) :: ctmp ! Character temporary
 
     upper_to_lower = iachar("a") - iachar("A")
 
     do i = 1, len(str)
-       ctmp = str(i:i)
-       aseq = iachar(ctmp)
-       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
-            ctmp = achar(aseq + upper_to_lower)
-       to_lower(i:i) = ctmp
+      ctmp = str(i:i)
+      aseq = iachar(ctmp)
+      if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
+           ctmp = achar(aseq + upper_to_lower)
+      to_lower(i:i) = ctmp
     end do
 
   end function to_lower

--- a/src/ccpp_scheme_utils.F90
+++ b/src/ccpp_scheme_utils.F90
@@ -12,6 +12,7 @@ module ccpp_scheme_utils
   public :: ccpp_initialize_constituent_ptr ! Used by framework to initialize
   public :: ccpp_constituent_index ! Lookup index constituent by name
   public :: ccpp_constituent_indices ! Lookup indices of consitutents by name
+  public :: to_lower ! Convert string to lowercase
 
   !! Private module variables & interfaces
 
@@ -81,7 +82,7 @@ contains
 
     call check_initialization(caller=subname, errcode=errcode, errmsg=errmsg)
     if (status_ok(errcode)) then
-      call constituent_obj%const_index(const_index, standard_name, &
+      call constituent_obj%const_index(const_index, to_lower(standard_name), &
           errcode, errmsg)
     else
       const_index = int_unassigned
@@ -110,7 +111,7 @@ contains
         do indx = 1, size(standard_names)
           ! For each std name in <standard_names>, find the const. index
           call constituent_obj%const_index(const_inds(indx), &
-              standard_names(indx), errcode, errmsg)
+              to_lower(standard_names(indx)), errcode, errmsg)
           if (errcode /= 0) then
             exit
           end if
@@ -118,5 +119,35 @@ contains
       end if
     end if
   end subroutine ccpp_constituent_indices
+
+  function to_lower(str)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+    character(len=*), intent(in) :: str      ! String to convert to lower case
+    character(len=len(str))      :: to_lower
+
+    !----- local -----
+    integer :: i              ! Index
+    integer :: aseq           ! ascii collating sequence
+    integer :: upper_to_lower ! integer to convert case
+    character(len=1) :: ctmp  ! Character temporary
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    upper_to_lower = iachar("a") - iachar("A")
+
+    do i = 1, len(str)
+       ctmp = str(i:i)
+       aseq = iachar(ctmp)
+       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
+            ctmp = achar(aseq + upper_to_lower)
+       to_lower(i:i) = ctmp
+    end do
+
+  end function to_lower
 
 end module ccpp_scheme_utils

--- a/src/ccpp_scheme_utils.F90
+++ b/src/ccpp_scheme_utils.F90
@@ -3,7 +3,7 @@ module ccpp_scheme_utils
   ! Module of utilities available to CCPP schemes
 
   use ccpp_constituent_prop_mod, only: ccpp_model_constituents_t, &
-      int_unassigned
+      int_unassigned, to_lower
 
   implicit none
   private
@@ -12,7 +12,6 @@ module ccpp_scheme_utils
   public :: ccpp_initialize_constituent_ptr ! Used by framework to initialize
   public :: ccpp_constituent_index ! Lookup index constituent by name
   public :: ccpp_constituent_indices ! Lookup indices of consitutents by name
-  public :: to_lower ! Convert string to lowercase
 
   !! Private module variables & interfaces
 
@@ -119,35 +118,5 @@ contains
       end if
     end if
   end subroutine ccpp_constituent_indices
-
-  function to_lower(str)
-
-    implicit none
-
-    ! !INPUT/OUTPUT PARAMETERS:
-    character(len=*), intent(in) :: str      ! String to convert to lower case
-    character(len=len(str))      :: to_lower
-
-    !----- local -----
-    integer :: i              ! Index
-    integer :: aseq           ! ascii collating sequence
-    integer :: upper_to_lower ! integer to convert case
-    character(len=1) :: ctmp  ! Character temporary
-
-    !-------------------------------------------------------------------------------
-    !
-    !-------------------------------------------------------------------------------
-
-    upper_to_lower = iachar("a") - iachar("A")
-
-    do i = 1, len(str)
-       ctmp = str(i:i)
-       aseq = iachar(ctmp)
-       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
-            ctmp = achar(aseq + upper_to_lower)
-       to_lower(i:i) = ctmp
-    end do
-
-  end function to_lower
 
 end module ccpp_scheme_utils

--- a/test/advection_test/cld_liq.F90
+++ b/test/advection_test/cld_liq.F90
@@ -30,7 +30,7 @@ contains
       errmsg = 'Error allocating dyn_const in cld_liq_register'
       return
     end if
-    call dyn_const(1)%instantiate(std_name="dyn_const3_wrt_moist_air_and_condensed_water", long_name='dyn const3', &
+    call dyn_const(1)%instantiate(std_name="DYN_const3_wrt_moist_air_and_condensed_water", long_name='dyn const3', &
         diag_name='DYNCONST3', units='kg kg-1', default_value=1._kind_phys, &
         vertical_dim='vertical_layer_dimension', advected=.true., &
         water_species=.true., mixing_ratio_type='dry', &

--- a/test/advection_test/test_host_data.F90
+++ b/test/advection_test/test_host_data.F90
@@ -16,7 +16,7 @@ module test_host_data
   !! \htmlinclude arg_table_test_host_data.html
   integer, public, parameter :: num_consts = 3
   character(len=32), public, parameter :: std_name_array(num_consts) = (/ &
-      'specific_humidity            ', &
+      'SPECIFIC_HUMIDITY            ', &
       'cloud_liquid_dry_mixing_ratio', &
       'cloud_ice_dry_mixing_ratio   ' /)
   character(len=32), public, parameter :: const_std_name = std_name_array(1)


### PR DESCRIPTION
Adds `to_lower` routine to `ccpp_constituent_prop_mod.F90` and uses that to make the `ccpp_constituent_index`, `ccpp_constituent_indices`, and `<host>_const_get_index` interfaces case-insensitive.

Also removes redundant routine in scripts/host_cap.py

User interface changes?: No

Testing: 2 small mods to check case insensitivity in advection test.
