### PR TITLE
[feature/capgen-v1-cleanup-01] Make constituent index lookup routines case insensitive

### DIFF
--- a/capgen/generator/host_constituents.py
+++ b/capgen/generator/host_constituents.py
@@ -580,7 +580,7 @@ def _generate_host_constituents(
     lines.append('module {}'.format(_HOST_CONST_MOD))
     lines.append('')
     lines.append('{}use ccpp_kinds, only: kind_phys'.format(_INDENT))
-    lines.append('{}use ccpp_scheme_utils, only: to_lower'.format(_INDENT))
+    lines.append('{}use ccpp_constituent_prop_mod, only: to_lower'.format(_INDENT))
     lines.append('{}use {}, only: &'.format(_INDENT, _CONST_PROP_MOD))
     lines.append('{}{}, &'.format(_INDENT * 2, _CONST_DDT))
     lines.append('{}{}, &'.format(_INDENT * 2, _CONST_PROP_TYPE))

--- a/capgen/generator/host_constituents.py
+++ b/capgen/generator/host_constituents.py
@@ -418,7 +418,7 @@ def _wrap_method_subs(host_dict) -> List[str]:
         'ccpp_const_get_index', 'const_index',
         [
             ('stdname', 'character(len=*), intent(in) :: stdname',
-             'standard_name=stdname'),
+             'standard_name=to_lower(stdname)'),
             ('const_index', 'integer, intent(out) :: const_index',
              'index=const_index'),
         ],
