### PR TITLE
Add correct comment to supported variable conversions.

### DIFF
--- a/capgen/generator/group_cap.py
+++ b/capgen/generator/group_cap.py
@@ -517,14 +517,24 @@ def _transform_comment(arg: ResolvedArg, reverse: bool = False) -> str:
         else:
             is_identity = (arg.unit_forward == arg.call_expr)
         if not is_identity:
-            if reverse:
-                bits.append('unit conversion: {} to {}'.format(
-                    arg.kind_scheme or '', arg.kind_host or '',
-                ))
-            else:
-                bits.append('unit conversion: {} to {}'.format(
-                    arg.kind_host or '', arg.kind_scheme or '',
-                ))
+            if (arg.kind_scheme != arg.kind_host):
+                if reverse:
+                    bits.append('type conversion: {} to {}'.format(
+                        arg.kind_scheme or '', arg.kind_host or '',
+                    ))
+                else:
+                    bits.append('type conversion: {} to {}'.format(
+                        arg.kind_host or '', arg.kind_scheme or '',
+                    ))
+            if (arg.unit_scheme != arg.unit_host):
+                if reverse:
+                    bits.append('unit conversion: {} to {}'.format(
+                        arg.unit_scheme or '', arg.unit_host or '',
+                    ))
+                else:
+                    bits.append('unit conversion: {} to {}'.format(
+                        arg.unit_host or '', arg.unit_scheme or '',
+                    ))
     if arg.needs_vert_flip:
         bits.append('vertical flip (top_at_one mismatch)')
     if not bits:

--- a/capgen/generator/suite_resolver.py
+++ b/capgen/generator/suite_resolver.py
@@ -1059,6 +1059,10 @@ class ResolvedArg:
         Kind declared in the scheme metadata.
     kind_host : str
         Kind of the host/suite variable.
+    unit_scheme : str
+        Unit declared in the scheme metadata.
+    unit_host : str
+        Unit of the host/suite variable.
     temp_name : str
         Name for the transformation temporary (``local_name + '_l'``).
     ptr_name : str
@@ -1085,6 +1089,8 @@ class ResolvedArg:
     unit_backward: str
     kind_scheme: str
     kind_host: str
+    unit_scheme: str
+    unit_host: str
     temp_name: str
     ptr_name: str
     transform_case: int
@@ -1559,6 +1565,8 @@ def _resolve_one_arg(
             unit_backward='',
             kind_scheme=scheme_var.kind,
             kind_host='',
+            unit_scheme=scheme_var.units,
+            unit_host='',
             temp_name='',
             ptr_name='',
             transform_case=1,
@@ -1599,6 +1607,8 @@ def _resolve_one_arg(
             unit_backward='',
             kind_scheme=scheme_var.kind,
             kind_host='',
+            unit_scheme=scheme_var.units,
+            unit_host='',
             temp_name='',
             ptr_name='',
             transform_case=1,
@@ -1965,6 +1975,8 @@ def _resolve_one_arg(
         unit_backward=unit_backward,
         kind_scheme=scheme_kind,
         kind_host=host_kind,
+        unit_scheme=scheme_units,
+        unit_host=host_units,
         temp_name=temp_name,
         ptr_name=ptr_name,
         transform_case=transform_case,


### PR DESCRIPTION
### Description

@climbfuji This is a small one to fix the trailing comments after the variable conversions in the Group caps.
Also, I couldn't find any message alerting us that a variable conversion is encountered? I think we should add something like is done in [Prebuid](https://ccpp-techdoc.readthedocs.io/en/latest/AutoGenPhysCaps.html#automatic-unit-conversions):
INFO: Automatic unit conversion from m to um for effective_radius_of_stratiform_cloud_snow_particle_in_um after returning from MODULE_mp_thompson SCHEME_mp_thompson SUBROUTINE_mp_thompson_run
If you agree, I can do this.