@@ -580,6 +580,7 @@ def _generate_host_constituents(
     lines.append('module {}'.format(_HOST_CONST_MOD))
     lines.append('')
     lines.append('{}use ccpp_kinds, only: kind_phys'.format(_INDENT))
+    lines.append('{}use ccpp_scheme_utils, only: to_lower'.format(_INDENT))
     lines.append('{}use {}, only: &'.format(_INDENT, _CONST_PROP_MOD))
     lines.append('{}{}, &'.format(_INDENT * 2, _CONST_DDT))
     lines.append('{}{}, &'.format(_INDENT * 2, _CONST_PROP_TYPE))

--- a/capgen/src/ccpp_constituent_prop_mod.F90
+++ b/capgen/src/ccpp_constituent_prop_mod.F90
@@ -419,7 +419,7 @@ contains
     else
       errcode = 0
       errmsg = ''
-      this%var_std_name = trim(std_name)
+      this%var_std_name = trim(to_lower(std_name))
     end if
     if (errcode == 0) then
       this%var_long_name = trim(long_name)

--- a/capgen/src/ccpp_constituent_prop_mod.F90
+++ b/capgen/src/ccpp_constituent_prop_mod.F90
@@ -2683,30 +2683,23 @@ contains
 
   function to_lower(str)
 
-    implicit none
+    character(len=*), intent(in) :: str ! String to convert to lower case
+    character(len=len(str)) :: to_lower
 
-    ! !INPUT/OUTPUT PARAMETERS:
-    character(len=*), intent(in) :: str      ! String to convert to lower case
-    character(len=len(str))      :: to_lower
-
-    !----- local -----
-    integer :: i              ! Index
-    integer :: aseq           ! ascii collating sequence
+    ! Local variables
+    integer :: i ! Index
+    integer :: aseq ! ascii collating sequence
     integer :: upper_to_lower ! integer to convert case
-    character(len=1) :: ctmp  ! Character temporary
-
-    !-------------------------------------------------------------------------------
-    !
-    !-------------------------------------------------------------------------------
+    character(len=1) :: ctmp ! Character temporary
 
     upper_to_lower = iachar("a") - iachar("A")
 
     do i = 1, len(str)
-       ctmp = str(i:i)
-       aseq = iachar(ctmp)
-       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
-            ctmp = achar(aseq + upper_to_lower)
-       to_lower(i:i) = ctmp
+      ctmp = str(i:i)
+      aseq = iachar(ctmp)
+      if (aseq >= iachar("A") .and. aseq <= iachar("Z")) &
+          ctmp = achar(aseq + upper_to_lower)
+      to_lower(i:i) = ctmp
     end do
 
   end function to_lower

--- a/capgen/src/ccpp_constituent_prop_mod.F90
+++ b/capgen/src/ccpp_constituent_prop_mod.F90
@@ -211,6 +211,9 @@ module ccpp_constituent_prop_mod
     procedure :: constituent_props_ptr => ccp_constituent_props_ptr
   end type ccpp_model_constituents_t
 
+  ! Public interfaces
+  public to_lower
+
   ! Private interfaces
   private to_str
   private initialize_errvars
@@ -2675,5 +2678,37 @@ contains
     end if
 
   end subroutine ccpt_set_water_species
+
+  !#######################################################################
+
+  function to_lower(str)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+    character(len=*), intent(in) :: str      ! String to convert to lower case
+    character(len=len(str))      :: to_lower
+
+    !----- local -----
+    integer :: i              ! Index
+    integer :: aseq           ! ascii collating sequence
+    integer :: upper_to_lower ! integer to convert case
+    character(len=1) :: ctmp  ! Character temporary
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    upper_to_lower = iachar("a") - iachar("A")
+
+    do i = 1, len(str)
+       ctmp = str(i:i)
+       aseq = iachar(ctmp)
+       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
+            ctmp = achar(aseq + upper_to_lower)
+       to_lower(i:i) = ctmp
+    end do
+
+  end function to_lower
 
 end module ccpp_constituent_prop_mod

--- a/capgen/src/ccpp_scheme_utils.F90
+++ b/capgen/src/ccpp_scheme_utils.F90
@@ -3,7 +3,7 @@ module ccpp_scheme_utils
   ! Module of utilities available to CCPP schemes
 
   use ccpp_constituent_prop_mod, only: ccpp_model_constituents_t, &
-      int_unassigned
+      int_unassigned, to_lower
 
   implicit none
   private
@@ -119,35 +119,5 @@ contains
       end if
     end if
   end subroutine ccpp_constituent_indices
-
-  function to_lower(str)
-
-    implicit none
-
-    ! !INPUT/OUTPUT PARAMETERS:
-    character(len=*), intent(in) :: str      ! String to convert to lower case
-    character(len=len(str))      :: to_lower
-
-    !----- local -----
-    integer :: i              ! Index
-    integer :: aseq           ! ascii collating sequence
-    integer :: upper_to_lower ! integer to convert case
-    character(len=1) :: ctmp  ! Character temporary
-
-    !-------------------------------------------------------------------------------
-    !
-    !-------------------------------------------------------------------------------
-
-    upper_to_lower = iachar("a") - iachar("A")
-
-    do i = 1, len(str)
-       ctmp = str(i:i)
-       aseq = iachar(ctmp)
-       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
-            ctmp = achar(aseq + upper_to_lower)
-       to_lower(i:i) = ctmp
-    end do
-
-  end function to_lower
 
 end module ccpp_scheme_utils

--- a/capgen/src/ccpp_scheme_utils.F90
+++ b/capgen/src/ccpp_scheme_utils.F90
@@ -12,6 +12,7 @@ module ccpp_scheme_utils
   public :: ccpp_initialize_constituent_ptr ! Used by framework to initialize
   public :: ccpp_constituent_index ! Lookup index constituent by name
   public :: ccpp_constituent_indices ! Lookup indices of consitutents by name
+  public :: to_lower ! Utility to convert string to lowercase
 
   !! Private module variables & interfaces
 
@@ -81,7 +82,7 @@ contains
 
     call check_initialization(caller=subname, errcode=errcode, errmsg=errmsg)
     if (status_ok(errcode)) then
-      call constituent_obj%const_index(const_index, standard_name, &
+      call constituent_obj%const_index(const_index, to_lower(standard_name), &
           errcode, errmsg)
     else
       const_index = int_unassigned
@@ -110,7 +111,7 @@ contains
         do indx = 1, size(standard_names)
           ! For each std name in <standard_names>, find the const. index
           call constituent_obj%const_index(const_inds(indx), &
-              standard_names(indx), errcode, errmsg)
+              to_lower(standard_names(indx)), errcode, errmsg)
           if (errcode /= 0) then
             exit
           end if
@@ -118,5 +119,35 @@ contains
       end if
     end if
   end subroutine ccpp_constituent_indices
+
+  function to_lower(str)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+    character(len=*), intent(in) :: str      ! String to convert to lower case
+    character(len=len(str))      :: to_lower
+
+    !----- local -----
+    integer :: i              ! Index
+    integer :: aseq           ! ascii collating sequence
+    integer :: upper_to_lower ! integer to convert case
+    character(len=1) :: ctmp  ! Character temporary
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    upper_to_lower = iachar("a") - iachar("A")
+
+    do i = 1, len(str)
+       ctmp = str(i:i)
+       aseq = iachar(ctmp)
+       if ( aseq >= iachar("A") .and. aseq <= iachar("Z") ) &
+            ctmp = achar(aseq + upper_to_lower)
+       to_lower(i:i) = ctmp
+    end do
+
+  end function to_lower
 
 end module ccpp_scheme_utils

--- a/end-to-end-tests/advection/cld_liq.F90
+++ b/end-to-end-tests/advection/cld_liq.F90
@@ -30,7 +30,7 @@ contains
       errmsg = 'Error allocating dyn_const in cld_liq_register'
       return
     end if
-    call dyn_const(1)%instantiate(std_name="dyn_const3_wrt_moist_air_and_condensed_water", long_name='dyn const3', &
+    call dyn_const(1)%instantiate(std_name="DYN_const3_wrt_moist_air_and_condensed_water", long_name='dyn const3', &
         diag_name='DYNCONST3', units='kg kg-1', default_value=1._kind_phys, &
         vertical_dim='vertical_layer_dimension', advected=.true., &
         water_species=.true., mixing_ratio_type='dry', &

--- a/end-to-end-tests/advection/test_host_data.F90
+++ b/end-to-end-tests/advection/test_host_data.F90
@@ -16,7 +16,7 @@ module test_host_data
   !! \htmlinclude arg_table_test_host_data.html
   integer, public, parameter :: num_consts = 3
   character(len=32), public, parameter :: std_name_array(num_consts) = (/ &
-      'specific_humidity            ', &
+      'SPECIFIC_HUMIDITY            ', &
       'cloud_liquid_dry_mixing_ratio', &
       'cloud_ice_dry_mixing_ratio   ' /)
   character(len=32), public, parameter :: const_std_name = std_name_array(1)


### PR DESCRIPTION
## Description

This PR is the same as #765, but for branch `feature/capgen-v1-cleanup-01`.

Adds `to_lower` routine to `capgen/src/ccpp_constituent_prop_mod.F90` and uses that to make the `ccpp_constituent_index`, `ccpp_constituent_indices`, and `<host>_const_get_index` interfaces case insensitive.

User interface changes?: No

Testing: 2 small mods to check case insensitivity in end-to-end advection test.
